### PR TITLE
:art: Remove one level of generate from multicut

### DIFF
--- a/src/axi_multicut.sv
+++ b/src/axi_multicut.sv
@@ -51,7 +51,7 @@ module axi_multicut #(
   );
 
   // AXI cuts (if needed)
-  for (genvar i = 0; i < NUM_CUTS; i++) begin
+  for (genvar i = 0; i < NUM_CUTS; i++) begin : g_cuts
     axi_cut #(
       .ADDR_WIDTH ( ADDR_WIDTH ),
       .DATA_WIDTH ( DATA_WIDTH ),


### PR DESCRIPTION
Restructure the AXI multicut to not need explicit case detection for 0, 1 or more cuts.