### PR TITLE
axi_test: Add constrained randomizing master and slave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- `axi_test`: Constrained randomizing AXI master (`rand_axi_master`) and slave (`rand_axi_slave`).
+  - `rand_axi_master` issues a configurable number of read and write transactions to configurable
+    memory regions (address ranges with associated memory types) and with random properties within
+    constraints (e.g., burst length, exclusive accesses, atomic operations).
+  - `rand_axi_slave` responds to transactions with random delays and data.
+- `axi_pkg`: AXI memory types (`mem_type_t`) and functions `get_arcache` and `get_awcache` to
+  calculate `AxCACHE` bits for a given memory type.
+
+### Changed
+- `axi_test`: The `reset` tasks in `axi_driver` and `axi_lite_driver` are now functions.
+
 
 ## 0.8.2 - 2019-12-20
 

--- a/src/axi_pkg.sv
+++ b/src/axi_pkg.sv
@@ -82,6 +82,56 @@ package axi_pkg;
     end
   endfunction
 
+  // MEMORY TYPE
+  typedef enum logic [3:0] {
+    DEVICE_NONBUFFERABLE,
+    DEVICE_BUFFERABLE,
+    NORMAL_NONCACHEABLE_NONBUFFERABLE,
+    NORMAL_NONCACHEABLE_BUFFERABLE,
+    WTHRU_NOALLOCATE,
+    WTHRU_RALLOCATE,
+    WTHRU_WALLOCATE,
+    WTHRU_RWALLOCATE,
+    WBACK_NOALLOCATE,
+    WBACK_RALLOCATE,
+    WBACK_WALLOCATE,
+    WBACK_RWALLOCATE
+  } mem_type_t;
+
+  function automatic logic [3:0] get_arcache(mem_type_t mtype);
+    unique case (mtype)
+      DEVICE_NONBUFFERABLE              : return 4'b0000;
+      DEVICE_BUFFERABLE                 : return 4'b0001;
+      NORMAL_NONCACHEABLE_NONBUFFERABLE : return 4'b0010;
+      NORMAL_NONCACHEABLE_BUFFERABLE    : return 4'b0011;
+      WTHRU_NOALLOCATE                  : return 4'b1010;
+      WTHRU_RALLOCATE                   : return 4'b1110;
+      WTHRU_WALLOCATE                   : return 4'b1010;
+      WTHRU_RWALLOCATE                  : return 4'b1110;
+      WBACK_NOALLOCATE                  : return 4'b1011;
+      WBACK_RALLOCATE                   : return 4'b1111;
+      WBACK_WALLOCATE                   : return 4'b1011;
+      WBACK_RWALLOCATE                  : return 4'b1111;
+    endcase // mtype
+  endfunction
+
+  function automatic logic [3:0] get_awcache(mem_type_t mtype);
+    unique case (mtype)
+      DEVICE_NONBUFFERABLE              : return 4'b0000;
+      DEVICE_BUFFERABLE                 : return 4'b0001;
+      NORMAL_NONCACHEABLE_NONBUFFERABLE : return 4'b0010;
+      NORMAL_NONCACHEABLE_BUFFERABLE    : return 4'b0011;
+      WTHRU_NOALLOCATE                  : return 4'b0110;
+      WTHRU_RALLOCATE                   : return 4'b0110;
+      WTHRU_WALLOCATE                   : return 4'b1110;
+      WTHRU_RWALLOCATE                  : return 4'b1110;
+      WBACK_NOALLOCATE                  : return 4'b0111;
+      WBACK_RALLOCATE                   : return 4'b0111;
+      WBACK_WALLOCATE                   : return 4'b1111;
+      WBACK_RWALLOCATE                  : return 4'b1111;
+    endcase // mtype
+  endfunction
+
   // ATOP[5:0]
   localparam ATOP_ATOMICSWAP  = 6'b110000;
   localparam ATOP_ATOMICCMP   = 6'b110001;

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -297,7 +297,7 @@ package axi_test;
       this.axi = axi;
     endfunction
 
-    task reset_master;
+    function void reset_master();
       axi.aw_id     <= '0;
       axi.aw_addr   <= '0;
       axi.aw_len    <= '0;
@@ -330,9 +330,9 @@ package axi_test;
       axi.ar_user   <= '0;
       axi.ar_valid  <= '0;
       axi.r_ready   <= '0;
-    endtask
+    endfunction
 
-    task reset_slave;
+    function void reset_slave();
       axi.aw_ready  <= '0;
       axi.w_ready   <= '0;
       axi.b_id      <= '0;
@@ -346,7 +346,7 @@ package axi_test;
       axi.r_last    <= '0;
       axi.r_user    <= '0;
       axi.r_valid   <= '0;
-    endtask
+    endfunction
 
     task cycle_start;
       #TT;

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -711,11 +711,22 @@ package axi_test;
       automatic mem_region_t mem_region;
       automatic int cprob;
 
-      // Randomly pick a memory region
-      rand_success = std::randomize(mem_region_idx) with {
-        mem_region_idx < mem_map.size();
-      }; assert(rand_success);
-      mem_region = mem_map[mem_region_idx];
+      // No memory regions defined
+      if (mem_map.size() == 0) begin
+        // Return a dummy region
+        mem_region = '{
+          addr_begin: '0,
+          addr_end:   '1,
+          mem_type:   axi_pkg::NORMAL_NONCACHEABLE_BUFFERABLE
+        };
+      end else begin
+        // Randomly pick a memory region
+        rand_success = std::randomize(mem_region_idx) with {
+          mem_region_idx < mem_map.size();
+        }; assert(rand_success);
+        mem_region = mem_map[mem_region_idx];
+      end
+
       // Randomly pick FIXED or INCR burst.  WRAP is currently not supported.
       rand_success = std::randomize(burst) with {
         burst <= axi_pkg::BURST_INCR;

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -718,15 +718,17 @@ package axi_test;
             addr >= addr_begin;
             addr <= addr_end;
           }; assert(rand_success);
-          if (((addr + 2**ax_beat.ax_size) & PFN_MASK) == (addr & PFN_MASK))
+          if (((addr + 2**ax_beat.ax_size) & PFN_MASK) == (addr & PFN_MASK)) begin
             break;
+          end
         end
         ax_beat.ax_addr = addr;
       end else begin // BURST_INCR
         forever begin
           rand_success = std::randomize(addr); assert(rand_success);
-          if (((addr + 2**ax_beat.ax_size * (ax_beat.ax_len + 1)) & PFN_MASK) == (addr & PFN_MASK))
+          if (((addr + 2**ax_beat.ax_size * (ax_beat.ax_len + 1)) & PFN_MASK) == (addr & PFN_MASK)) begin
             break;
+          end
         end
         ax_beat.ax_addr = addr;
       end

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -602,6 +602,18 @@ package axi_test;
     parameter int   AXI_MAX_BURST_LEN = 0,
     parameter bit   AXI_EXCLS = 1'b0,
     parameter bit   AXI_ATOPS = 1'b0,
+    parameter logic [3:0] AXI_MEMORY_TYPES [] = { // all legal memory types enabled by default
+      '0,
+                                                                                      axi_pkg::CACHE_BUFFERABLE,
+                                                          axi_pkg::CACHE_MODIFIABLE,
+                                                          axi_pkg::CACHE_MODIFIABLE | axi_pkg::CACHE_BUFFERABLE,
+                                axi_pkg::CACHE_RD_ALLOC | axi_pkg::CACHE_MODIFIABLE,
+                                axi_pkg::CACHE_RD_ALLOC | axi_pkg::CACHE_MODIFIABLE | axi_pkg::CACHE_BUFFERABLE,
+      axi_pkg::CACHE_WR_ALLOC |                           axi_pkg::CACHE_MODIFIABLE,
+      axi_pkg::CACHE_WR_ALLOC |                           axi_pkg::CACHE_MODIFIABLE | axi_pkg::CACHE_BUFFERABLE,
+      axi_pkg::CACHE_WR_ALLOC | axi_pkg::CACHE_RD_ALLOC | axi_pkg::CACHE_MODIFIABLE,
+      axi_pkg::CACHE_WR_ALLOC | axi_pkg::CACHE_RD_ALLOC | axi_pkg::CACHE_MODIFIABLE | axi_pkg::CACHE_BUFFERABLE
+    },
     // Dependent parameters, do not override.
     parameter int   AXI_STRB_WIDTH = DW/8,
     parameter int   N_AXI_IDS = 2**IW
@@ -611,6 +623,7 @@ package axi_test;
     ) axi_driver_t;
     typedef logic [AW-1:0]    addr_t;
     typedef axi_pkg::burst_t  burst_t;
+    typedef axi_pkg::cache_t  cache_t;
     typedef logic [DW-1:0]    data_t;
     typedef logic [IW-1:0]    id_t;
     typedef axi_pkg::size_t   size_t;
@@ -666,6 +679,7 @@ package axi_test;
       automatic ax_beat_t ax_beat = new;
       automatic addr_t addr;
       automatic burst_t burst;
+      automatic cache_t cache;
       automatic id_t id;
       automatic size_t size;
       // Randomly pick FIXED or INCR burst.  WRAP is currently not supported.
@@ -675,6 +689,11 @@ package axi_test;
       ax_beat.ax_burst = burst;
       // Randomize burst length.
       ax_beat.ax_len = $random();
+      // Randomize memory type.
+      rand_success = std::randomize(cache) with {
+        cache inside {AXI_MEMORY_TYPES};
+      };
+      ax_beat.ax_cache = cache;
       // Randomize beat size.
       rand_success = std::randomize(size) with {
         2**size <= AXI_STRB_WIDTH;

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -212,9 +212,9 @@ package axi_test;
 
   /// The data transferred on a beat on the AW/AR channels.
   class axi_ax_beat #(
-    parameter AW,
-    parameter IW,
-    parameter UW
+    parameter AW = 32,
+    parameter IW = 8 ,
+    parameter UW = 1
   );
     rand logic [IW-1:0] ax_id     = '0;
     rand logic [AW-1:0] ax_addr   = '0;
@@ -232,8 +232,8 @@ package axi_test;
 
   /// The data transferred on a beat on the W channel.
   class axi_w_beat #(
-    parameter DW,
-    parameter UW
+    parameter DW = 32,
+    parameter UW = 1
   );
     rand logic [DW-1:0]   w_data = '0;
     rand logic [DW/8-1:0] w_strb = '0;
@@ -243,8 +243,8 @@ package axi_test;
 
   /// The data transferred on a beat on the B channel.
   class axi_b_beat #(
-    parameter IW,
-    parameter UW
+    parameter IW = 8,
+    parameter UW = 1
   );
     rand logic [IW-1:0] b_id   = '0;
     axi_pkg::resp_t     b_resp = '0;
@@ -253,9 +253,9 @@ package axi_test;
 
   /// The data transferred on a beat on the R channel.
   class axi_r_beat #(
-    parameter DW,
-    parameter IW,
-    parameter UW
+    parameter DW = 32,
+    parameter IW = 8 ,
+    parameter UW = 1
   );
     rand logic [IW-1:0] r_id   = '0;
     rand logic [DW-1:0] r_data = '0;
@@ -267,10 +267,10 @@ package axi_test;
 
   /// A driver for AXI4 interface.
   class axi_driver #(
-    parameter int  AW       ,
-    parameter int  DW       ,
-    parameter int  IW       ,
-    parameter int  UW       ,
+    parameter int  AW = 32  ,
+    parameter int  DW = 32  ,
+    parameter int  IW = 8   ,
+    parameter int  UW = 1   ,
     parameter time TA = 0ns , // stimuli application time
     parameter time TT = 0ns   // stimuli test time
   );
@@ -581,16 +581,16 @@ package axi_test;
 
   class rand_axi_master #(
     // AXI interface parameters
-    parameter int   AW,
-    parameter int   DW,
-    parameter int   IW,
-    parameter int   UW,
+    parameter int   AW = 32,
+    parameter int   DW = 32,
+    parameter int   IW = 8,
+    parameter int   UW = 1,
     // Stimuli application and test time
-    parameter time  TA,
-    parameter time  TT,
+    parameter time  TA = 0ps,
+    parameter time  TT = 0ps,
     // Maximum number of read and write transactions in flight
-    parameter int   MAX_READ_TXNS,
-    parameter int   MAX_WRITE_TXNS,
+    parameter int   MAX_READ_TXNS = 1,
+    parameter int   MAX_WRITE_TXNS = 1,
     // Upper and lower bounds on wait cycles on Ax, W, and resp (R and B) channels
     parameter int   AX_MIN_WAIT_CYCLES = 0,
     parameter int   AX_MAX_WAIT_CYCLES = 100,
@@ -1104,13 +1104,13 @@ package axi_test;
 
   class rand_axi_slave #(
     // AXI interface parameters
-    parameter int   AW,
-    parameter int   DW,
-    parameter int   IW,
-    parameter int   UW,
+    parameter int   AW = 32,
+    parameter int   DW = 32,
+    parameter int   IW = 8,
+    parameter int   UW = 1,
     // Stimuli application and test time
-    parameter time  TA,
-    parameter time  TT,
+    parameter time  TA = 0ps,
+    parameter time  TT = 0ps,
     // Upper and lower bounds on wait cycles on Ax, W, and resp (R and B) channels
     parameter int   AX_MIN_WAIT_CYCLES = 0,
     parameter int   AX_MAX_WAIT_CYCLES = 100,

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -1087,6 +1087,7 @@ package axi_test;
       this.drv = new(axi);
       this.ar_queue = new;
       this.b_queue = new;
+      this.reset();
     endfunction
 
     function void reset();

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -1094,8 +1094,8 @@ package axi_test;
 
     // Issue n_reads random read and n_writes random write transactions to an address range.
     task run(input int n_reads, input int n_writes);
-      static logic  ar_done = 1'b0,
-                    aw_done = 1'b0;
+      automatic logic  ar_done = 1'b0,
+                       aw_done = 1'b0;
       fork
         begin
           send_ars(n_reads);

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -784,10 +784,10 @@ package axi_test;
         // Determine `ax_addr`.
         if (beat.ax_atop == axi_pkg::ATOP_ATOMICCMP) begin
           // The address must be aligned to half the outbound data size. [E2-337]
-          beat.ax_addr = beat.ax_addr & ~(1<<beat.ax_size - 1);
+          beat.ax_addr = beat.ax_addr & ~((1'b1 << beat.ax_size) - 1);
         end else begin
           // The address must be aligned to the data size. [E2-337]
-          beat.ax_addr = beat.ax_addr & ~(1<<(beat.ax_size+1) - 1);
+          beat.ax_addr = beat.ax_addr & ~((1'b1 << (beat.ax_size+1)) - 1);
         end
         // Determine `ax_burst`.
         if (beat.ax_atop == axi_pkg::ATOP_ATOMICCMP) begin
@@ -984,15 +984,15 @@ package axi_test;
         addr = aw_beat.ax_addr;
         for (int unsigned i = 0; i < aw_beat.ax_len + 1; i++) begin
           automatic w_beat_t w_beat = new;
-          int unsigned begin_byte, n_bytes;
-          logic [AXI_STRB_WIDTH-1:0] rand_strb, strb_mask;
+          automatic int unsigned begin_byte, n_bytes;
+          automatic logic [AXI_STRB_WIDTH-1:0] rand_strb, strb_mask;
           rand_success = std::randomize(w_beat); assert (rand_success);
           // Determine strobe.
           w_beat.w_strb = '0;
           n_bytes = 2**aw_beat.ax_size;
           begin_byte = addr % AXI_STRB_WIDTH;
           strb_mask = ((1'b1 << n_bytes) - 1) << begin_byte;
-          rand_strb = $random();
+          rand_success = std::randomize(rand_strb); assert (rand_success);
           w_beat.w_strb |= (rand_strb & strb_mask);
           // Determine last.
           w_beat.w_last = (i == aw_beat.ax_len);

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -961,11 +961,12 @@ package axi_test;
     task send_ws(ref logic aw_done);
       while (!(aw_done && aw_queue.size() == 0)) begin
         automatic ax_beat_t aw_beat;
-        automatic addr_t addr;
+        automatic addr_t addr, aligned_addr;
         static logic rand_success;
         wait (aw_queue.size() > 0);
         aw_beat = aw_queue.pop_front();
-        addr = aw_beat.ax_addr;
+        aligned_addr = (aw_beat.ax_addr >> aw_beat.ax_size) << aw_beat.ax_size;
+        addr = aligned_addr;
         for (int unsigned i = 0; i < aw_beat.ax_len + 1; i++) begin
           automatic w_beat_t w_beat = new;
           int unsigned begin_byte, n_bytes;
@@ -973,8 +974,13 @@ package axi_test;
           rand_success = std::randomize(w_beat); assert (rand_success);
           // Determine strobe.
           w_beat.w_strb = '0;
-          n_bytes = 2**aw_beat.ax_size;
-          begin_byte = addr % AXI_STRB_WIDTH;
+          if (i == 0) begin // first beat
+            n_bytes = 2**aw_beat.ax_size - (aw_beat.ax_addr - aligned_addr);
+            begin_byte = aw_beat.ax_addr % AXI_STRB_WIDTH;
+          end else begin // all following beats
+            n_bytes = 2**aw_beat.ax_size;
+            begin_byte = addr % AXI_STRB_WIDTH;
+          end
           strb_mask = ((1'b1 << n_bytes) - 1) << begin_byte;
           rand_strb = $random();
           w_beat.w_strb |= (rand_strb & strb_mask);
@@ -983,7 +989,7 @@ package axi_test;
           rand_wait(W_MIN_WAIT_CYCLES, W_MAX_WAIT_CYCLES);
           drv.send_w(w_beat);
           if (aw_beat.ax_burst == axi_pkg::BURST_INCR)
-            addr += n_bytes;
+            addr += 2**aw_beat.ax_size;
         end
       end
     endtask

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -579,4 +579,157 @@ package axi_test;
 
   endclass
 
+  class rand_axi_slave #(
+    // AXI interface parameters
+    parameter int   AW,
+    parameter int   DW,
+    parameter int   IW,
+    parameter int   UW,
+    // Stimuli application and test time
+    parameter time  TA,
+    parameter time  TT,
+    // Upper and lower bounds on wait cycles on Ax, W, and resp (R and B) channels
+    parameter int   AX_MIN_WAIT_CYCLES = 0,
+    parameter int   AX_MAX_WAIT_CYCLES = 100,
+    parameter int   R_MIN_WAIT_CYCLES = 0,
+    parameter int   R_MAX_WAIT_CYCLES = 5,
+    parameter int   RESP_MIN_WAIT_CYCLES = 0,
+    parameter int   RESP_MAX_WAIT_CYCLES = 20
+  );
+    typedef axi_test::axi_driver #(
+      .AW(AW), .DW(DW), .IW(IW), .UW(UW), .TA(TA), .TT(TT)
+    ) axi_driver_t;
+    typedef rand_id_queue_pkg::rand_id_queue #(
+      .data_t   (axi_driver_t::ax_beat_t),
+      .ID_WIDTH (IW)
+    ) rand_ax_beat_queue_t;
+    typedef axi_driver_t::ax_beat_t ax_beat_t;
+    typedef axi_driver_t::b_beat_t b_beat_t;
+    typedef axi_driver_t::r_beat_t r_beat_t;
+    typedef axi_driver_t::w_beat_t w_beat_t;
+
+    axi_driver_t          drv;
+    rand_ax_beat_queue_t  ar_queue,
+                          b_queue;
+    ax_beat_t             aw_queue[$];
+
+    function new(
+      virtual AXI_BUS_DV #(
+        .AXI_ADDR_WIDTH(AW),
+        .AXI_DATA_WIDTH(DW),
+        .AXI_ID_WIDTH(IW),
+        .AXI_USER_WIDTH(UW)
+      ) axi
+    );
+      this.drv = new(axi);
+      this.ar_queue = new;
+      this.b_queue = new;
+    endfunction
+
+    function void reset();
+      drv.reset_slave();
+    endfunction
+
+    // TODO: The `rand_wait` task exists in `rand_verif_pkg`, but that task cannot be called with
+    // `this.drv.axi.clk_i` as `clk` argument.  What is the syntax getting an assignable reference?
+    task automatic rand_wait(input int unsigned min, max);
+      int unsigned rand_success, cycles;
+      rand_success = std::randomize(cycles) with {
+        cycles >= min;
+        cycles <= max;
+      };
+      assert (rand_success) else $error("Failed to randomize wait cycles!");
+      repeat (cycles) @(posedge this.drv.axi.clk_i);
+    endtask
+
+    task recv_ars();
+      forever begin
+        automatic ax_beat_t ar_beat;
+        rand_wait(AX_MIN_WAIT_CYCLES, AX_MAX_WAIT_CYCLES);
+        drv.recv_ar(ar_beat);
+        ar_queue.push(ar_beat.ax_id, ar_beat);
+      end
+    endtask
+
+    task send_rs();
+      forever begin
+        automatic logic rand_success;
+        automatic ax_beat_t ar_beat;
+        automatic r_beat_t r_beat = new;
+        wait (!ar_queue.empty());
+        ar_beat = ar_queue.peek();
+        rand_success = std::randomize(r_beat); assert(rand_success);
+        r_beat.r_id = ar_beat.ax_id;
+        if (ar_beat.ax_lock)
+          r_beat.r_resp[0]= $random();
+        rand_wait(R_MIN_WAIT_CYCLES, R_MAX_WAIT_CYCLES);
+        if (ar_beat.ax_len == '0) begin
+          r_beat.r_last = 1'b1;
+          void'(ar_queue.pop_id(ar_beat.ax_id));
+        end else begin
+          ar_beat.ax_len--;
+          ar_queue.set(ar_beat.ax_id, ar_beat);
+        end
+        drv.send_r(r_beat);
+      end
+    endtask
+
+    task recv_aws();
+      forever begin
+        automatic ax_beat_t aw_beat;
+        rand_wait(AX_MIN_WAIT_CYCLES, AX_MAX_WAIT_CYCLES);
+        drv.recv_aw(aw_beat);
+        aw_queue.push_back(aw_beat);
+        // Atomic{Load,Swap,Compare}s require an R response.
+        if (aw_beat.ax_atop[5]) begin
+          ar_queue.push(aw_beat.ax_id, aw_beat);
+        end
+      end
+    endtask
+
+    task recv_ws();
+      forever begin
+        automatic ax_beat_t aw_beat;
+        forever begin
+          automatic w_beat_t w_beat;
+          rand_wait(RESP_MIN_WAIT_CYCLES, RESP_MAX_WAIT_CYCLES);
+          drv.recv_w(w_beat);
+          if (w_beat.w_last)
+            break;
+        end
+        wait (aw_queue.size() > 0);
+        aw_beat = aw_queue.pop_front();
+        b_queue.push(aw_beat.ax_id, aw_beat);
+      end
+    endtask
+
+    task send_bs();
+      forever begin
+        automatic ax_beat_t aw_beat;
+        automatic b_beat_t b_beat = new;
+        automatic logic rand_success;
+        wait (!b_queue.empty());
+        aw_beat = b_queue.pop();
+        rand_success = std::randomize(b_beat); assert(rand_success);
+        b_beat.b_id = aw_beat.ax_id;
+        if (aw_beat.ax_lock) begin
+          b_beat.b_resp[0]= $random();
+        end
+        rand_wait(RESP_MIN_WAIT_CYCLES, RESP_MAX_WAIT_CYCLES);
+        drv.send_b(b_beat);
+      end
+    endtask
+
+    task run();
+      fork
+        recv_ars();
+        send_rs();
+        recv_aws();
+        recv_ws();
+        send_bs();
+      join
+    endtask
+
+  endclass
+
 endpackage

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -41,7 +41,7 @@ package axi_test;
       this.axi = axi;
     endfunction
 
-    task reset_master;
+    function void reset_master();
       axi.aw_addr  <= '0;
       axi.aw_valid <= '0;
       axi.w_valid  <= '0;
@@ -51,9 +51,9 @@ package axi_test;
       axi.ar_valid <= '0;
       axi.ar_addr  <= '0;
       axi.r_ready  <= '0;
-    endtask
+    endfunction
 
-    task reset_slave;
+    function void reset_slave();
       axi.aw_ready <= '0;
       axi.w_ready  <= '0;
       axi.b_resp   <= '0;
@@ -62,7 +62,7 @@ package axi_test;
       axi.r_data   <= '0;
       axi.r_resp   <= '0;
       axi.r_valid  <= '0;
-    endtask
+    endfunction
 
     task cycle_start;
       #TT;

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -712,26 +712,22 @@ package axi_test;
       }; assert(rand_success);
       ax_beat.ax_size = size;
       // Randomize address.  Make sure that the burst does not cross a 4KiB boundary.
-      if (ax_beat.ax_burst == axi_pkg::BURST_FIXED) begin
-        forever begin
-          rand_success = std::randomize(addr) with {
-            addr >= addr_begin;
-            addr <= addr_end;
-          }; assert(rand_success);
+      forever begin
+        rand_success = std::randomize(addr) with {
+          addr >= addr_begin;
+          addr <= addr_end;
+        }; assert(rand_success);
+        if (ax_beat.ax_burst == axi_pkg::BURST_FIXED) begin
           if (((addr + 2**ax_beat.ax_size) & PFN_MASK) == (addr & PFN_MASK)) begin
             break;
           end
-        end
-        ax_beat.ax_addr = addr;
-      end else begin // BURST_INCR
-        forever begin
-          rand_success = std::randomize(addr); assert(rand_success);
+        end else begin // BURST_INCR
           if (((addr + 2**ax_beat.ax_size * (ax_beat.ax_len + 1)) & PFN_MASK) == (addr & PFN_MASK)) begin
             break;
           end
         end
-        ax_beat.ax_addr = addr;
       end
+      ax_beat.ax_addr = addr;
       rand_success = std::randomize(id); assert(rand_success);
       ax_beat.ax_id = id;
       return ax_beat;

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -971,12 +971,11 @@ package axi_test;
     task send_ws(ref logic aw_done);
       while (!(aw_done && aw_queue.size() == 0)) begin
         automatic ax_beat_t aw_beat;
-        automatic addr_t addr, aligned_addr;
+        automatic addr_t addr;
         static logic rand_success;
         wait (aw_queue.size() > 0);
         aw_beat = aw_queue.pop_front();
-        aligned_addr = (aw_beat.ax_addr >> aw_beat.ax_size) << aw_beat.ax_size;
-        addr = aligned_addr;
+        addr = aw_beat.ax_addr;
         for (int unsigned i = 0; i < aw_beat.ax_len + 1; i++) begin
           automatic w_beat_t w_beat = new;
           int unsigned begin_byte, n_bytes;
@@ -984,13 +983,8 @@ package axi_test;
           rand_success = std::randomize(w_beat); assert (rand_success);
           // Determine strobe.
           w_beat.w_strb = '0;
-          if (i == 0) begin // first beat
-            n_bytes = 2**aw_beat.ax_size - (aw_beat.ax_addr - aligned_addr);
-            begin_byte = aw_beat.ax_addr % AXI_STRB_WIDTH;
-          end else begin // all following beats
-            n_bytes = 2**aw_beat.ax_size;
-            begin_byte = addr % AXI_STRB_WIDTH;
-          end
+          n_bytes = 2**aw_beat.ax_size;
+          begin_byte = addr % AXI_STRB_WIDTH;
           strb_mask = ((1'b1 << n_bytes) - 1) << begin_byte;
           rand_strb = $random();
           w_beat.w_strb |= (rand_strb & strb_mask);
@@ -999,7 +993,7 @@ package axi_test;
           rand_wait(W_MIN_WAIT_CYCLES, W_MAX_WAIT_CYCLES);
           drv.send_w(w_beat);
           if (aw_beat.ax_burst == axi_pkg::BURST_INCR)
-            addr += 2**aw_beat.ax_size;
+            addr += n_bytes;
         end
       end
     endtask

--- a/test/tb_axi_atop_filter.sv
+++ b/test/tb_axi_atop_filter.sv
@@ -42,7 +42,7 @@ module tb_axi_atop_filter #(
   parameter int unsigned REQ_MAX_WAIT_CYCLES = 10,
   parameter int unsigned RESP_MIN_WAIT_CYCLES = 0,
   parameter int unsigned RESP_MAX_WAIT_CYCLES = REQ_MAX_WAIT_CYCLES/2,
-  parameter int unsigned N_TXNS = 10000
+  parameter int unsigned N_TXNS = 1000
 );
 
   timeunit 1ns;

--- a/test/tb_axi_atop_filter.sv
+++ b/test/tb_axi_atop_filter.sv
@@ -111,271 +111,27 @@ module tb_axi_atop_filter #(
     .mst    (downstream)
   );
 
-  typedef axi_test::axi_driver #(
-    .AW (AXI_ADDR_WIDTH),
-    .DW (AXI_DATA_WIDTH),
-    .IW (AXI_ID_WIDTH),
-    .UW (AXI_USER_WIDTH),
-    .TA (TA),
-    .TT (TT)
-  ) axi_driver_t;
-
-  typedef rand_id_queue #(
-    .data_t   (axi_driver_t::ax_beat_t),
-    .ID_WIDTH (AXI_ID_WIDTH)
-  ) rand_ax_beat_queue;
-
-  typedef logic [AXI_ADDR_WIDTH-1:0]  axi_addr_t;
-  typedef logic [AXI_ID_WIDTH-1:0]    axi_id_t;
-
-  localparam axi_addr_t PFN_MASK = '{11: 1'b0, 10: 1'b0, 9: 1'b0, 8: 1'b0, 7: 1'b0, 6: 1'b0,
-      5: 1'b0, 4: 1'b0, 3: 1'b0, 2: 1'b0, 1: 1'b0, 0: 1'b0, default: '1};
-
-  task rand_req_wait();
-    rand_wait(REQ_MIN_WAIT_CYCLES, REQ_MAX_WAIT_CYCLES, clk);
-  endtask
-
-  task rand_resp_wait();
-    rand_wait(RESP_MIN_WAIT_CYCLES, RESP_MAX_WAIT_CYCLES, clk);
-  endtask
-
-  function axi_driver_t::ax_beat_t new_rand_burst();
-    automatic int unsigned rand_success = 0;
-    automatic axi_driver_t::ax_beat_t ax_beat = new;
-    automatic axi_addr_t addr;
-    automatic axi_pkg::burst_t burst;
-    automatic axi_pkg::size_t size;
-    // Randomly pick FIXED or INCR burst.  WRAP is currently not supported.
-    rand_success = std::randomize(burst) with {
-      burst <= axi_pkg::BURST_INCR;
-    }; assert(rand_success);
-    ax_beat.ax_burst = burst;
-    // Randomize burst length.
-    ax_beat.ax_len = $random();
-    // Randomize beat size.
-    rand_success = std::randomize(size) with {
-      2**size <= AXI_STRB_WIDTH;
-    }; assert(rand_success);
-    ax_beat.ax_size = size;
-    // Randomize address.  Make sure that the burst does not cross a 4KiB boundary.
-    if (ax_beat.ax_burst == BURST_FIXED) begin
-      forever begin
-        rand_success = std::randomize(addr); assert(rand_success);
-        if (((addr + 2**ax_beat.ax_size) & PFN_MASK) == (addr & PFN_MASK))
-          break;
-      end
-      ax_beat.ax_addr = addr;
-    end else begin // BURST_INCR
-      forever begin
-        rand_success = std::randomize(addr); assert(rand_success);
-        if (((addr + 2**ax_beat.ax_size * (ax_beat.ax_len + 1)) & PFN_MASK) == (addr & PFN_MASK))
-          break;
-      end
-      ax_beat.ax_addr = addr;
-    end
-    return ax_beat;
-  endfunction
+  typedef logic [AXI_ID_WIDTH-1:0]  axi_id_t;
 
   // AXI Master
   logic mst_done = 1'b0;
-  axi_driver_t axi_master = new(upstream_dv);
-  // TODO: Is it possible to move such a master driver as class to `axi_test`?
+  axi_test::rand_axi_master #(
+    .AW(AXI_ADDR_WIDTH), .DW(AXI_DATA_WIDTH), .IW(AXI_ID_WIDTH), .UW(AXI_USER_WIDTH),
+    .TA(TA), .TT(TT),
+    .MAX_READ_TXNS        (AXI_MAX_READ_TXNS),
+    .MAX_WRITE_TXNS       (AXI_MAX_WRITE_TXNS),
+    .AX_MIN_WAIT_CYCLES   (REQ_MIN_WAIT_CYCLES),
+    .AX_MAX_WAIT_CYCLES   (REQ_MAX_WAIT_CYCLES),
+    .W_MIN_WAIT_CYCLES    (REQ_MIN_WAIT_CYCLES),
+    .W_MAX_WAIT_CYCLES    (REQ_MAX_WAIT_CYCLES),
+    .RESP_MIN_WAIT_CYCLES (RESP_MIN_WAIT_CYCLES),
+    .RESP_MAX_WAIT_CYCLES (RESP_MAX_WAIT_CYCLES),
+    .AXI_ATOPS            (1'b1)
+  ) axi_master = new(upstream_dv);
   initial begin
-    static axi_driver_t::ax_beat_t aw_queue[$];
-    static int unsigned atop_flight_cnt[NUM_AXI_IDS-1:0],
-                        r_flight_cnt[NUM_AXI_IDS-1:0],
-                        w_flight_cnt[NUM_AXI_IDS-1:0],
-                        tot_atop_flight_cnt = 0,
-                        tot_r_flight_cnt = 0,
-                        tot_w_flight_cnt = 0;
-    static logic  ar_done = 1'b0,
-                  aw_done = 1'b0;
-    static semaphore cnt_sem = new(1);
-    axi_master.reset_master();
-    for (int unsigned i = 0; i < NUM_AXI_IDS; i++) begin
-      atop_flight_cnt[i] = 0;
-      r_flight_cnt[i] = 0;
-      w_flight_cnt[i] = 0;
-    end
-    wait (rst_n);
-    fork
-      // AR
-      begin
-        repeat (N_TXNS) begin
-          automatic axi_driver_t::ax_beat_t ar_beat = new_rand_burst();
-          static int unsigned rand_success;
-          automatic axi_id_t id;
-          while (tot_r_flight_cnt >= AXI_MAX_READ_TXNS) begin
-            @(posedge clk);
-          end
-          // The ID must not be the same as that of any in-flight ATOP.
-          cnt_sem.get();
-          do begin
-            rand_success = std::randomize(id); assert(rand_success);
-          end while (atop_flight_cnt[id] != 0);
-          ar_beat.ax_id = id;
-          r_flight_cnt[ar_beat.ax_id]++;
-          tot_r_flight_cnt++;
-          cnt_sem.put();
-          rand_req_wait();
-          axi_master.send_ar(ar_beat);
-        end
-        ar_done = 1'b1;
-      end
-      // R
-      while (!(ar_done && tot_r_flight_cnt == 0 && aw_done && tot_atop_flight_cnt == 0)) begin
-        automatic axi_driver_t::r_beat_t r_beat;
-        rand_resp_wait();
-        axi_master.recv_r(r_beat);
-        if (r_beat.r_last) begin
-          cnt_sem.get();
-          if (r_beat.r_resp == RESP_OKAY) begin
-            r_flight_cnt[r_beat.r_id]--;
-            tot_r_flight_cnt--;
-          end
-          cnt_sem.put();
-        end
-      end
-      // AW
-      begin
-        repeat (N_TXNS) begin
-          automatic axi_driver_t::ax_beat_t aw_beat = new_rand_burst();
-          static int unsigned rand_success = 0;
-          automatic axi_id_t id;
-          while (tot_w_flight_cnt >= AXI_MAX_WRITE_TXNS
-              || tot_atop_flight_cnt >= AXI_MAX_WRITE_TXNS) begin
-            @(posedge clk);
-          end
-          aw_beat.ax_atop[5:4] = $random();
-          if (aw_beat.ax_atop[5:4] != 2'b00) begin // ATOP
-            // Determine `ax_atop`.
-            if (aw_beat.ax_atop[5:4] == ATOP_ATOMICSTORE ||
-                aw_beat.ax_atop[5:4] == ATOP_ATOMICLOAD) begin
-              // Endianness
-              aw_beat.ax_atop[3] = $random();
-              // Atomic operation
-              aw_beat.ax_atop[2:0] = $random();
-            end else begin // Atomic{Swap,Compare}
-              aw_beat.ax_atop[3:1] = '0;
-              aw_beat.ax_atop[0] = $random();
-            end
-            // Determine `ax_size` and `ax_len`.
-            if (2**aw_beat.ax_size < AXI_STRB_WIDTH) begin
-              // Transaction does *not* occupy full data bus, so we must send just one beat. [E2.1.3]
-              aw_beat.ax_len = '0;
-            end else begin
-              automatic int unsigned bytes;
-              if (aw_beat.ax_atop == ATOP_ATOMICCMP) begin
-                // Total data transferred in burst can be 2, 4, 8, 16, or 32 B.
-                automatic int unsigned log_bytes;
-                rand_success = std::randomize(log_bytes) with {
-                  log_bytes > 0; 2**log_bytes >= AXI_STRB_WIDTH; 2**log_bytes <= 32;
-                }; assert(rand_success);
-                bytes = 2**log_bytes;
-              end else begin
-                // Total data transferred in burst can be 1, 2, 4, or 8 B.
-                if (AXI_STRB_WIDTH >= 8) begin
-                  bytes = AXI_STRB_WIDTH;
-                end else begin
-                  automatic int unsigned log_bytes;
-                  rand_success = std::randomize(log_bytes); assert(rand_success);
-                  log_bytes = log_bytes % (4 - $clog2(AXI_STRB_WIDTH)) - $clog2(AXI_STRB_WIDTH);
-                  bytes = 2**log_bytes;
-                end
-              end
-              aw_beat.ax_len = bytes / AXI_STRB_WIDTH - 1;
-            end
-            // Determine `ax_addr`.
-            if (aw_beat.ax_atop == ATOP_ATOMICCMP) begin
-              // The address must be aligned to half the outbound data size. [E2-337]
-              aw_beat.ax_addr = aw_beat.ax_addr & ~(1<<aw_beat.ax_size - 1);
-            end else begin
-              // The address must be aligned to the data size. [E2-337]
-              aw_beat.ax_addr = aw_beat.ax_addr & ~(1<<(aw_beat.ax_size+1) - 1);
-            end
-            // Determine `ax_burst`.
-            if (aw_beat.ax_atop == ATOP_ATOMICCMP) begin
-              // If the address is aligned to the total size of outgoing data, the burst type must be
-              // INCR. Otherwise, it must be WRAP. [E2-338]
-              aw_beat.ax_burst = (aw_beat.ax_addr % ((aw_beat.ax_len+1) * 2**aw_beat.ax_size) == 0) ?
-                  BURST_INCR : BURST_WRAP;
-            end else begin
-              // Only INCR allowed.
-              aw_beat.ax_burst = BURST_INCR;
-            end
-            // Determine `ax_id`, which must not be the same as that of any other in-flight AXI
-            // transaction.
-            cnt_sem.get();
-            do begin
-              rand_success = std::randomize(id); assert(rand_success);
-            end while (atop_flight_cnt[id] != 0 || r_flight_cnt[id] != 0 || w_flight_cnt[id] != 0);
-          end else begin
-            // Determine `ax_id`, which must not be the same as that of any in-flight ATOP.
-            cnt_sem.get();
-            do begin
-              rand_success = std::randomize(id); assert(rand_success);
-            end while (atop_flight_cnt[id] != 0);
-          end
-          aw_beat.ax_id = id;
-          // Add AW to queue and put it in flight.
-          aw_queue.push_back(aw_beat);
-          if (aw_beat.ax_atop == '0) begin
-            w_flight_cnt[aw_beat.ax_id]++;
-            tot_w_flight_cnt++;
-          end else begin
-            atop_flight_cnt[aw_beat.ax_id]++;
-            tot_atop_flight_cnt++;
-          end
-          cnt_sem.put();
-          rand_req_wait();
-          axi_master.send_aw(aw_beat);
-        end
-        aw_done = 1'b1;
-      end
-      // W
-      while (!(aw_done && aw_queue.size() == 0)) begin
-        automatic axi_driver_t::ax_beat_t aw_beat;
-        automatic axi_addr_t addr;
-        static int unsigned rand_success = 0;
-        wait (aw_queue.size() > 0);
-        aw_beat = aw_queue.pop_front();
-        addr = aw_beat.ax_addr;
-        for (int unsigned i = 0; i < aw_beat.ax_len + 1; i++) begin
-          automatic axi_driver_t::w_beat_t w_beat = new;
-          int unsigned begin_byte, n_bytes;
-          logic [AXI_STRB_WIDTH-1:0] rand_strb, strb_mask;
-          rand_success = std::randomize(w_beat); assert (rand_success);
-          // Determine strobe.
-          w_beat.w_strb = '0;
-          n_bytes = 2**aw_beat.ax_size;
-          begin_byte = addr % AXI_STRB_WIDTH;
-          strb_mask = ((1'b1 << n_bytes) - 1) << begin_byte;
-          rand_strb = $random();
-          w_beat.w_strb |= (rand_strb & strb_mask);
-          // Determine last.
-          w_beat.w_last = (i == aw_beat.ax_len);
-          rand_req_wait();
-          axi_master.send_w(w_beat);
-          if (aw_beat.ax_burst == BURST_INCR)
-            addr += n_bytes;
-        end
-      end
-      // B
-      while (!(aw_done && tot_atop_flight_cnt == 0 && tot_w_flight_cnt == 0)) begin
-        automatic axi_driver_t::b_beat_t b_beat;
-        rand_resp_wait();
-        axi_master.recv_b(b_beat);
-        cnt_sem.get();
-        if (b_beat.b_resp == RESP_SLVERR) begin
-          atop_flight_cnt[b_beat.b_id]--;
-          tot_atop_flight_cnt--;
-        end else begin
-          w_flight_cnt[b_beat.b_id]--;
-          tot_w_flight_cnt--;
-        end
-        cnt_sem.put();
-      end
-    join
+    axi_master.reset();
+    wait(rst_n);
+    axi_master.run(N_TXNS, N_TXNS, {AXI_ADDR_WIDTH{1'b0}}, {AXI_ADDR_WIDTH{1'b1}});
     mst_done = 1'b1;
   end
 
@@ -385,73 +141,20 @@ module tb_axi_atop_filter #(
   end
 
   // AXI Slave
-  axi_driver_t axi_slave = new(downstream_dv);
-  // TODO: Is it possible to move such a slave driver as class to `axi_test`?
+  axi_test::rand_axi_slave #(
+    .AW(AXI_ADDR_WIDTH), .DW(AXI_DATA_WIDTH), .IW(AXI_ID_WIDTH), .UW(AXI_USER_WIDTH),
+    .TA(TA), .TT(TT),
+    .AX_MIN_WAIT_CYCLES   (RESP_MIN_WAIT_CYCLES),
+    .AX_MAX_WAIT_CYCLES   (RESP_MAX_WAIT_CYCLES),
+    .R_MIN_WAIT_CYCLES    (RESP_MIN_WAIT_CYCLES),
+    .R_MAX_WAIT_CYCLES    (RESP_MAX_WAIT_CYCLES),
+    .RESP_MIN_WAIT_CYCLES (RESP_MIN_WAIT_CYCLES),
+    .RESP_MAX_WAIT_CYCLES (RESP_MAX_WAIT_CYCLES)
+  ) axi_slave = new(downstream_dv);
   initial begin
-    static rand_ax_beat_queue       ar_queue = new;
-    static axi_driver_t::ax_beat_t  aw_queue[$];
-    static rand_ax_beat_queue       b_queue = new;
-    axi_slave.reset_slave();
+    axi_slave.reset();
     wait (rst_n);
-    fork
-      // AR
-      forever begin
-        automatic axi_driver_t::ax_beat_t ar_beat;
-        rand_resp_wait();
-        axi_slave.recv_ar(ar_beat);
-        ar_queue.push(ar_beat.ax_id, ar_beat);
-      end
-      // R
-      forever begin
-        automatic axi_driver_t::ax_beat_t ar_beat;
-        automatic axi_driver_t::r_beat_t r_beat = new;
-        wait (!ar_queue.empty());
-        ar_beat = ar_queue.peek();
-        void'(std::randomize(r_beat));
-        r_beat.r_id = ar_beat.ax_id;
-        rand_resp_wait();
-        if (ar_beat.ax_len == '0) begin
-          r_beat.r_last = 1'b1;
-          void'(ar_queue.pop_id(ar_beat.ax_id));
-        end else begin
-          ar_beat.ax_len--;
-          ar_queue.set(ar_beat.ax_id, ar_beat);
-        end
-        axi_slave.send_r(r_beat);
-      end
-      // AW
-      forever begin
-        automatic axi_driver_t::ax_beat_t aw_beat;
-        rand_resp_wait();
-        axi_slave.recv_aw(aw_beat);
-        aw_queue.push_back(aw_beat);
-      end
-      // W
-      forever begin
-        automatic axi_driver_t::ax_beat_t aw_beat;
-        forever begin
-          automatic axi_driver_t::w_beat_t w_beat;
-          rand_resp_wait();
-          axi_slave.recv_w(w_beat);
-          if (w_beat.w_last)
-            break;
-        end
-        wait (aw_queue.size() > 0);
-        aw_beat = aw_queue.pop_front();
-        b_queue.push(aw_beat.ax_id, aw_beat);
-      end
-      // B
-      forever begin
-        automatic axi_driver_t::ax_beat_t aw_beat;
-        automatic axi_driver_t::b_beat_t b_beat = new;
-        wait (!b_queue.empty());
-        aw_beat = b_queue.pop();
-        void'(std::randomize(b_beat));
-        b_beat.b_id = aw_beat.ax_id;
-        rand_resp_wait();
-        axi_slave.send_b(b_beat);
-      end
-    join
+    axi_slave.run();
   end
 
   typedef struct packed {
@@ -459,16 +162,29 @@ module tb_axi_atop_filter #(
     logic     thru;
   } w_cmd_t;
 
+  typedef axi_test::axi_ax_beat #(
+    .AW(AXI_ADDR_WIDTH), .IW(AXI_ID_WIDTH), .UW(AXI_USER_WIDTH)
+  ) ax_beat_t;
+  typedef axi_test::axi_b_beat #(
+    .IW(AXI_ID_WIDTH), .UW(AXI_USER_WIDTH)
+  ) b_beat_t;
+  typedef axi_test::axi_r_beat #(
+    .DW(AXI_DATA_WIDTH), .IW(AXI_ID_WIDTH), .UW(AXI_USER_WIDTH)
+  ) r_beat_t;
+  typedef axi_test::axi_w_beat #(
+    .DW(AXI_DATA_WIDTH), .UW(AXI_USER_WIDTH)
+  ) w_beat_t;
+
   // Monitor and check responses of filter.
   initial begin
-    static axi_driver_t::ax_beat_t  ar_xfer_queue[$],
-                                    aw_xfer_queue[$];
-    static axi_driver_t::b_beat_t   b_inject_queue[$],
-                                    b_xfer_queue[$];
-    static axi_driver_t::r_beat_t   r_inject_queue[$],
-                                    r_xfer_queue[$];
-    static w_cmd_t                  w_cmd_queue[$];
-    static axi_driver_t::w_beat_t   w_xfer_queue[$];
+    static ax_beat_t  ar_xfer_queue[$],
+                      aw_xfer_queue[$];
+    static b_beat_t   b_inject_queue[$],
+                      b_xfer_queue[$];
+    static r_beat_t   r_inject_queue[$],
+                      r_xfer_queue[$];
+    static w_cmd_t    w_cmd_queue[$];
+    static w_beat_t   w_xfer_queue[$];
     forever begin
       @(posedge clk);
       #(TT);
@@ -478,7 +194,7 @@ module tb_axi_atop_filter #(
       end
       // Push upstream ARs into transfer queues.
       if (upstream.ar_valid && upstream.ar_ready) begin
-        automatic axi_driver_t::ax_beat_t ar_beat = new;
+        automatic ax_beat_t ar_beat = new;
         ar_beat.ax_id     = upstream.ar_id;
         ar_beat.ax_addr   = upstream.ar_addr;
         ar_beat.ax_len    = upstream.ar_len;
@@ -494,7 +210,7 @@ module tb_axi_atop_filter #(
       end
       // Push upstream AWs that must go through into transfer queues, and push to W command queue.
       if (upstream.aw_valid && upstream.aw_ready) begin
-        automatic axi_driver_t::ax_beat_t aw_beat = new;
+        automatic ax_beat_t aw_beat = new;
         automatic w_cmd_t w_cmd;
         aw_beat.ax_id     = upstream.aw_id;
         aw_beat.ax_addr   = upstream.aw_addr;
@@ -515,7 +231,7 @@ module tb_axi_atop_filter #(
           aw_xfer_queue.push_back(aw_beat);
         end else if (aw_beat.ax_atop[5:4] != ATOP_ATOMICSTORE) begin
           for (int unsigned i = 0; i < aw_beat.ax_len + 1; i++) begin
-            automatic axi_driver_t::r_beat_t r_beat = new;
+            automatic r_beat_t r_beat = new;
             r_beat.r_id = aw_beat.ax_id;
             r_beat.r_resp = RESP_SLVERR;
             r_beat.r_data = '0;
@@ -528,7 +244,7 @@ module tb_axi_atop_filter #(
       // Push upstream Ws that must go through into transfer queue; push to B and R inject queue for
       // completed W bursts that must not go through.
       if (upstream.w_valid && upstream.w_ready) begin
-        automatic axi_driver_t::w_beat_t w_beat = new;
+        automatic w_beat_t w_beat = new;
         automatic w_cmd_t w_cmd;
         w_beat.w_data = upstream.w_data;
         w_beat.w_strb = upstream.w_strb;
@@ -541,7 +257,7 @@ module tb_axi_atop_filter #(
         end
         if (w_beat.w_last) begin
           if (!w_cmd.thru) begin
-            automatic axi_driver_t::b_beat_t b_beat = new;
+            automatic b_beat_t b_beat = new;
             b_beat.b_id = w_cmd.id;
             b_beat.b_resp = RESP_SLVERR;
             b_inject_queue.push_back(b_beat);
@@ -551,7 +267,7 @@ module tb_axi_atop_filter #(
       end
       // Push downstream Rs into transfer queue.
       if (downstream.r_valid && downstream.r_ready) begin
-        automatic axi_driver_t::r_beat_t r_beat = new;
+        automatic r_beat_t r_beat = new;
         r_beat.r_id   = downstream.r_id;
         r_beat.r_data = downstream.r_data;
         r_beat.r_resp = downstream.r_resp;
@@ -561,7 +277,7 @@ module tb_axi_atop_filter #(
       end
       // Push downstream Bs into transfer queue.
       if (downstream.b_valid && downstream.b_ready) begin
-        automatic axi_driver_t::b_beat_t b_beat = new;
+        automatic b_beat_t b_beat = new;
         b_beat.b_id   = downstream.b_id;
         b_beat.b_resp = downstream.b_resp;
         b_beat.b_user = downstream.b_user;
@@ -569,7 +285,7 @@ module tb_axi_atop_filter #(
       end
       // Ensure downstream ARs match beats from transfer queue.
       if (downstream.ar_valid && downstream.ar_ready) begin
-        automatic axi_driver_t::ax_beat_t exp_beat;
+        automatic ax_beat_t exp_beat;
         assert (ar_xfer_queue.size() > 0) else $fatal(1, "downstream.AR: Unknown beat!");
         exp_beat = ar_xfer_queue.pop_front();
         assert (downstream.ar_id      == exp_beat.ax_id);
@@ -585,7 +301,7 @@ module tb_axi_atop_filter #(
       end
       // Ensure downstream AWs match beats from transfer queue.
       if (downstream.aw_valid && downstream.aw_ready) begin
-        automatic axi_driver_t::ax_beat_t exp_beat;
+        automatic ax_beat_t exp_beat;
         assert (aw_xfer_queue.size() > 0) else $fatal(1, "downstream.AW: Unknown beat!");
         exp_beat = aw_xfer_queue.pop_front();
         assert (downstream.aw_id      == exp_beat.ax_id);
@@ -601,7 +317,7 @@ module tb_axi_atop_filter #(
       end
       // Ensure downstream Ws match beats from transfer queue.
       if (downstream.w_valid && downstream.w_ready) begin
-        automatic axi_driver_t::w_beat_t exp_beat;
+        automatic w_beat_t exp_beat;
         assert (w_xfer_queue.size() > 0) else $fatal(1, "downstream.W: Unknown beat!");
         exp_beat = w_xfer_queue.pop_front();
         assert (downstream.w_data == exp_beat.w_data);
@@ -611,7 +327,7 @@ module tb_axi_atop_filter #(
       end
       // Ensure upstream Rs match beats from transfer or inject queue.
       if (upstream.r_valid && upstream.r_ready) begin
-        automatic axi_driver_t::r_beat_t exp_beat;
+        automatic r_beat_t exp_beat;
         if (r_inject_queue.size() > 0 && r_inject_queue[0].r_id == upstream.r_id) begin
           exp_beat = r_inject_queue.pop_front();
         end else if (r_xfer_queue.size() > 0 && r_xfer_queue[0].r_id == upstream.r_id) begin
@@ -627,7 +343,7 @@ module tb_axi_atop_filter #(
       end
       // Ensure upstream Bs match beats from transfer or inject queue.
       if (upstream.b_valid && upstream.b_ready) begin
-        automatic axi_driver_t::b_beat_t exp_beat;
+        automatic b_beat_t exp_beat;
         if (b_inject_queue.size() > 0 && b_inject_queue[0].b_id == upstream.b_id) begin
           exp_beat = b_inject_queue.pop_front();
         end else if (b_xfer_queue.size() > 0 && b_xfer_queue[0].b_id == upstream.b_id) begin

--- a/test/tb_axi_atop_filter.sv
+++ b/test/tb_axi_atop_filter.sv
@@ -131,7 +131,8 @@ module tb_axi_atop_filter #(
   initial begin
     axi_master.reset();
     wait(rst_n);
-    axi_master.run(N_TXNS, N_TXNS, {AXI_ADDR_WIDTH{1'b0}}, {AXI_ADDR_WIDTH{1'b1}});
+    axi_master.add_memory_region({AXI_ADDR_WIDTH{1'b0}}, {AXI_ADDR_WIDTH{1'b1}}, axi_pkg::WTHRU_NOALLOCATE);
+    axi_master.run(N_TXNS, N_TXNS);
     mst_done = 1'b1;
   end
 


### PR DESCRIPTION
### Added
- `axi_test`: Constrained randomizing AXI master (`rand_axi_master`) and slave (`rand_axi_slave`).
  - `rand_axi_master` issues a configurable number of read and write transactions to configurable memory regions (address ranges with associated memory types) and with random properties within constraints (e.g., burst length, exclusive accesses, atomic operations).
  - `rand_axi_slave` responds to transactions with random delays and data.
- `axi_pkg`: AXI memory types (`mem_type_t`) and functions `get_arcache` and `get_awcache` to calculate `AxCACHE` bits for a given memory type.

### Changed
- `axi_test`: The `reset` tasks in `axi_driver` and `axi_lite_driver` are now functions.