### PR TITLE
Add AXI CDCs

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -53,6 +53,7 @@ sources:
   - target: test
     files:
       - test/tb_axi_atop_filter.sv
+      - test/tb_axi_cdc.sv
       - test/tb_axi_delayer.sv
       - test/tb_axi_lite_to_axi.sv
       - test/tb_axi_lite_xbar.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -22,6 +22,7 @@ sources:
   - src/axi_intf.sv
   # Level 2
   - src/axi_atop_filter.sv
+  - src/axi_cdc.sv
   - src/axi_cut.sv
   - src/axi_delayer.sv
   - src/axi_demux.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+- `axi_cdc`: Add a safe AXI clock domain crossing (CDC) implementation.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is the implementation of the AMBA AXI protocol developed as part of the PUL
 | Name                                                 | Description                                                                                       | Doc                         |
 |------------------------------------------------------|---------------------------------------------------------------------------------------------------|-----------------------------|
 | [`axi_atop_filter.sv`](src/axi_atop_filter.sv)       | Filters atomic operations (ATOPs), i.e., write transactions that have a non-zero `aw_atop` value. |                             |
+| [`axi_cdc.sv`](src/axi_cdc.sv)                       | AXI clock domain crossing based on a Gray FIFO implementation.                                    |                             |
 | [`axi_cut.sv`](src/axi_cut.sv)                       | Breaks all combinatorial paths between its input and output.                                      |                             |
 | [`axi_decerr_slv.sv`](src/axi_decerr_slv.sv)         | Always responds with an AXI decode error for transactions which are sent to it.                   |                             |
 | [`axi_delayer.sv`](src/axi_delayer.sv)               | Synthesizable module which can (randomly) delays AXI channels.                                    |                             |

--- a/scripts/run_vsim.sh
+++ b/scripts/run_vsim.sh
@@ -32,3 +32,4 @@ call_vsim tb_axi_delayer
 call_vsim tb_axi_atop_filter -GN_TXNS=1000
 call_vsim tb_axi_xbar -t 1ns -coverage -voptargs="+acc +cover=bcesfx"
 call_vsim tb_axi_lite_xbar -t 1ns -coverage -voptargs="+acc +cover=bcesfx"
+call_vsim tb_axi_cdc

--- a/src/axi_cdc.sv
+++ b/src/axi_cdc.sv
@@ -1,0 +1,194 @@
+// Copyright (c) 2019 ETH Zurich, University of Bologna
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Andreas Kurth <akurth@iis.ee.ethz.ch>
+// Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
+// Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+
+`include "axi/assign.svh"
+import axi_pkg::*;
+
+/// A clock domain crossing on an AXI interface.
+///
+/// For each of the five AXI channels, this module instantiates a CDC FIFO, whose push and pop
+/// ports are in separate clock domains.  IMPORTANT: For each AXI channel, you MUST properly
+/// constrain three paths through the FIFO; see the header of `cdc_fifo_gray` for instructions.
+module axi_cdc #(
+  parameter type aw_chan_t  = logic, // AW Channel Type
+  parameter type w_chan_t   = logic, //  W Channel Type
+  parameter type b_chan_t   = logic, //  B Channel Type
+  parameter type ar_chan_t  = logic, // AR Channel Type
+  parameter type r_chan_t   = logic, //  R Channel Type
+  parameter type axi_req_t  = logic, // encapsulates request channels
+  parameter type axi_resp_t = logic, // encapsulates request channels
+  /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
+  parameter int unsigned  LOG_DEPTH = 1
+) (
+  // slave side - clocked by `src_clk_i`
+  input  logic      src_clk_i,
+  input  logic      src_rst_ni,
+  input  axi_req_t  src_req_i,
+  output axi_resp_t src_resp_o,
+  // master side - clocked by `dst_clk_i`
+  input  logic      dst_clk_i,
+  input  logic      dst_rst_ni,
+  output axi_req_t  dst_req_o,
+  input  axi_resp_t dst_resp_i
+);
+
+    cdc_fifo_gray #(
+        //  We need to cast to bits here because of some arbitrary bug in Synopsys.
+        .WIDTH       ( $bits(aw_chan_t)    ),
+        .LOG_DEPTH   ( LOG_DEPTH           )
+    ) i_cdc_fifo_gray_aw (
+        .src_rst_ni,
+        .src_clk_i,
+        .src_data_i  ( src_req_i.aw        ),
+        .src_valid_i ( src_req_i.aw_valid  ),
+        .src_ready_o ( src_resp_o.aw_ready ),
+        .dst_rst_ni,
+        .dst_clk_i,
+        .dst_data_o  ( dst_req_o.aw        ),
+        .dst_valid_o ( dst_req_o.aw_valid  ),
+        .dst_ready_i ( dst_resp_i.aw_ready )
+    );
+
+    cdc_fifo_gray #(
+        .WIDTH       ( $bits(w_chan_t)    ),
+        .LOG_DEPTH   ( LOG_DEPTH          )
+    ) i_cdc_fifo_gray_w (
+        .src_rst_ni,
+        .src_clk_i,
+        .src_data_i  ( src_req_i.w        ),
+        .src_valid_i ( src_req_i.w_valid  ),
+        .src_ready_o ( src_resp_o.w_ready ),
+        .dst_rst_ni,
+        .dst_clk_i,
+        .dst_data_o  ( dst_req_o.w        ),
+        .dst_valid_o ( dst_req_o.w_valid  ),
+        .dst_ready_i ( dst_resp_i.w_ready )
+    );
+
+    cdc_fifo_gray #(
+        .WIDTH       ( $bits(b_chan_t)    ),
+        .LOG_DEPTH   ( LOG_DEPTH          )
+    ) i_cdc_fifo_gray_b (
+        .src_rst_ni  ( dst_rst_ni         ),
+        .src_clk_i   ( dst_clk_i          ),
+        .src_data_i  ( dst_resp_i.b       ),
+        .src_valid_i ( dst_resp_i.b_valid ),
+        .src_ready_o ( dst_req_o.b_ready  ),
+        .dst_rst_ni  ( src_rst_ni         ),
+        .dst_clk_i   ( src_clk_i          ),
+        .dst_data_o  ( src_resp_o.b       ),
+        .dst_valid_o ( src_resp_o.b_valid ),
+        .dst_ready_i ( src_req_i.b_ready  )
+    );
+
+    cdc_fifo_gray #(
+        .WIDTH       ( $bits(ar_chan_t)    ),
+        .LOG_DEPTH   ( LOG_DEPTH           )
+    ) i_cdc_fifo_gray_ar (
+        .src_rst_ni,
+        .src_clk_i,
+        .src_data_i  ( src_req_i.ar        ),
+        .src_valid_i ( src_req_i.ar_valid  ),
+        .src_ready_o ( src_resp_o.ar_ready ),
+        .dst_rst_ni,
+        .dst_clk_i,
+        .dst_data_o  ( dst_req_o.ar        ),
+        .dst_valid_o ( dst_req_o.ar_valid  ),
+        .dst_ready_i ( dst_resp_i.ar_ready )
+    );
+
+    cdc_fifo_gray #(
+        .WIDTH       ( $bits(r_chan_t)    ),
+        .LOG_DEPTH   ( LOG_DEPTH          )
+    ) i_cdc_fifo_gray_r (
+        .src_rst_ni  ( dst_rst_ni         ),
+        .src_clk_i   ( dst_clk_i          ),
+        .src_data_i  ( dst_resp_i.r       ),
+        .src_valid_i ( dst_resp_i.r_valid ),
+        .src_ready_o ( dst_req_o.r_ready  ),
+        .dst_rst_ni  ( src_rst_ni         ),
+        .dst_clk_i   ( src_clk_i          ),
+        .dst_data_o  ( src_resp_o.r       ),
+        .dst_valid_o ( src_resp_o.r_valid ),
+        .dst_ready_i ( src_req_i.r_ready  )
+    );
+
+endmodule
+
+`include "axi/assign.svh"
+`include "axi/typedef.svh"
+
+// interface wrapper
+module axi_cdc_wrap #(
+  parameter int unsigned AXI_ID_WIDTH   = 0,
+  parameter int unsigned AXI_ADDR_WIDTH = 0,
+  parameter int unsigned AXI_DATA_WIDTH = 0,
+  parameter int unsigned AXI_USER_WIDTH = 0,
+  /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
+  parameter int unsigned LOG_DEPTH = 1
+) (
+   // slave side - clocked by `src_clk_i`
+  input  logic      src_clk_i,
+  input  logic      src_rst_ni,
+  AXI_BUS.Slave     src,
+  // master side - clocked by `dst_clk_i`
+  input  logic      dst_clk_i,
+  input  logic      dst_rst_ni,
+  AXI_BUS.Master    dst
+);
+
+  typedef logic [AXI_ID_WIDTH-1:0]     id_t;
+  typedef logic [AXI_ADDR_WIDTH-1:0]   addr_t;
+  typedef logic [AXI_DATA_WIDTH-1:0]   data_t;
+  typedef logic [AXI_DATA_WIDTH/8-1:0] strb_t;
+  typedef logic [AXI_USER_WIDTH-1:0]   user_t;
+  `AXI_TYPEDEF_AW_CHAN_T ( aw_chan_t, addr_t, id_t,         user_t);
+  `AXI_TYPEDEF_W_CHAN_T  (  w_chan_t, data_t,       strb_t, user_t);
+  `AXI_TYPEDEF_B_CHAN_T  (  b_chan_t,         id_t,         user_t);
+  `AXI_TYPEDEF_AR_CHAN_T ( ar_chan_t, addr_t, id_t,         user_t);
+  `AXI_TYPEDEF_R_CHAN_T  (  r_chan_t, data_t, id_t,         user_t);
+  `AXI_TYPEDEF_REQ_T     (     req_t, aw_chan_t, w_chan_t, ar_chan_t);
+  `AXI_TYPEDEF_RESP_T    (    resp_t,  b_chan_t, r_chan_t);
+
+  req_t  src_req,  dst_req;
+  resp_t src_resp, dst_resp;
+
+  `AXI_ASSIGN_TO_REQ    ( src_req,  src      );
+  `AXI_ASSIGN_FROM_RESP ( src,      src_resp );
+
+  `AXI_ASSIGN_FROM_REQ  ( dst     , dst_req  );
+  `AXI_ASSIGN_TO_RESP   ( dst_resp, dst      );
+
+  axi_cdc #(
+    .aw_chan_t  ( aw_chan_t ),
+    .w_chan_t   ( w_chan_t  ),
+    .b_chan_t   ( b_chan_t  ),
+    .ar_chan_t  ( ar_chan_t ),
+    .r_chan_t   ( r_chan_t  ),
+    .axi_req_t  ( req_t     ),
+    .axi_resp_t ( resp_t    ),
+    .LOG_DEPTH  ( LOG_DEPTH )
+  ) i_axi_cdc (
+    .src_clk_i,
+    .src_rst_ni,
+    .src_req_i  ( src_req  ),
+    .src_resp_o ( src_resp ),
+    .dst_clk_i,
+    .dst_rst_ni,
+    .dst_req_o  ( dst_req  ),
+    .dst_resp_i ( dst_resp ),
+  );
+
+  endmodule

--- a/src/axi_cdc.sv
+++ b/src/axi_cdc.sv
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 ETH Zurich, University of Bologna
+// Copyright (c) 20192-2020 ETH Zurich, University of Bologna
 //
 // Copyright and related rights are licensed under the Solderpad Hardware
 // License, Version 0.51 (the "License"); you may not use this file except in
@@ -30,7 +30,7 @@ module axi_cdc #(
   parameter type axi_req_t  = logic, // encapsulates request channels
   parameter type axi_resp_t = logic, // encapsulates request channels
   /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
-  parameter int unsigned  LOG_DEPTH = 1
+  parameter int unsigned  LogDepth  = 1
 ) (
   // slave side - clocked by `src_clk_i`
   input  logic      src_clk_i,
@@ -47,7 +47,7 @@ module axi_cdc #(
     cdc_fifo_gray #(
         //  We need to cast to bits here because of some arbitrary bug in Synopsys.
         .WIDTH       ( $bits(aw_chan_t)    ),
-        .LOG_DEPTH   ( LOG_DEPTH           )
+        .LOG_DEPTH   ( LogDepth            )
     ) i_cdc_fifo_gray_aw (
         .src_rst_ni,
         .src_clk_i,
@@ -63,7 +63,7 @@ module axi_cdc #(
 
     cdc_fifo_gray #(
         .WIDTH       ( $bits(w_chan_t)    ),
-        .LOG_DEPTH   ( LOG_DEPTH          )
+        .LOG_DEPTH   ( LogDepth           )
     ) i_cdc_fifo_gray_w (
         .src_rst_ni,
         .src_clk_i,
@@ -79,7 +79,7 @@ module axi_cdc #(
 
     cdc_fifo_gray #(
         .WIDTH       ( $bits(b_chan_t)    ),
-        .LOG_DEPTH   ( LOG_DEPTH          )
+        .LOG_DEPTH   ( LogDepth           )
     ) i_cdc_fifo_gray_b (
         .src_rst_ni  ( dst_rst_ni         ),
         .src_clk_i   ( dst_clk_i          ),
@@ -95,7 +95,7 @@ module axi_cdc #(
 
     cdc_fifo_gray #(
         .WIDTH       ( $bits(ar_chan_t)    ),
-        .LOG_DEPTH   ( LOG_DEPTH           )
+        .LOG_DEPTH   ( LogDepth            )
     ) i_cdc_fifo_gray_ar (
         .src_rst_ni,
         .src_clk_i,
@@ -111,7 +111,7 @@ module axi_cdc #(
 
     cdc_fifo_gray #(
         .WIDTH       ( $bits(r_chan_t)    ),
-        .LOG_DEPTH   ( LOG_DEPTH          )
+        .LOG_DEPTH   ( LogDepth           )
     ) i_cdc_fifo_gray_r (
         .src_rst_ni  ( dst_rst_ni         ),
         .src_clk_i   ( dst_clk_i          ),
@@ -132,12 +132,12 @@ endmodule
 
 // interface wrapper
 module axi_cdc_wrap #(
-  parameter int unsigned AXI_ID_WIDTH   = 0,
-  parameter int unsigned AXI_ADDR_WIDTH = 0,
-  parameter int unsigned AXI_DATA_WIDTH = 0,
-  parameter int unsigned AXI_USER_WIDTH = 0,
+  parameter int unsigned AxiIdWidth   = 0,
+  parameter int unsigned AxiAddrWidth = 0,
+  parameter int unsigned AxiDataWidth = 0,
+  parameter int unsigned AxiUserWidth = 0,
   /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
-  parameter int unsigned LOG_DEPTH = 1
+  parameter int unsigned LogDepth = 1
 ) (
    // slave side - clocked by `src_clk_i`
   input  logic      src_clk_i,
@@ -149,11 +149,11 @@ module axi_cdc_wrap #(
   AXI_BUS.Master    dst
 );
 
-  typedef logic [AXI_ID_WIDTH-1:0]     id_t;
-  typedef logic [AXI_ADDR_WIDTH-1:0]   addr_t;
-  typedef logic [AXI_DATA_WIDTH-1:0]   data_t;
-  typedef logic [AXI_DATA_WIDTH/8-1:0] strb_t;
-  typedef logic [AXI_USER_WIDTH-1:0]   user_t;
+  typedef logic [AxiIdWidth-1:0]     id_t;
+  typedef logic [AxiAddrWidth-1:0]   addr_t;
+  typedef logic [AxiDataWidth-1:0]   data_t;
+  typedef logic [AxiDataWidth/8-1:0] strb_t;
+  typedef logic [AxiUserWidth-1:0]   user_t;
   `AXI_TYPEDEF_AW_CHAN_T ( aw_chan_t, addr_t, id_t,         user_t);
   `AXI_TYPEDEF_W_CHAN_T  (  w_chan_t, data_t,       strb_t, user_t);
   `AXI_TYPEDEF_B_CHAN_T  (  b_chan_t,         id_t,         user_t);
@@ -179,7 +179,7 @@ module axi_cdc_wrap #(
     .r_chan_t   ( r_chan_t  ),
     .axi_req_t  ( req_t     ),
     .axi_resp_t ( resp_t    ),
-    .LOG_DEPTH  ( LOG_DEPTH )
+    .LogDepth   ( LogDepth )
   ) i_axi_cdc (
     .src_clk_i,
     .src_rst_ni,
@@ -188,7 +188,7 @@ module axi_cdc_wrap #(
     .dst_clk_i,
     .dst_rst_ni,
     .dst_req_o  ( dst_req  ),
-    .dst_resp_i ( dst_resp ),
+    .dst_resp_i ( dst_resp )
   );
 
   endmodule

--- a/src/axi_cdc.sv
+++ b/src/axi_cdc.sv
@@ -131,13 +131,13 @@ endmodule
 `include "axi/typedef.svh"
 
 // interface wrapper
-module axi_cdc_wrap #(
-  parameter int unsigned AxiIdWidth   = 0,
-  parameter int unsigned AxiAddrWidth = 0,
-  parameter int unsigned AxiDataWidth = 0,
-  parameter int unsigned AxiUserWidth = 0,
+module axi_cdc_intf #(
+  parameter int unsigned AXI_ID_WIDTH   = 0,
+  parameter int unsigned AXI_ADDR_WIDTH = 0,
+  parameter int unsigned AXI_DATA_WIDTH = 0,
+  parameter int unsigned AXI_USER_WIDTH = 0,
   /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
-  parameter int unsigned LogDepth = 1
+  parameter int unsigned LOG_DEPTH = 1
 ) (
    // slave side - clocked by `src_clk_i`
   input  logic      src_clk_i,
@@ -149,11 +149,11 @@ module axi_cdc_wrap #(
   AXI_BUS.Master    dst
 );
 
-  typedef logic [AxiIdWidth-1:0]     id_t;
-  typedef logic [AxiAddrWidth-1:0]   addr_t;
-  typedef logic [AxiDataWidth-1:0]   data_t;
-  typedef logic [AxiDataWidth/8-1:0] strb_t;
-  typedef logic [AxiUserWidth-1:0]   user_t;
+  typedef logic [AXI_ID_WIDTH-1:0]     id_t;
+  typedef logic [AXI_ADDR_WIDTH-1:0]   addr_t;
+  typedef logic [AXI_DATA_WIDTH-1:0]   data_t;
+  typedef logic [AXI_DATA_WIDTH/8-1:0] strb_t;
+  typedef logic [AXI_USER_WIDTH-1:0]   user_t;
   `AXI_TYPEDEF_AW_CHAN_T ( aw_chan_t, addr_t, id_t,         user_t);
   `AXI_TYPEDEF_W_CHAN_T  (  w_chan_t, data_t,       strb_t, user_t);
   `AXI_TYPEDEF_B_CHAN_T  (  b_chan_t,         id_t,         user_t);
@@ -179,7 +179,7 @@ module axi_cdc_wrap #(
     .r_chan_t   ( r_chan_t  ),
     .axi_req_t  ( req_t     ),
     .axi_resp_t ( resp_t    ),
-    .LogDepth   ( LogDepth )
+    .LogDepth   ( LOG_DEPTH )
   ) i_axi_cdc (
     .src_clk_i,
     .src_rst_ni,

--- a/test/synth_bench.sv
+++ b/test/synth_bench.sv
@@ -61,6 +61,20 @@ module synth_bench (
     ) i_lite_xbar (.*);
   end
 
+  // Clock Domain Crossing
+  for (genvar i = 0; i < 6; i++) begin
+    localparam int AW = AXI_ADDR_WIDTH[i];
+    for (genvar j = 0; j < 3; j++) begin
+      localparam IUW = AXI_ID_USER_WIDTH[j];
+      synth_axi_cdc #(
+        .AXI_ADDR_WIDTH (AW),
+        .AXI_DATA_WIDTH (128),
+        .AXI_ID_WIDTH   (IUW),
+        .AXI_USER_WIDTH (IUW)
+      ) i_cdc (.*);
+    end
+  end
+
 endmodule
 
 
@@ -134,6 +148,47 @@ module synth_axi_atop_filter #(
     .rst_ni (rst_ni),
     .slv    (upstream),
     .mst    (downstream)
+  );
+
+endmodule
+
+module synth_axi_cdc #(
+  parameter int unsigned AXI_ADDR_WIDTH = 0,
+  parameter int unsigned AXI_DATA_WIDTH = 0,
+  parameter int unsigned AXI_ID_WIDTH = 0,
+  parameter int unsigned AXI_USER_WIDTH = 0
+) (
+  input logic clk_i,
+  input logic rst_ni
+);
+
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH (AXI_ADDR_WIDTH),
+    .AXI_DATA_WIDTH (AXI_DATA_WIDTH),
+    .AXI_ID_WIDTH   (AXI_ID_WIDTH),
+    .AXI_USER_WIDTH (AXI_USER_WIDTH)
+  ) upstream ();
+
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH (AXI_ADDR_WIDTH),
+    .AXI_DATA_WIDTH (AXI_DATA_WIDTH),
+    .AXI_ID_WIDTH   (AXI_ID_WIDTH),
+    .AXI_USER_WIDTH (AXI_USER_WIDTH)
+  ) downstream ();
+
+  axi_cdc_intf #(
+    .AXI_ID_WIDTH   (AXI_ID_WIDTH),
+    .AXI_ADDR_WIDTH (AXI_ADDR_WIDTH),
+    .AXI_DATA_WIDTH (AXI_DATA_WIDTH),
+    .AXI_USER_WIDTH (AXI_USER_WIDTH),
+    .LOG_DEPTH      (2)
+  ) dut (
+    .src_clk_i  (clk_i),
+    .src_rst_ni (rst_ni),
+    .src        (upstream),
+    .dst_clk_i  (clk_i),
+    .dst_rst_ni (rst_ni),
+    .dst        (downstream)
   );
 
 endmodule

--- a/test/tb_axi_cdc.sv
+++ b/test/tb_axi_cdc.sv
@@ -1,0 +1,307 @@
+// Copyright 2019-2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Testbench for axi_cdc
+
+`include "axi/assign.svh"
+import axi_pkg::*;
+
+module tb_axi_cdc #(
+  // AXI Parameters
+  parameter int unsigned AXI_AW = 32,
+  parameter int unsigned AXI_DW = 64,
+  parameter int unsigned AXI_IW = 4,
+  parameter int unsigned AXI_UW = 2,
+  parameter int unsigned AXI_MAX_READ_TXNS = 10,
+  parameter int unsigned AXI_MAX_WRITE_TXNS = 12,
+  // TB Parameters
+  parameter time TCLK_UPSTREAM = 10ns,
+  parameter time TA_UPSTREAM = TCLK_UPSTREAM * 1/4,
+  parameter time TT_UPSTREAM = TCLK_UPSTREAM * 3/4,
+  parameter time TCLK_DOWNSTREAM = 3ns,
+  parameter time TA_DOWNSTREAM = TCLK_DOWNSTREAM * 1/4,
+  parameter time TT_DOWNSTREAM = TCLK_DOWNSTREAM * 3/4,
+  parameter int unsigned REQ_MIN_WAIT_CYCLES = 0,
+  parameter int unsigned REQ_MAX_WAIT_CYCLES = 10,
+  parameter int unsigned RESP_MIN_WAIT_CYCLES = 0,
+  parameter int unsigned RESP_MAX_WAIT_CYCLES = REQ_MAX_WAIT_CYCLES/2,
+  parameter int unsigned N_TXNS = 1000
+);
+
+  timeunit 1ns;
+  timeprecision 10ps;
+
+  localparam int unsigned N_RD_TXNS = N_TXNS / 2;
+  localparam int unsigned N_WR_TXNS = N_TXNS / 2;
+
+  // Clocks and Resets
+
+  logic upstream_clk,
+        downstream_clk,
+        upstream_rst_n,
+        downstream_rst_n;
+
+  clk_rst_gen #(
+    .CLK_PERIOD     (TCLK_UPSTREAM),
+    .RST_CLK_CYCLES (5)
+  ) i_clk_rst_gen_upstream (
+    .clk_o  (upstream_clk),
+    .rst_no (upstream_rst_n)
+  );
+
+  clk_rst_gen #(
+    .CLK_PERIOD     (TCLK_DOWNSTREAM),
+    .RST_CLK_CYCLES (5)
+  ) i_clk_rst_gen_downstream (
+    .clk_o  (downstream_clk),
+    .rst_no (downstream_rst_n)
+  );
+
+  // AXI Interfaces
+
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH (AXI_AW),
+    .AXI_DATA_WIDTH (AXI_DW),
+    .AXI_ID_WIDTH   (AXI_IW),
+    .AXI_USER_WIDTH (AXI_UW)
+  ) upstream_dv (
+    .clk_i  (upstream_clk)
+  );
+
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH (AXI_AW),
+    .AXI_DATA_WIDTH (AXI_DW),
+    .AXI_ID_WIDTH   (AXI_IW),
+    .AXI_USER_WIDTH (AXI_UW)
+  ) upstream ();
+
+  `AXI_ASSIGN(upstream, upstream_dv);
+
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH (AXI_AW),
+    .AXI_DATA_WIDTH (AXI_DW),
+    .AXI_ID_WIDTH   (AXI_IW),
+    .AXI_USER_WIDTH (AXI_UW)
+  ) downstream_dv (
+    .clk_i  (downstream_clk)
+  );
+
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH (AXI_AW),
+    .AXI_DATA_WIDTH (AXI_DW),
+    .AXI_ID_WIDTH   (AXI_IW),
+    .AXI_USER_WIDTH (AXI_UW)
+  ) downstream ();
+
+  `AXI_ASSIGN(downstream_dv, downstream);
+
+  // AXI Channel Structs
+
+  typedef logic [AXI_AW-1:0]    addr_t;
+  typedef logic [AXI_DW-1:0]    data_t;
+  typedef logic [AXI_IW-1:0]    id_t;
+  typedef logic [AXI_DW/8-1:0]  strb_t;
+  typedef logic [AXI_UW-1:0]    user_t;
+  typedef struct packed {
+    id_t     id;
+    addr_t   addr;
+    len_t    len;
+    size_t   size;
+    burst_t  burst;
+    logic    lock;
+    cache_t  cache;
+    prot_t   prot;
+    qos_t    qos;
+    region_t region;
+    atop_t   atop;
+    user_t   user;
+  } aw_chan_t;
+  typedef struct packed {
+    data_t data;
+    strb_t strb;
+    user_t user;
+    logic  last;
+  } w_chan_t;
+  typedef struct packed {
+    id_t   id;
+    resp_t resp;
+    user_t user;
+  } b_chan_t;
+  typedef struct packed {
+    id_t     id;
+    addr_t   addr;
+    len_t    len;
+    size_t   size;
+    burst_t  burst;
+    logic    lock;
+    cache_t  cache;
+    prot_t   prot;
+    qos_t    qos;
+    region_t region;
+    user_t   user;
+  } ar_chan_t;
+  typedef struct packed {
+    id_t   id;
+    data_t data;
+    resp_t resp;
+    user_t user;
+    logic  last;
+  } r_chan_t;
+
+  axi_cdc_wrap #(
+    .AxiAddrWidth (AXI_AW),
+    .AxiDataWidth (AXI_DW),
+    .AxiIdWidth   (AXI_IW),
+    .AxiUserWidth (AXI_UW),
+    .LogDepth      (2)
+  ) dut (
+    .src_clk_i  (upstream_clk),
+    .src_rst_ni (upstream_rst_n),
+    .src        (upstream),
+    .dst_clk_i  (downstream_clk),
+    .dst_rst_ni (downstream_rst_n),
+    .dst        (downstream)
+  );
+
+  typedef axi_test::rand_axi_master #(
+    .AW                   (AXI_AW),
+    .DW                   (AXI_DW),
+    .IW                   (AXI_IW),
+    .UW                   (AXI_UW),
+    .TA                   (TA_UPSTREAM),
+    .TT                   (TT_UPSTREAM),
+    .MAX_READ_TXNS        (AXI_MAX_READ_TXNS),
+    .MAX_WRITE_TXNS       (AXI_MAX_WRITE_TXNS),
+    .AX_MIN_WAIT_CYCLES   (REQ_MIN_WAIT_CYCLES),
+    .AX_MAX_WAIT_CYCLES   (REQ_MAX_WAIT_CYCLES),
+    .W_MIN_WAIT_CYCLES    (REQ_MIN_WAIT_CYCLES),
+    .W_MAX_WAIT_CYCLES    (REQ_MAX_WAIT_CYCLES),
+    .RESP_MIN_WAIT_CYCLES (RESP_MIN_WAIT_CYCLES),
+    .RESP_MAX_WAIT_CYCLES (RESP_MAX_WAIT_CYCLES),
+    .AXI_MAX_BURST_LEN    (16)
+  ) axi_master_t;
+  axi_master_t axi_master = new(upstream_dv);
+
+  initial begin
+    wait (upstream_rst_n);
+    axi_master.run(N_RD_TXNS, N_WR_TXNS);
+  end
+
+  typedef axi_test::rand_axi_slave #(
+    .AW                   (AXI_AW),
+    .DW                   (AXI_DW),
+    .IW                   (AXI_IW),
+    .UW                   (AXI_UW),
+    .TA                   (TA_DOWNSTREAM),
+    .TT                   (TT_DOWNSTREAM),
+    .AX_MIN_WAIT_CYCLES   (RESP_MIN_WAIT_CYCLES),
+    .AX_MAX_WAIT_CYCLES   (RESP_MAX_WAIT_CYCLES),
+    .R_MIN_WAIT_CYCLES    (RESP_MIN_WAIT_CYCLES),
+    .R_MAX_WAIT_CYCLES    (RESP_MAX_WAIT_CYCLES),
+    .RESP_MIN_WAIT_CYCLES (RESP_MIN_WAIT_CYCLES),
+    .RESP_MAX_WAIT_CYCLES (RESP_MAX_WAIT_CYCLES)
+  ) axi_slave_t;
+  axi_slave_t axi_slave = new(downstream_dv);
+
+  initial begin
+    wait (downstream_rst_n);
+    axi_slave.run();
+  end
+
+  ar_chan_t   mst_ar, slv_ar, ar_queue[$];
+  aw_chan_t   mst_aw, slv_aw, aw_queue[$];
+  b_chan_t    mst_b,  slv_b,  b_queue[$];
+  r_chan_t    mst_r,  slv_r,  r_queue[$];
+  w_chan_t    mst_w,  slv_w,  w_queue[$];
+
+  `AXI_ASSIGN_TO_AR(mst_ar, upstream);
+  `AXI_ASSIGN_TO_AR(slv_ar, downstream);
+  `AXI_ASSIGN_TO_AW(mst_aw, upstream);
+  `AXI_ASSIGN_TO_AW(slv_aw, downstream);
+  `AXI_ASSIGN_TO_B(mst_b, upstream);
+  `AXI_ASSIGN_TO_B(slv_b, downstream);
+  `AXI_ASSIGN_TO_R(mst_r, upstream);
+  `AXI_ASSIGN_TO_R(slv_r, downstream);
+  `AXI_ASSIGN_TO_W(mst_w, upstream);
+  `AXI_ASSIGN_TO_W(slv_w, downstream);
+
+  logic mst_done = 1'b0;
+  // Monitor and check upstream
+  initial begin
+    automatic b_chan_t exp_b;
+    automatic r_chan_t exp_r;
+    automatic int unsigned rd_cnt = 0, wr_cnt = 0;
+    forever begin
+      @(posedge upstream_clk);
+      #(TT_UPSTREAM);
+      if (upstream.aw_valid && upstream.aw_ready) begin
+        aw_queue.push_back(mst_aw);
+      end
+      if (upstream.w_valid && upstream.w_ready) begin
+        w_queue.push_back(mst_w);
+      end
+      if (upstream.b_valid && upstream.b_ready) begin
+        exp_b = b_queue.pop_front();
+        assert (mst_b == exp_b);
+        wr_cnt++;
+      end
+      if (upstream.ar_valid && upstream.ar_ready) begin
+        ar_queue.push_back(mst_ar);
+      end
+      if (upstream.r_valid && upstream.r_ready) begin
+        exp_r = r_queue.pop_front();
+        assert (mst_r == exp_r);
+        if (upstream.r_last) begin
+          rd_cnt++;
+        end
+      end
+      if (rd_cnt == N_RD_TXNS && wr_cnt == N_WR_TXNS) begin
+        mst_done = 1'b1;
+      end
+    end
+  end
+
+  // Monitor and check downstream
+  initial begin
+    automatic ar_chan_t exp_ar;
+    automatic aw_chan_t exp_aw;
+    automatic w_chan_t  exp_w;
+    forever begin
+      @(posedge downstream_clk);
+      #(TT_DOWNSTREAM);
+      if (downstream.aw_valid && downstream.aw_ready) begin
+        exp_aw = aw_queue.pop_front();
+        assert (slv_aw == exp_aw);
+      end
+      if (downstream.w_valid && downstream.w_ready) begin
+        exp_w = w_queue.pop_front();
+        assert (slv_w == exp_w);
+      end
+      if (downstream.b_valid && downstream.b_ready) begin
+        b_queue.push_back(slv_b);
+      end
+      if (downstream.ar_valid && downstream.ar_ready) begin
+        exp_ar = ar_queue.pop_front();
+        assert (slv_ar == exp_ar);
+      end
+      if (downstream.r_valid && downstream.r_ready) begin
+        r_queue.push_back(slv_r);
+      end
+    end
+  end
+
+  // Terminate simulation after all transactions have completed.
+  initial begin
+   wait (mst_done);
+   #(10*TCLK_UPSTREAM);
+   $finish();
+  end
+
+endmodule

--- a/test/tb_axi_cdc.sv
+++ b/test/tb_axi_cdc.sv
@@ -155,12 +155,12 @@ module tb_axi_cdc #(
     logic  last;
   } r_chan_t;
 
-  axi_cdc_wrap #(
-    .AxiAddrWidth (AXI_AW),
-    .AxiDataWidth (AXI_DW),
-    .AxiIdWidth   (AXI_IW),
-    .AxiUserWidth (AXI_UW),
-    .LogDepth      (2)
+  axi_cdc_intf #(
+    .AXI_ADDR_WIDTH (AXI_AW),
+    .AXI_DATA_WIDTH (AXI_DW),
+    .AXI_ID_WIDTH   (AXI_IW),
+    .AXI_USER_WIDTH (AXI_UW),
+    .LOG_DEPTH      (2)
   ) dut (
     .src_clk_i  (upstream_clk),
     .src_rst_ni (upstream_rst_n),


### PR DESCRIPTION
This adds AXI CDCs which are based on the safer FIFO Gray design from our `common_cells` library.

Todo:
- [x] Rebase on xbar implementation
- [x] Run testbench
- [x] Add changelog entry
- [x] Add interface wrapper