### PR TITLE
Remove interface name aliasing to keep VCS happy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- The `in` and `out` modports have been removed from the interface definition of both AXI and AXI
+  Lite.  These modports were "aliases" of `Slave` and `Master`, respectively, and caused problems
+  because many tools did not recognize the aliases as being identical to `Slave` and `Master`.
+
 ## 0.6.0 - 2019-02-27
 
 ### Changed

--- a/src/axi_cut.sv
+++ b/src/axi_cut.sv
@@ -29,8 +29,8 @@ module axi_cut #(
 )(
   input logic clk_i  ,
   input logic rst_ni ,
-  AXI_BUS.in  in     ,
-  AXI_BUS.out out
+  AXI_BUS.Slave  in     ,
+  AXI_BUS.Master out
 );
 
   localparam STRB_WIDTH = DATA_WIDTH / 8;

--- a/src/axi_cut.sv
+++ b/src/axi_cut.sv
@@ -27,10 +27,10 @@ module axi_cut #(
   // The user data width.
   parameter int USER_WIDTH = -1
 )(
-  input logic clk_i  ,
-  input logic rst_ni ,
-  AXI_BUS.Slave  in     ,
-  AXI_BUS.Master out
+  input logic     clk_i  ,
+  input logic     rst_ni ,
+  AXI_BUS.Slave   in     ,
+  AXI_BUS.Master  out
 );
 
   localparam STRB_WIDTH = DATA_WIDTH / 8;

--- a/src/axi_cut.sv
+++ b/src/axi_cut.sv
@@ -42,6 +42,7 @@ module axi_cut #(
   typedef logic [USER_WIDTH-1:0] user_t;
 
   // Check the invariants.
+  `ifndef VCS
   `ifndef SYNTHESIS
   initial begin
     assert(ADDR_WIDTH >= 0);
@@ -57,6 +58,7 @@ module axi_cut #(
     assert(out.AXI_ID_WIDTH == ID_WIDTH);
     assert(out.AXI_USER_WIDTH == USER_WIDTH);
   end
+  `endif
   `endif
 
   // Create spill registers to buffer each channel.

--- a/src/axi_id_remap.sv
+++ b/src/axi_id_remap.sv
@@ -24,10 +24,10 @@ module axi_id_resize #(
     parameter int ID_WIDTH_OUT = -1,
     parameter int TABLE_SIZE   = 1
 )(
-    input logic clk_i,
-    input logic rst_ni,
-    AXI_BUS.in  in,
-    AXI_BUS.out out
+    input logic     clk_i,
+    input logic     rst_ni,
+    AXI_BUS.Slave   in,
+    AXI_BUS.Master  out
 );
 
     // Instantiate a downsizer if the outgoing ID is smaller, otherwise simply
@@ -62,10 +62,10 @@ module axi_id_remap #(
     parameter int ID_WIDTH_OUT  = -1,
     parameter int TABLE_SIZE    = 1
 )(
-    input logic clk_i,
-    input logic rst_ni,
-    AXI_BUS.in  in,
-    AXI_BUS.out out
+    input logic     clk_i,
+    input logic     rst_ni,
+    AXI_BUS.Slave   in,
+    AXI_BUS.Master  out
 );
 
     logic full_id_aw_b;

--- a/src/axi_intf.sv
+++ b/src/axi_intf.sv
@@ -98,24 +98,6 @@ interface AXI_BUS #(
     output r_id, r_data, r_resp, r_last, r_user, r_valid, input r_ready
   );
 
-  /// The interface as an output (issuing requests, initiator, master).
-  modport out (
-    output aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_atop, aw_user, aw_valid, input aw_ready,
-    output w_data, w_strb, w_last, w_user, w_valid, input w_ready,
-    input b_id, b_resp, b_user, b_valid, output b_ready,
-    output ar_id, ar_addr, ar_len, ar_size, ar_burst, ar_lock, ar_cache, ar_prot, ar_qos, ar_region, ar_user, ar_valid, input ar_ready,
-    input r_id, r_data, r_resp, r_last, r_user, r_valid, output r_ready
-  );
-
-  /// The interface as an input (accepting requests, target, slave).
-  modport in (
-    input aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_atop, aw_user, aw_valid, output aw_ready,
-    input w_data, w_strb, w_last, w_user, w_valid, output w_ready,
-    output b_id, b_resp, b_user, b_valid, input b_ready,
-    input ar_id, ar_addr, ar_len, ar_size, ar_burst, ar_lock, ar_cache, ar_prot, ar_qos, ar_region, ar_user, ar_valid, output ar_ready,
-    output r_id, r_data, r_resp, r_last, r_user, r_valid, input r_ready
-  );
-
 endinterface
 
 
@@ -196,24 +178,6 @@ interface AXI_BUS_DV #(
   );
 
   modport Slave (
-    input aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_atop, aw_user, aw_valid, output aw_ready,
-    input w_data, w_strb, w_last, w_user, w_valid, output w_ready,
-    output b_id, b_resp, b_user, b_valid, input b_ready,
-    input ar_id, ar_addr, ar_len, ar_size, ar_burst, ar_lock, ar_cache, ar_prot, ar_qos, ar_region, ar_user, ar_valid, output ar_ready,
-    output r_id, r_data, r_resp, r_last, r_user, r_valid, input r_ready
-  );
-
-  /// The interface as an output (issuing requests, initiator, master).
-  modport out (
-    output aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_atop, aw_user, aw_valid, input aw_ready,
-    output w_data, w_strb, w_last, w_user, w_valid, input w_ready,
-    input b_id, b_resp, b_user, b_valid, output b_ready,
-    output ar_id, ar_addr, ar_len, ar_size, ar_burst, ar_lock, ar_cache, ar_prot, ar_qos, ar_region, ar_user, ar_valid, input ar_ready,
-    input r_id, r_data, r_resp, r_last, r_user, r_valid, output r_ready
-  );
-
-  /// The interface as an input (accepting requests, target, slave).
-  modport in (
     input aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_atop, aw_user, aw_valid, output aw_ready,
     input w_data, w_strb, w_last, w_user, w_valid, output w_ready,
     output b_id, b_resp, b_user, b_valid, input b_ready,
@@ -356,24 +320,6 @@ interface AXI_LITE #(
     output r_data, r_resp, r_valid, input r_ready
   );
 
-  /// The interface as an output (issuing requests, initiator, master).
-  modport out (
-    output aw_addr, aw_valid, input aw_ready,
-    output w_data, w_strb, w_valid, input w_ready,
-    input b_resp, b_valid, output b_ready,
-    output ar_addr, ar_valid, input ar_ready,
-    input r_data, r_resp, r_valid, output r_ready
-  );
-
-  /// The interface as an input (accepting requests, target, slave).
-  modport in (
-    input aw_addr, aw_valid, output aw_ready,
-    input w_data, w_strb, w_valid, output w_ready,
-    output b_resp, b_valid, input b_ready,
-    input ar_addr, ar_valid, output ar_ready,
-    output r_data, r_resp, r_valid, input r_ready
-  );
-
 endinterface
 
 /// A clocked AXI4-Lite interface for use in design verification.
@@ -422,24 +368,6 @@ interface AXI_LITE_DV #(
   );
 
   modport Slave (
-    input aw_addr, aw_valid, output aw_ready,
-    input w_data, w_strb, w_valid, output w_ready,
-    output b_resp, b_valid, input b_ready,
-    input ar_addr, ar_valid, output ar_ready,
-    output r_data, r_resp, r_valid, input r_ready
-  );
-
-  /// The interface as an output (issuing requests, initiator, master).
-  modport out (
-    output aw_addr, aw_valid, input aw_ready,
-    output w_data, w_strb, w_valid, input w_ready,
-    input b_resp, b_valid, output b_ready,
-    output ar_addr, ar_valid, input ar_ready,
-    input r_data, r_resp, r_valid, output r_ready
-  );
-
-  /// The interface as an input (accepting requests, target, slave).
-  modport in (
     input aw_addr, aw_valid, output aw_ready,
     input w_data, w_strb, w_valid, output w_ready,
     output b_resp, b_valid, input b_ready,

--- a/src/axi_join.sv
+++ b/src/axi_join.sv
@@ -14,8 +14,8 @@
 
 /// A connector that joins two AXI interfaces.
 module axi_join (
-    AXI_BUS.in  in,
-    AXI_BUS.out out
+    AXI_BUS.Slave  in,
+    AXI_BUS.Master out
 );
 
     `ifndef SYNTHESIS

--- a/src/axi_lite_cut.sv
+++ b/src/axi_lite_cut.sv
@@ -23,10 +23,10 @@ module axi_lite_cut #(
   /// The data width.
   parameter int DATA_WIDTH = -1
 )(
-  input logic  clk_i  ,
-  input logic  rst_ni ,
-  AXI_LITE.in  in     ,
-  AXI_LITE.out out
+  input logic     clk_i  ,
+  input logic     rst_ni ,
+  AXI_LITE.Slave  in     ,
+  AXI_LITE.Master out
 );
 
   // Check the invariants.

--- a/src/axi_lite_join.sv
+++ b/src/axi_lite_join.sv
@@ -14,8 +14,8 @@
 
 /// A connector that joins two AXI-Lite interfaces.
 module axi_lite_join (
-    AXI_LITE.in  in,
-    AXI_LITE.out out
+    AXI_LITE.Slave  in,
+    AXI_LITE.Master out
 );
 
     `ifndef SYNTHESIS

--- a/src/axi_lite_multicut.sv
+++ b/src/axi_lite_multicut.sv
@@ -25,10 +25,10 @@ module axi_lite_multicut #(
   // The number of cuts. Must be >= 0.
   parameter int NUM_CUTS = 0
 )(
-  input logic  clk_i  ,
-  input logic  rst_ni ,
-  AXI_LITE.in  in     ,
-  AXI_LITE.out out
+  input logic     clk_i  ,
+  input logic     rst_ni ,
+  AXI_LITE.Slave  in     ,
+  AXI_LITE.Master out
 );
 
   // Check the invariants.

--- a/src/axi_lite_multicut.sv
+++ b/src/axi_lite_multicut.sv
@@ -70,10 +70,10 @@ module axi_lite_multicut #(
       .ADDR_WIDTH ( ADDR_WIDTH ),
       .DATA_WIDTH ( DATA_WIDTH )
     ) i_first (
-      .clk_i  ( clk_i        ),
-      .rst_ni ( rst_ni       ),
-      .in     ( in           ),
-      .out    ( s_cut[0].out )
+      .clk_i  ( clk_i           ),
+      .rst_ni ( rst_ni          ),
+      .in     ( in              ),
+      .out    ( s_cut[0].Master )
     );
 
     for (genvar i = 1; i < NUM_CUTS-1; i++) begin
@@ -81,10 +81,10 @@ module axi_lite_multicut #(
         .ADDR_WIDTH ( ADDR_WIDTH ),
         .DATA_WIDTH ( DATA_WIDTH )
       ) i_middle (
-        .clk_i  ( clk_i         ),
-        .rst_ni ( rst_ni        ),
-        .in     ( s_cut[i-1].in ),
-        .out    ( s_cut[i].out  )
+        .clk_i  ( clk_i             ),
+        .rst_ni ( rst_ni            ),
+        .in     ( s_cut[i-1].Slave  ),
+        .out    ( s_cut[i].Master   )
       );
     end
 
@@ -92,10 +92,10 @@ module axi_lite_multicut #(
       .ADDR_WIDTH ( ADDR_WIDTH ),
       .DATA_WIDTH ( DATA_WIDTH )
     ) i_last (
-      .clk_i  ( clk_i                ),
-      .rst_ni ( rst_ni               ),
-      .in     ( s_cut[NUM_CUTS-2].in ),
-      .out    ( out                  )
+      .clk_i  ( clk_i                   ),
+      .rst_ni ( rst_ni                  ),
+      .in     ( s_cut[NUM_CUTS-2].Slave ),
+      .out    ( out                     )
     );
   end
 

--- a/src/axi_lite_to_axi.sv
+++ b/src/axi_lite_to_axi.sv
@@ -14,7 +14,7 @@
 /// An AXI4-Lite to AXI4 adapter.
 module axi_lite_to_axi (
   AXI_LITE.in in,
-  AXI_BUS.out out
+  AXI_BUS.Master  out
 );
 
   `ifndef SYNTHESIS

--- a/src/axi_lite_to_axi.sv
+++ b/src/axi_lite_to_axi.sv
@@ -13,7 +13,7 @@
 
 /// An AXI4-Lite to AXI4 adapter.
 module axi_lite_to_axi (
-  AXI_LITE.in in,
+  AXI_LITE.Slave  in,
   AXI_BUS.Master  out
 );
 

--- a/src/axi_lite_xbar.sv
+++ b/src/axi_lite_xbar.sv
@@ -29,8 +29,8 @@ module axi_lite_xbar #(
 )(
   input logic            clk_i               ,
   input logic            rst_ni              ,
-  AXI_LITE.in            master [NUM_MASTER] ,
-  AXI_LITE.out           slave  [NUM_SLAVE]  ,
+  AXI_LITE.Slave         master [NUM_MASTER] ,
+  AXI_LITE.Master        slave  [NUM_SLAVE]  ,
   AXI_ROUTING_RULES.xbar rules
 );
 
@@ -91,8 +91,8 @@ module axi_lite_xbar_simple #(
 )(
   input logic            clk_i               ,
   input logic            rst_ni              ,
-  AXI_LITE.in            master [NUM_MASTER] ,
-  AXI_LITE.out           slave  [NUM_SLAVE]  ,
+  AXI_LITE.Slave         master [NUM_MASTER] ,
+  AXI_LITE.Master        slave  [NUM_SLAVE]  ,
   AXI_ROUTING_RULES.xbar rules               ,
   AXI_ARBITRATION.req    arb_rd              ,
   AXI_ARBITRATION.req    arb_wr

--- a/src/axi_modify_address.sv
+++ b/src/axi_modify_address.sv
@@ -17,8 +17,8 @@ module axi_modify_address #(
   parameter int ADDR_WIDTH_IN  = -1,
   parameter int ADDR_WIDTH_OUT = ADDR_WIDTH_IN
 )(
-  AXI_BUS.in  in,
-  AXI_BUS.out out,
+  AXI_BUS.Slave   in,
+  AXI_BUS.Master  out,
   output logic [ADDR_WIDTH_IN-1:0]  aw_addr_in,
   output logic [ADDR_WIDTH_IN-1:0]  ar_addr_in,
   input  logic [ADDR_WIDTH_OUT-1:0] aw_addr_out,

--- a/src/axi_multicut.sv
+++ b/src/axi_multicut.sv
@@ -31,8 +31,8 @@ module axi_multicut #(
 )(
   input logic clk_i  ,
   input logic rst_ni ,
-  AXI_BUS.in  in     ,
-  AXI_BUS.out out
+  AXI_BUS.Slave  in     ,
+  AXI_BUS.Master out
 );
 
   // Check the invariants.
@@ -83,7 +83,7 @@ module axi_multicut #(
       .clk_i  ( clk_i        ),
       .rst_ni ( rst_ni       ),
       .in     ( in           ),
-      .out    ( s_cut[0].out )
+      .out    ( s_cut[0].Master )
     );
 
     for (genvar i = 1; i < NUM_CUTS-1; i++) begin
@@ -95,8 +95,8 @@ module axi_multicut #(
       ) i_middle (
         .clk_i  ( clk_i         ),
         .rst_ni ( rst_ni        ),
-        .in     ( s_cut[i-1].in ),
-        .out    ( s_cut[i].out  )
+        .in     ( s_cut[i-1].Slave ),
+        .out    ( s_cut[i].Master  )
       );
     end
 
@@ -108,7 +108,7 @@ module axi_multicut #(
     ) i_last (
       .clk_i  ( clk_i                ),
       .rst_ni ( rst_ni               ),
-      .in     ( s_cut[NUM_CUTS-2].in ),
+      .in     ( s_cut[NUM_CUTS-2].Slave ),
       .out    ( out                  )
     );
   end

--- a/src/axi_multicut.sv
+++ b/src/axi_multicut.sv
@@ -29,10 +29,10 @@ module axi_multicut #(
   // The number of cuts. Must be >= 0.
   parameter int NUM_CUTS = 0
 )(
-  input logic clk_i  ,
-  input logic rst_ni ,
-  AXI_BUS.Slave  in     ,
-  AXI_BUS.Master out
+  input logic     clk_i  ,
+  input logic     rst_ni ,
+  AXI_BUS.Slave   in     ,
+  AXI_BUS.Master  out
 );
 
   // Check the invariants.
@@ -80,9 +80,9 @@ module axi_multicut #(
       .ID_WIDTH   ( ID_WIDTH   ),
       .USER_WIDTH ( USER_WIDTH )
     ) i_first (
-      .clk_i  ( clk_i        ),
-      .rst_ni ( rst_ni       ),
-      .in     ( in           ),
+      .clk_i  ( clk_i           ),
+      .rst_ni ( rst_ni          ),
+      .in     ( in              ),
       .out    ( s_cut[0].Master )
     );
 
@@ -93,10 +93,10 @@ module axi_multicut #(
         .ID_WIDTH   ( ID_WIDTH   ),
         .USER_WIDTH ( USER_WIDTH )
       ) i_middle (
-        .clk_i  ( clk_i         ),
-        .rst_ni ( rst_ni        ),
-        .in     ( s_cut[i-1].Slave ),
-        .out    ( s_cut[i].Master  )
+        .clk_i  ( clk_i             ),
+        .rst_ni ( rst_ni            ),
+        .in     ( s_cut[i-1].Slave  ),
+        .out    ( s_cut[i].Master   )
       );
     end
 
@@ -106,10 +106,10 @@ module axi_multicut #(
       .ID_WIDTH   ( ID_WIDTH   ),
       .USER_WIDTH ( USER_WIDTH )
     ) i_last (
-      .clk_i  ( clk_i                ),
-      .rst_ni ( rst_ni               ),
+      .clk_i  ( clk_i                   ),
+      .rst_ni ( rst_ni                  ),
       .in     ( s_cut[NUM_CUTS-2].Slave ),
-      .out    ( out                  )
+      .out    ( out                     )
     );
   end
 

--- a/src/axi_to_axi_lite.sv
+++ b/src/axi_to_axi_lite.sv
@@ -27,8 +27,8 @@ module axi_to_axi_lite #(
   input logic  clk_i,
   input logic  rst_ni,
   input logic  testmode_i,
-  AXI_BUS.in   in,
-  AXI_LITE.out out
+  AXI_BUS.Slave   in,
+  AXI_LITE.Master out
 );
 
   `ifndef SYNTHESIS

--- a/src/axi_to_axi_lite.sv
+++ b/src/axi_to_axi_lite.sv
@@ -24,9 +24,9 @@ module axi_to_axi_lite #(
   /// Maximum number of outstanding writes.
   parameter int NUM_PENDING_WR = 1
 )(
-  input logic  clk_i,
-  input logic  rst_ni,
-  input logic  testmode_i,
+  input logic     clk_i,
+  input logic     rst_ni,
+  input logic     testmode_i,
   AXI_BUS.Slave   in,
   AXI_LITE.Master out
 );
@@ -84,7 +84,7 @@ module axi_to_axi_lite #(
     .push_i  ( in.ar_ready & in.ar_valid              ),
     // After the last response on the R channel we pop the metadata off the
     // queue.
-    .data_o  ( {meta_rd_id, meta_rd_user}                   ),
+    .data_o  ( {meta_rd_id, meta_rd_user}          ),
     .pop_i   ( in.r_valid & in.r_ready & in.r_last )
   );
 
@@ -101,7 +101,7 @@ module axi_to_axi_lite #(
     .data_i  ( {in.aw_id, in.aw_user}    ),
     .push_i  ( in.aw_ready & in.aw_valid ),
     // After the response on the B channel we pop the metadata off the queue.
-    .data_o  ( {meta_wr_id, meta_wr_user}      ),
+    .data_o  ( {meta_wr_id, meta_wr_user}),
     .pop_i   ( in.b_valid & in.b_ready   )
   );
 

--- a/test/synth_bench.sv
+++ b/test/synth_bench.sv
@@ -91,12 +91,12 @@ module synth_slice #(
     .clk_i      (clk_i),
     .rst_ni     (rst_ni),
     .testmode_i (1'b0),
-    .in         (a_full.in),
-    .out        (a_lite.out)
+    .in         (a_full.Slave),
+    .out        (a_lite.Master)
   );
   axi_lite_to_axi b (
-    .in   (b_lite.in),
-    .out  (b_full.out)
+    .in   (b_lite.Slave),
+    .out  (b_full.Master)
   );
 
 endmodule
@@ -139,8 +139,8 @@ module axi_lite_xbar_slice #(
   ) xbar (
     .clk_i  ( clk_i              ),
     .rst_ni ( rst_ni             ),
-    .master ( xbar_master.in     ),
-    .slave  ( xbar_slave.out     ),
+    .master ( xbar_master.Slave  ),
+    .slave  ( xbar_slave.Master  ),
     .rules  ( xbar_routing.xbar  )
   );
 


### PR DESCRIPTION
Continuation of #9.