### PR TITLE
Remove interface name aliasing to keep VCS happy

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -20,6 +20,7 @@ sources:
       - test/tb_axi_to_axi_lite.sv
   - src/axi_intf.sv
 
+  - src/axi_atop_filter.sv
   - src/axi_arbiter.sv
   - src/axi_address_resolver.sv
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Add AXI atomic operations (ATOP) filter
+
 ## 0.5.0 - 2018-11-29
 - Add axi channel delayer
 

--- a/include/axi/assign.svh
+++ b/include/axi/assign.svh
@@ -24,6 +24,7 @@
   assign slv.aw_prot    = mst.aw_prot;    \
   assign slv.aw_qos     = mst.aw_qos;     \
   assign slv.aw_region  = mst.aw_region;  \
+  assign slv.aw_atop    = mst.aw_atop;    \
   assign slv.aw_user    = mst.aw_user;    \
   assign slv.aw_valid   = mst.aw_valid;   \
   assign mst.aw_ready   = slv.aw_ready;   \

--- a/src/axi_atop_filter.sv
+++ b/src/axi_atop_filter.sv
@@ -1,0 +1,317 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the “License”); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// TODO: Module specification
+
+// The AXI standard specifies that there may be no ordering requirements between different atomic
+// bursts (i.e., a burst started by an AW with ATOP other than 0) and none between atomic bursts and
+// non-atomic bursts [E2.1.4].  That is, an atomic burst may never have the same ID as any other
+// write or read burst that is ongoing at the same time.
+
+module axi_atop_filter #(
+  parameter int unsigned AXI_ID_WIDTH = 0,  // Synopsys DC requires a default value for parameters.
+  parameter int unsigned MAX_OUTSTND_BURSTS = 0
+) (
+  input  logic    clk_i,
+  input  logic    rst_ni,
+  AXI_BUS.Master  mst,
+  AXI_BUS.Slave   slv
+);
+
+  typedef logic [$clog2(MAX_OUTSTND_BURSTS+1)-1:0] cnt_t;
+  cnt_t   w_cnt_d, w_cnt_q;
+
+  typedef enum logic [2:0] { W_FEEDTHROUGH, BLOCK_AW, ABSORB_W, INJECT_B, WAIT_R } w_state_t;
+  w_state_t   w_state_d, w_state_q;
+
+  typedef enum logic { R_FEEDTHROUGH, INJECT_R } r_state_t;
+  r_state_t   r_state_d, r_state_q;
+
+  typedef logic [AXI_ID_WIDTH-1:0] id_t;
+  id_t  id_d, id_q;
+
+  typedef logic [7:0] len_t;
+  len_t   r_beats_d,  r_beats_q;
+
+  typedef struct packed {
+    len_t len;
+  } r_resp_cmd_t;
+  r_resp_cmd_t  r_resp_cmd_push, r_resp_cmd_pop;
+
+  logic r_resp_cmd_push_valid,  r_resp_cmd_push_ready,
+        r_resp_cmd_pop_valid,   r_resp_cmd_pop_ready;
+
+  // Manage AW, W, and B channels.
+  always_comb begin
+    // Defaults:
+    // Disable AW and W handshakes.
+    mst.aw_valid = 1'b0;
+    slv.aw_ready = 1'b0;
+    mst.w_valid = 1'b0;
+    slv.w_ready = 1'b0;
+    // Feed write responses through.
+    mst.b_ready = slv.b_ready;
+    slv.b_valid = mst.b_valid;
+    slv.b_id    = mst.b_id;
+    slv.b_resp  = mst.b_resp;
+    slv.b_user  = mst.b_user;
+    // Keep ID stored for B and R response.
+    id_d = id_q;
+    // Do not push R response commands.
+    r_resp_cmd_push_valid = 1'b0;
+    // Keep the current state.
+    w_state_d = w_state_q;
+
+    unique case (w_state_q)
+      W_FEEDTHROUGH: begin
+        // Feed AW channel through if the maximum number of outstanding bursts is not reached.
+        if (w_cnt_q < MAX_OUTSTND_BURSTS) begin
+          mst.aw_valid = slv.aw_valid;
+          slv.aw_ready = mst.aw_ready;
+        end
+        // Feed W channel through if at least one AW request is outstanding.  This does not allow
+        // W beats before the corresponding AW because we need to know the `atop` of an AW to decide
+        // what to do with the W beats.
+        if (w_cnt_q > 0) begin
+          mst.w_valid = slv.w_valid;
+          slv.w_ready = mst.w_ready;
+        end
+        // Filter out AWs that are atomic operations.
+        if (slv.aw_valid && slv.aw_atop[5:4] != axi_pkg::ATOP_NONE) begin
+          mst.aw_valid = 1'b0; // Do not let AW pass to master port.
+          slv.aw_ready = 1'b1; // Absorb AW on slave port.
+          id_d = slv.aw_id; // Store ID for B response.
+          // All atomic operations except atomic stores require a response on the R channel.
+          if (slv.aw_atop[5:4] != axi_pkg::ATOP_ATOMICSTORE) begin
+            // Push R response command.  We do not have to wait for the ready of the register
+            // because we know it is ready: we are its only master and will wait for the register to
+            // be emptied before going back to the `W_FEEDTHROUGH` state.
+            r_resp_cmd_push_valid = 1'b1;
+          end
+          // If there are outstanding W bursts, block the AW channel and let the W bursts complete.
+          if (w_cnt_q > 0) begin
+            w_state_d = BLOCK_AW;
+          // If there are no outstanding W bursts, absorb the W beats for this atomic AW.
+          end else begin
+            mst.w_valid = 1'b0; // Do not let W beats pass to master port.
+            slv.w_ready = 1'b1; // Absorb W beats on slave port.
+            if (slv.w_valid && slv.w_last) begin
+              // If the W beat is valid and the last, proceed by injecting the B response.
+              w_state_d = INJECT_B;
+            end else begin
+              // Otherwise continue with absorbing W beats.
+              w_state_d = ABSORB_W;
+            end
+          end
+        end
+      end
+
+      BLOCK_AW: begin
+        // Feed W channel through to let outstanding bursts complete.
+        if (w_cnt_q > 0) begin
+          mst.w_valid = slv.w_valid;
+          slv.w_ready = mst.w_ready;
+        end else begin
+          // If there are no more outstanding W bursts, start absorbing the next W burst.
+          slv.w_ready = 1'b1;
+          if (slv.w_valid && slv.w_last) begin
+            // If the W beat is valid and the last, proceed by injecting the B response.
+            w_state_d = INJECT_B;
+          end else begin
+            // Otherwise continue with absorbing W beats.
+            w_state_d = ABSORB_W;
+          end
+        end
+      end
+
+      ABSORB_W: begin
+        // Absorb all W beats of the current burst.
+        slv.w_ready = 1'b1;
+        if (slv.w_valid && slv.w_last) begin
+          w_state_d = INJECT_B;
+        end
+      end
+
+      INJECT_B: begin
+        // Pause forwarding of B response.
+        mst.b_ready = 1'b0;
+        // Inject error response instead.  Since the B channel has an ID and the atomic burst we are
+        // replying to is guaranteed to be the only burst with this ID in flight, we do not have to
+        // observe any ordering and can immediatly inject on the B channel.
+        slv.b_id = id_q;
+        slv.b_resp = axi_pkg::RESP_SLVERR;
+        slv.b_user = '0;
+        slv.b_valid = 1'b1;
+        if (slv.b_ready) begin
+          // If not all beats of the R response have been injected, wait for them. Otherwise, return
+          // to `W_FEEDTHROUGH`.
+          if (r_resp_cmd_pop_valid && !r_resp_cmd_pop_ready) begin
+            w_state_d = WAIT_R;
+          end else begin
+            w_state_d = W_FEEDTHROUGH;
+          end
+        end
+      end
+
+      WAIT_R: begin
+        // Wait with returning to `W_FEEDTHROUGH` until all beats of the R response have been
+        // injected.
+        if (!r_resp_cmd_pop_valid) begin
+          w_state_d = W_FEEDTHROUGH;
+        end
+      end
+      
+      default: w_state_d = W_FEEDTHROUGH;
+    endcase
+  end
+
+  // Manage R channel.
+  always_comb begin
+    // Defaults:
+    // Feed read responses through.
+    slv.r_valid = mst.r_valid;
+    mst.r_ready = slv.r_ready;
+    slv.r_id    = mst.r_id;
+    slv.r_data  = mst.r_data;
+    slv.r_resp  = mst.r_resp;
+    slv.r_last  = mst.r_last;
+    slv.r_user  = mst.r_user;
+    // Do not pop R response command.
+    r_resp_cmd_pop_ready = 1'b0;
+    // Keep the current value of the beats counter.
+    r_beats_d = r_beats_q;
+    // Keep the current state.
+    r_state_d = r_state_q;
+
+    unique case (r_state_q)
+      R_FEEDTHROUGH: begin
+        if (r_resp_cmd_pop_valid) begin
+          // Upon a command to inject an R response, immediately proceed with doing so because there
+          // are no ordering requirements with other bursts that may be ongoing on the R channel at
+          // this moment.
+          r_beats_d = r_resp_cmd_pop.len;
+          r_state_d = INJECT_R;
+        end
+      end
+
+      INJECT_R: begin
+        mst.r_ready = 1'b0;
+        slv.r_id = id_q;
+        slv.r_data = '0;
+        slv.r_resp = axi_pkg::RESP_SLVERR;
+        slv.r_user = '0;
+        slv.r_valid = 1'b1;
+        slv.r_last = (r_beats_q == '0);
+        if (slv.r_ready) begin
+          if (slv.r_last) begin
+            r_resp_cmd_pop_ready = 1'b1;
+            r_state_d = R_FEEDTHROUGH;
+          end else begin
+            r_beats_d -= 1;
+          end
+        end
+      end
+
+      default: begin
+        r_state_d = R_FEEDTHROUGH;
+      end
+    endcase
+  end
+
+  // Make sure downstream slaves do not get any atomic operations.
+  assign mst.aw_atop = '0;
+
+  // Connect signals on AW and W channel that are not managed by the control FSM from slave port to
+  // master port.
+  assign mst.aw_id      = slv.aw_id;
+  assign mst.aw_addr    = slv.aw_addr;
+  assign mst.aw_len     = slv.aw_len;
+  assign mst.aw_size    = slv.aw_size;
+  assign mst.aw_burst   = slv.aw_burst;
+  assign mst.aw_lock    = slv.aw_lock;
+  assign mst.aw_cache   = slv.aw_cache;
+  assign mst.aw_prot    = slv.aw_prot;
+  assign mst.aw_qos     = slv.aw_qos;
+  assign mst.aw_region  = slv.aw_region;
+  assign mst.aw_user    = slv.aw_user;
+  assign mst.w_data     = slv.w_data;
+  assign mst.w_strb     = slv.w_strb;
+  assign mst.w_last     = slv.w_last;
+  assign mst.w_user     = slv.w_user;
+
+  // Feed all signals on AR through.
+  assign mst.ar_id      = slv.ar_id;
+  assign mst.ar_addr    = slv.ar_addr;
+  assign mst.ar_len     = slv.ar_len;
+  assign mst.ar_size    = slv.ar_size;
+  assign mst.ar_burst   = slv.ar_burst;
+  assign mst.ar_lock    = slv.ar_lock;
+  assign mst.ar_cache   = slv.ar_cache;
+  assign mst.ar_prot    = slv.ar_prot;
+  assign mst.ar_qos     = slv.ar_qos;
+  assign mst.ar_region  = slv.ar_region;
+  assign mst.ar_user    = slv.ar_user;
+  assign mst.ar_valid   = slv.ar_valid;
+  assign slv.ar_ready   = mst.ar_ready;
+
+  // Keep track of outstanding downstream write bursts and responses.
+  always_comb begin
+    w_cnt_d = w_cnt_q;
+    if (mst.aw_valid && mst.aw_ready) begin
+      w_cnt_d += 1;
+    end
+    if (mst.w_valid && mst.w_ready && mst.w_last) begin
+      w_cnt_d -= 1;
+    end
+  end
+
+  always_ff @(posedge clk_i, negedge rst_ni) begin
+    if (!rst_ni) begin
+      id_q <= '0;
+      r_beats_q <= '0;
+      r_state_q <= R_FEEDTHROUGH;
+      w_cnt_q <= '0;
+      w_state_q <= W_FEEDTHROUGH;
+    end else begin
+      id_q <= id_d;
+      r_beats_q <= r_beats_d;
+      r_state_q <= r_state_d;
+      w_cnt_q <= w_cnt_d;
+      w_state_q <= w_state_d;
+    end
+  end
+
+  stream_register #(
+    .T(r_resp_cmd_t)
+  ) r_resp_cmd (
+    .clk_i      (clk_i),
+    .rst_ni     (rst_ni),
+    .clr_i      (1'b0),
+    .testmode_i (1'b0),
+    .valid_i    (r_resp_cmd_push_valid),
+    .ready_o    (r_resp_cmd_push_ready),
+    .data_i     (r_resp_cmd_push),
+    .valid_o    (r_resp_cmd_pop_valid),
+    .ready_i    (r_resp_cmd_pop_ready),
+    .data_o     (r_resp_cmd_pop)
+  );
+  assign r_resp_cmd_push.len = slv.aw_len;
+
+// pragma translate_off
+`ifndef VERILATOR
+  initial begin: p_assertions
+    assert (AXI_ID_WIDTH >= 1) else $fatal("AXI ID width must be at least 1!");
+    assert (MAX_OUTSTND_BURSTS >= 1)
+      else $fatal("Maximum number of outstanding bursts must be at least 1!");
+  end
+`endif
+// pragma translate_on
+
+endmodule

--- a/src/axi_cut.sv
+++ b/src/axi_cut.sv
@@ -71,6 +71,7 @@ module axi_cut #(
     prot_t      prot;
     qos_t       qos;
     region_t    region;
+    logic [5:0] atop;   // Only defined on the AW channel.
     user_t      user;
   } channel_ax_t;
 
@@ -106,6 +107,7 @@ module axi_cut #(
   assign aw_in.prot    = in.aw_prot    ;
   assign aw_in.qos     = in.aw_qos     ;
   assign aw_in.region  = in.aw_region  ;
+  assign aw_in.atop    = in.aw_atop    ;
   assign aw_in.user    = in.aw_user    ;
   assign out.aw_id     = aw_out.id     ;
   assign out.aw_addr   = aw_out.addr   ;
@@ -117,6 +119,7 @@ module axi_cut #(
   assign out.aw_prot   = aw_out.prot   ;
   assign out.aw_qos    = aw_out.qos    ;
   assign out.aw_region = aw_out.region ;
+  assign out.aw_atop   = aw_out.atop   ;
   assign out.aw_user   = aw_out.user   ;
   spill_register #(.T(channel_ax_t)) i_reg_aw (
     .clk_i   ( clk_i        ),
@@ -178,6 +181,7 @@ module axi_cut #(
   assign ar_in.prot    = in.ar_prot    ;
   assign ar_in.qos     = in.ar_qos     ;
   assign ar_in.region  = in.ar_region  ;
+  assign ar_in.atop    = 'X            ; // Not defined on the AR channel.
   assign ar_in.user    = in.ar_user    ;
   assign out.ar_id     = ar_out.id     ;
   assign out.ar_addr   = ar_out.addr   ;

--- a/src/axi_cut.sv
+++ b/src/axi_cut.sv
@@ -29,8 +29,8 @@ module axi_cut #(
 )(
   input logic clk_i  ,
   input logic rst_ni ,
-  AXI_BUS.in  in     ,
-  AXI_BUS.out out
+  AXI_BUS.Slave  in     ,
+  AXI_BUS.Master out
 );
 
   localparam STRB_WIDTH = DATA_WIDTH / 8;
@@ -42,6 +42,7 @@ module axi_cut #(
   typedef logic [USER_WIDTH-1:0] user_t;
 
   // Check the invariants.
+  `ifndef VCS
   `ifndef SYNTHESIS
   initial begin
     assert(ADDR_WIDTH >= 0);
@@ -57,6 +58,7 @@ module axi_cut #(
     assert(out.AXI_ID_WIDTH == ID_WIDTH);
     assert(out.AXI_USER_WIDTH == USER_WIDTH);
   end
+  `endif
   `endif
 
   // Create spill registers to buffer each channel.

--- a/src/axi_id_remap.sv
+++ b/src/axi_id_remap.sv
@@ -101,6 +101,7 @@ module axi_id_remap #(
     assign out.aw_prot   = in.aw_prot;
     assign out.aw_qos    = in.aw_qos;
     assign out.aw_region = in.aw_region;
+    assign out.aw_atop   = in.aw_atop;
     assign out.aw_user   = in.aw_user;
 
     assign out.ar_addr   = in.ar_addr;

--- a/src/axi_intf.sv
+++ b/src/axi_intf.sv
@@ -42,6 +42,7 @@ interface AXI_BUS #(
   prot_t      aw_prot;
   qos_t       aw_qos;
   region_t    aw_region;
+  logic [5:0] aw_atop;
   user_t      aw_user;
   logic       aw_valid;
   logic       aw_ready;
@@ -82,7 +83,7 @@ interface AXI_BUS #(
   logic       r_ready;
 
   modport Master (
-    output aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_user, aw_valid, input aw_ready,
+    output aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_atop, aw_user, aw_valid, input aw_ready,
     output w_data, w_strb, w_last, w_user, w_valid, input w_ready,
     input b_id, b_resp, b_user, b_valid, output b_ready,
     output ar_id, ar_addr, ar_len, ar_size, ar_burst, ar_lock, ar_cache, ar_prot, ar_qos, ar_region, ar_user, ar_valid, input ar_ready,
@@ -90,7 +91,7 @@ interface AXI_BUS #(
   );
 
   modport Slave (
-    input aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_user, aw_valid, output aw_ready,
+    input aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_atop, aw_user, aw_valid, output aw_ready,
     input w_data, w_strb, w_last, w_user, w_valid, output w_ready,
     output b_id, b_resp, b_user, b_valid, input b_ready,
     input ar_id, ar_addr, ar_len, ar_size, ar_burst, ar_lock, ar_cache, ar_prot, ar_qos, ar_region, ar_user, ar_valid, output ar_ready,
@@ -99,7 +100,7 @@ interface AXI_BUS #(
 
   /// The interface as an output (issuing requests, initiator, master).
   modport out (
-    output aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_user, aw_valid, input aw_ready,
+    output aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_atop, aw_user, aw_valid, input aw_ready,
     output w_data, w_strb, w_last, w_user, w_valid, input w_ready,
     input b_id, b_resp, b_user, b_valid, output b_ready,
     output ar_id, ar_addr, ar_len, ar_size, ar_burst, ar_lock, ar_cache, ar_prot, ar_qos, ar_region, ar_user, ar_valid, input ar_ready,
@@ -108,7 +109,7 @@ interface AXI_BUS #(
 
   /// The interface as an input (accepting requests, target, slave).
   modport in (
-    input aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_user, aw_valid, output aw_ready,
+    input aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_atop, aw_user, aw_valid, output aw_ready,
     input w_data, w_strb, w_last, w_user, w_valid, output w_ready,
     output b_id, b_resp, b_user, b_valid, input b_ready,
     input ar_id, ar_addr, ar_len, ar_size, ar_burst, ar_lock, ar_cache, ar_prot, ar_qos, ar_region, ar_user, ar_valid, output ar_ready,
@@ -245,6 +246,7 @@ interface AXI_BUS_ASYNC
   logic [2:0]                 aw_prot;
   logic [3:0]                 aw_qos;
   logic [3:0]                 aw_region;
+  logic [5:0]                 aw_atop;
   logic [AXI_USER_WIDTH-1:0]  aw_user;
   logic [BUFFER_WIDTH-1:0]    aw_writetoken;
   logic [BUFFER_WIDTH-1:0]    aw_readpointer;
@@ -285,7 +287,7 @@ interface AXI_BUS_ASYNC
   logic [BUFFER_WIDTH-1:0]    r_readpointer;
 
   modport Master (
-    output aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_user, aw_writetoken, input aw_readpointer,
+    output aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_atop, aw_user, aw_writetoken, input aw_readpointer,
     output w_data, w_strb, w_last, w_user, w_writetoken, input w_readpointer,
     input b_id, b_resp, b_user, b_writetoken, output b_readpointer,
     output ar_id, ar_addr, ar_len, ar_size, ar_burst, ar_lock, ar_cache, ar_prot, ar_qos, ar_region, ar_user, ar_writetoken, input ar_readpointer,
@@ -293,7 +295,7 @@ interface AXI_BUS_ASYNC
   );
 
   modport Slave (
-    input aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_user, aw_writetoken, output aw_readpointer,
+    input aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_atop, aw_user, aw_writetoken, output aw_readpointer,
     input w_data, w_strb, w_last, w_user, w_writetoken, output w_readpointer,
     output b_id, b_resp, b_user, b_writetoken, input b_readpointer,
     input ar_id, ar_addr, ar_len, ar_size, ar_burst, ar_lock, ar_cache, ar_prot, ar_qos, ar_region, ar_user, ar_writetoken, output ar_readpointer,

--- a/src/axi_join.sv
+++ b/src/axi_join.sv
@@ -37,6 +37,7 @@ module axi_join (
     assign out.aw_prot   = in.aw_prot;
     assign out.aw_qos    = in.aw_qos;
     assign out.aw_region = in.aw_region;
+    assign out.aw_atop   = in.aw_atop;
     assign out.aw_user   = in.aw_user;
     assign out.aw_valid  = in.aw_valid;
     assign out.w_data    = in.w_data;

--- a/src/axi_join.sv
+++ b/src/axi_join.sv
@@ -14,8 +14,8 @@
 
 /// A connector that joins two AXI interfaces.
 module axi_join (
-    AXI_BUS.in  in,
-    AXI_BUS.out out
+    AXI_BUS.Slave  in,
+    AXI_BUS.Master out
 );
 
     `ifndef SYNTHESIS

--- a/src/axi_lite_to_axi.sv
+++ b/src/axi_lite_to_axi.sv
@@ -34,6 +34,7 @@ module axi_lite_to_axi (
   assign out.aw_prot   = '0;
   assign out.aw_qos    = '0;
   assign out.aw_region = '0;
+  assign out.aw_atop   = '0;
   assign out.aw_user   = '0;
   assign out.aw_valid  = in.aw_valid;
   assign in.aw_ready   = out.aw_ready;

--- a/src/axi_modify_address.sv
+++ b/src/axi_modify_address.sv
@@ -45,6 +45,7 @@ module axi_modify_address #(
   assign out.aw_prot   = in.aw_prot;
   assign out.aw_qos    = in.aw_qos;
   assign out.aw_region = in.aw_region;
+  assign out.aw_atop   = in.aw_atop;
   assign out.aw_user   = in.aw_user;
   assign out.aw_valid  = in.aw_valid;
   assign out.w_data    = in.w_data;

--- a/src/axi_multicut.sv
+++ b/src/axi_multicut.sv
@@ -31,8 +31,8 @@ module axi_multicut #(
 )(
   input logic clk_i  ,
   input logic rst_ni ,
-  AXI_BUS.in  in     ,
-  AXI_BUS.out out
+  AXI_BUS.Slave  in     ,
+  AXI_BUS.Master out
 );
 
   // Check the invariants.
@@ -83,7 +83,7 @@ module axi_multicut #(
       .clk_i  ( clk_i        ),
       .rst_ni ( rst_ni       ),
       .in     ( in           ),
-      .out    ( s_cut[0].out )
+      .out    ( s_cut[0].Master )
     );
 
     for (genvar i = 1; i < NUM_CUTS-1; i++) begin
@@ -95,8 +95,8 @@ module axi_multicut #(
       ) i_middle (
         .clk_i  ( clk_i         ),
         .rst_ni ( rst_ni        ),
-        .in     ( s_cut[i-1].in ),
-        .out    ( s_cut[i].out  )
+        .in     ( s_cut[i-1].Slave ),
+        .out    ( s_cut[i].Master  )
       );
     end
 
@@ -108,7 +108,7 @@ module axi_multicut #(
     ) i_last (
       .clk_i  ( clk_i                ),
       .rst_ni ( rst_ni               ),
-      .in     ( s_cut[NUM_CUTS-2].in ),
+      .in     ( s_cut[NUM_CUTS-2].Slave ),
       .out    ( out                  )
     );
   end

--- a/src/axi_pkg.sv
+++ b/src/axi_pkg.sv
@@ -38,6 +38,26 @@ package axi_pkg;
   localparam CACHE_RD_ALLOC   = 4'b0100;
   localparam CACHE_WR_ALLOC   = 4'b1000;
 
+  // ATOP[5:0]
+  localparam ATOP_ATOMICSWAP  = 6'b110000;
+  localparam ATOP_ATOMICCMP   = 6'b110001;
+  // ATOP[5:4]
+  localparam ATOP_NONE        = 2'b00;
+  localparam ATOP_ATOMICSTORE = 2'b01;
+  localparam ATOP_ATOMICLOAD  = 2'b10;
+  // ATOP[3]
+  localparam ATOP_LITTLE_END  = 1'b0;
+  localparam ATOP_BIG_END     = 1'b1;
+  // ATOP[2:0]
+  localparam ATOP_ADD   = 3'b000;
+  localparam ATOP_CLR   = 3'b001;
+  localparam ATOP_EOR   = 3'b010;
+  localparam ATOP_SET   = 3'b011;
+  localparam ATOP_SMAX  = 3'b100;
+  localparam ATOP_SMIN  = 3'b101;
+  localparam ATOP_UMAX  = 3'b110;
+  localparam ATOP_UMIN  = 3'b111;
+
   // 4 is recommended by AXI standard, so lets stick to it, do not change
   localparam IdWidth   = 4;
   localparam UserWidth = 1;

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -224,6 +224,7 @@ package axi_test;
     logic [2:0]         ax_prot   = '0;
     logic [3:0]         ax_qos    = '0;
     logic [3:0]         ax_region = '0;
+    logic [5:0]         ax_atop   = '0; // Only defined on the AW channel.
     rand logic [UW-1:0] ax_user   = '0;
   endclass
 
@@ -305,6 +306,7 @@ package axi_test;
       axi.aw_prot   <= '0;
       axi.aw_qos    <= '0;
       axi.aw_region <= '0;
+      axi.aw_atop   <= '0;
       axi.aw_user   <= '0;
       axi.aw_valid  <= '0;
       axi.w_data    <= '0;
@@ -366,6 +368,7 @@ package axi_test;
       axi.aw_prot   <= #TA beat.ax_prot;
       axi.aw_qos    <= #TA beat.ax_qos;
       axi.aw_region <= #TA beat.ax_region;
+      axi.aw_atop   <= #TA beat.ax_atop;
       axi.aw_user   <= #TA beat.ax_user;
       axi.aw_valid  <= #TA 1;
       cycle_start();
@@ -381,6 +384,7 @@ package axi_test;
       axi.aw_prot   <= #TA '0;
       axi.aw_qos    <= #TA '0;
       axi.aw_region <= #TA '0;
+      axi.aw_atop   <= #TA '0;
       axi.aw_user   <= #TA '0;
       axi.aw_valid  <= #TA 0;
     endtask
@@ -493,6 +497,7 @@ package axi_test;
       beat.ax_prot   = axi.aw_prot;
       beat.ax_qos    = axi.aw_qos;
       beat.ax_region = axi.aw_region;
+      beat.ax_atop   = axi.aw_atop;
       beat.ax_user   = axi.aw_user;
       cycle_end();
       axi.aw_ready <= #TA 0;
@@ -547,6 +552,7 @@ package axi_test;
       beat.ax_prot   = axi.ar_prot;
       beat.ax_qos    = axi.ar_qos;
       beat.ax_region = axi.ar_region;
+      beat.ax_atop   = 'X;  // Not defined on the AR channel.
       beat.ax_user   = axi.ar_user;
       cycle_end();
       axi.ar_ready  <= #TA 0;

--- a/src/axi_to_axi_lite.sv
+++ b/src/axi_to_axi_lite.sv
@@ -27,8 +27,8 @@ module axi_to_axi_lite #(
   input logic  clk_i,
   input logic  rst_ni,
   input logic  testmode_i,
-  AXI_BUS.in   in,
-  AXI_LITE.out out
+  AXI_BUS.Slave   in,
+  AXI_LITE.Master out
 );
 
   `ifndef SYNTHESIS

--- a/src_files.yml
+++ b/src_files.yml
@@ -4,6 +4,7 @@ axi:
     - src/axi_test.sv
     - src/axi_intf.sv
 
+    - src/axi_atop_filter.sv
     - src/axi_arbiter.sv
     - src/axi_address_resolver.sv
 

--- a/test/tb_axi_delayer.sv
+++ b/test/tb_axi_delayer.sv
@@ -104,6 +104,7 @@ module tb_axi_delayer;
   assign aw_chan_i.prot = axi_master.aw_prot;
   assign aw_chan_i.qos = axi_master.aw_qos;
   assign aw_chan_i.region = axi_master.aw_region;
+  assign aw_chan_i.atop = axi_master.aw_atop;
 
   assign ar_chan_i.id = axi_master.ar_id;
   assign ar_chan_i.addr = axi_master.ar_addr;
@@ -139,6 +140,7 @@ module tb_axi_delayer;
   assign axi_slave.aw_prot = aw_chan_o.prot;
   assign axi_slave.aw_qos = aw_chan_o.qos;
   assign axi_slave.aw_region = aw_chan_o.region;
+  assign axi_slave.aw_atop = aw_chan_o.atop;
 
   assign axi_slave.ar_id = ar_chan_o.id;
   assign axi_slave.ar_addr = ar_chan_o.addr;

--- a/test/tb_axi_lite_to_axi.wave.do
+++ b/test/tb_axi_lite_to_axi.wave.do
@@ -29,6 +29,7 @@ add wave -noupdate -expand -group axi /tb_axi_lite_to_axi/axi/aw_cache
 add wave -noupdate -expand -group axi /tb_axi_lite_to_axi/axi/aw_prot
 add wave -noupdate -expand -group axi /tb_axi_lite_to_axi/axi/aw_qos
 add wave -noupdate -expand -group axi /tb_axi_lite_to_axi/axi/aw_region
+add wave -noupdate -expand -group axi /tb_axi_lite_to_axi/axi/aw_atop
 add wave -noupdate -expand -group axi /tb_axi_lite_to_axi/axi/aw_user
 add wave -noupdate -expand -group axi /tb_axi_lite_to_axi/axi/aw_valid
 add wave -noupdate -expand -group axi /tb_axi_lite_to_axi/axi/aw_ready

--- a/test/tb_axi_to_axi_lite.wave.do
+++ b/test/tb_axi_to_axi_lite.wave.do
@@ -21,6 +21,7 @@ add wave -noupdate -expand -group {in (AXI4)} /tb_axi_to_axi_lite/axi/aw_cache
 add wave -noupdate -expand -group {in (AXI4)} /tb_axi_to_axi_lite/axi/aw_prot
 add wave -noupdate -expand -group {in (AXI4)} /tb_axi_to_axi_lite/axi/aw_qos
 add wave -noupdate -expand -group {in (AXI4)} /tb_axi_to_axi_lite/axi/aw_region
+add wave -noupdate -expand -group {in (AXI4)} /tb_axi_to_axi_lite/axi/aw_atop
 add wave -noupdate -expand -group {in (AXI4)} /tb_axi_to_axi_lite/axi/aw_user
 add wave -noupdate -expand -group {in (AXI4)} /tb_axi_to_axi_lite/axi/aw_valid
 add wave -noupdate -expand -group {in (AXI4)} /tb_axi_to_axi_lite/axi/aw_ready


### PR DESCRIPTION
At the moment in an alias for Slave and out an alias for Master. This causes VCS to complain and refuse to compile when the names are mixed. This PR remove the in and out aliases. Linked to 