### PR TITLE
AXI4-Lite Mailbox implementation

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -31,6 +31,7 @@ sources:
   - src/axi_join.sv
   - src/axi_lite_demux.sv
   - src/axi_lite_join.sv
+  - src/axi_lite_mailbox.sv
   - src/axi_lite_mux.sv
   - src/axi_lite_to_apb.sv
   - src/axi_lite_to_axi.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -60,6 +60,7 @@ sources:
       - test/tb_axi_delayer.sv
       - test/tb_axi_lite_to_apb.sv
       - test/tb_axi_lite_to_axi.sv
+      - test/tb_axi_lite_mailbox.sv
       - test/tb_axi_lite_xbar.sv
       - test/tb_axi_to_axi_lite.sv
       - test/tb_axi_xbar_pkg.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+- Add `axi_lite_mailbox`: AXI4-Lite mailbox.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This is the implementation of the AMBA AXI protocol developed as part of the PUL
 | [`axi_join.sv`](src/axi_join.sv)                     | A connector that joins two AXI interfaces.                                                        |                             |
 | [`axi_lite_demux.sv`](src/axi_lite_demux.sv)         | Demultiplexes an AXI4-Lite bus from one slave port to multiple master ports.                      | [Doc](doc/axi_lite_demux.md)|
 | [`axi_lite_join.sv`](src/axi_lite_join.sv)           | A connector that joins two AXI-Lite interfaces.                                                   |                             |
+| [`axi_lite_mailbox.sv`](src/axi_lite_mailbox.sv)     | A AXI4-Lite Mailbox with two slave ports and usage triggered irq.                                 | [Doc](doc/axi_lite_mailbox.md) |
 | [`axi_lite_mux.sv`](src/axi_lite_mux.sv)             | Multiplexes AXI4-Lite slave ports down to one master port.                                        | [Doc](doc/axi_lite_mux.md)  |
 | [`axi_lite_to_apb.sv`](src/axi_lite_to_apb.sv)       | An AXI4-Lite to APB4 adapter.                                                                     |                             |
 | [`axi_lite_to_axi.sv`](src/axi_lite_to_axi.sv)       | An AXI4-Lite to AXI4 adapter.                                                                     |                             |

--- a/doc/README.md
+++ b/doc/README.md
@@ -5,6 +5,7 @@ This folder contains the documentation of the following modules:
 - [AXI Crossbar (`axi_xbar`)](axi_xbar.md)
 - [AXI Demultiplexer (`axi_demux`)](axi_demux.md)
 - [AXI Multiplexer (`axi_mux`)](axi_mux.md)
+- [AXI4-Lite Mailbox (`axi_lite_mailbox`)](axi_lite_mailbox.md)
 
 
 ## Relevant Specifications

--- a/doc/axi_lite_mailbox.md
+++ b/doc/axi_lite_mailbox.md
@@ -1,0 +1,155 @@
+# AXI4-Lite Mailbox
+
+`axi_lite_mailbox` implements a hardware mailbox, where two AXI4-Lite slave ports are connected to each other over two FIFOs. Data written on port 0 is made available on the read data at port 1 and vice versa.
+The module features an interrupt for each port which can be enabled with the [IRQEN](#irqen-register) register. Interrupts can be configured to trigger depending on the fill levels of the read ([RIRQT](#rirqt-register)) and write ([WIRQT](#wirqt-register)) FIFO. It is further possible to trigger an interrupt on an mailbox error condition as defined by the [ERROR](#error-register) register.
+
+## Module Parameters
+
+This table describes the parameters of the module.
+
+| Name           | Type           | Description                                                                                  |
+|:---------------|:---------------|:---------------------------------------------------------------------------------------------|
+| `MailboxDepth` | `int unsigned `| The depth of the FIFOs between the two slave ports, min `32'd2`                              |
+| `IrqEdgeTrig`  | `bit`          | Interrupts trigger mode. <br/>[0]: level trigger <br/>[1]: edge trigger                      |
+| `IrqActHigh`   | `bit`          | Interrupts polarity. <br/>[0]: active low / falling edge <br/>[1]: active high / rising edge |
+| `AxiAddrWidth` | `int unsigned` | The AXI4-Lite address width on the AW and AR channels                                        |
+| `AxiDataWidth` | `int unsigned` | The AXI4-Lite data width on the W and R channels                                             |
+| `req_lite_t`   | `type`         | In accordance with the `AXI_LITE_TYPEDEF_REQ_T` macro                                        |
+| `resp_lite_t`  | `type`         | In accordance with the `AXI_LITE_TYPEDEF_RESP_T` macro                                       |
+
+## Module Ports
+
+This table describes the ports of the module.
+
+| Name           | Type                       | Description                                            |
+|:---------------|:---------------------------|:-------------------------------------------------------|
+| `clk_i`        | `input  logic`             | clock                                                  |
+| `rst_ni`       | `input  logic`             | asynchronous reset active low                          |
+| `test_i`       | `input  logic`             | testmode enable                                        |
+| `slv_reqs_i`   | `input  req_lite_t  [1:0]` | requests of the two AXI4-Lite ports                    |
+| `slv_resps_o`  | `output resp_lite_t [1:0]` | responses of the two AXI4-Lite ports                   |
+| `irq_o`        | `output logic       [1:0]` | interrupt output for each port                         |
+| `base_addr_i`  | `input  addr_t      [1:0]` | base address for each port                             |
+
+
+## Register Address Mapping
+
+This table describes the type of register and the respective address mapping. The address depends on the parameter `AxiDataWidth` and the respective `base_addr_i[*]` of the port accociated to the index.
+There are two example columns given for the resulting address for a `base_addr_i[*]` of `'0` and `AxiDataWidth` of 32 and 64 bit.
+Each register has one of the acces types `R/W = read and write`, `R = read-only` and `W = write-only`. Writes to read-only and reads from write-only registers are responded by an `axi_pkg::RESP_SLVERR`.
+
+| Base Address + Offset\*AxiDataWidth/8 | Address for `AxiDataWidth = 32` | Address for `AxiDataWidth = 64` | Register Name                     | Access Type | Default Value | Description                       |
+|:--------------------------------------|:-------------------------------:|:-------------------------------:|:---------------------------------:|:-----------:|:-------------:|:----------------------------------|
+| base_addr_i + 0\*AxiDataWidth/8       | 0x00                            | 0x00                            | [MBOXW](#mboxw-register)          | W           | N/A           | Write data address                |
+| base_addr_i + 1\*AxiDataWidth/8       | 0x04                            | 0x08                            | [MBOXR](#mboxr-register)          | R           | N/A           | Read data address                 |
+| base_addr_i + 2\*AxiDataWidth/8       | 0x08                            | 0x10                            | [STATUS](#status-register)        | R           | `0x1`         | Status flags of the mailbox       |
+| base_addr_i + 3\*AxiDataWidth/8       | 0x0C                            | 0x18                            | [ERROR](#error-register)          | R           | `0x0`         | Error flags                       |
+| base_addr_i + 4\*AxiDataWidth/8       | 0x10                            | 0x20                            | [WIRQT](#wirqt-register)          | R/W         | `0x0`         | Write data interrupt threshold    |
+| base_addr_i + 5\*AxiDataWidth/8       | 0x14                            | 0x28                            | [RIRQT](#rirqt-register)          | R/W         | `0x0`         | Read data interrupt threshold     |
+| base_addr_i + 6\*AxiDataWidth/8       | 0x18                            | 0x30                            | [IRQS](#irqs-register)            | R/W         | `0x0`         | Interrupt status register         |
+| base_addr_i + 7\*AxiDataWidth/8       | 0x1C                            | 0x38                            | [IRQEN](#irqen-register)          | R/W         | `0x0`         | Interrupt enable register         |
+| base_addr_i + 8\*AxiDataWidth/8       | 0x20                            | 0x40                            | [IRQP](#irqp-register)            | R           | `0x0`         | Interrupt pending register        |
+| base_addr_i + 9\*AxiDataWidth/8       | 0x24                            | 0x48                            | [CRTL](#ctrl-register)            | R/W         | `0x0`         | Module control register           |
+
+### MBOXW Register
+
+Mailbox write register. Write here to send data to the other slave port. A interrupt request will be raised when the fill pointer of the FIFO surpasses the [WIRQT Register](#wirqt-register) (if enabled).
+Writes are ignored when the FIFO is full and a `axi_pkg::RESP_SLVERR` is returned. Additionally the corresponding bit in the [ERROR Register](#error-register) is set.
+
+### MBOXR Register
+
+Mailbox read register. Read here to recieve data from the other slave port. A interrupt request will be raised when the fill pointer of the FIFO surpasses the [RIRQT Register](#rirqt-register) (if enabled).
+When the FIFO is empty the read response `axi_pkg::RESP_SLVERR` is returned. Additionally the corresponding bit in the [ERROR Register](#error-register) is set.
+
+### STATUS Register
+
+Mailbox status register. This register holds the current status of the mailbox.
+
+| Bit(s)             | Name     | Access Type | Reset Value | Description                                                                                                                                                                           |
+|:------------------:|:--------:|:-----------:|:-----------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `AxiDataWidth-1:4` | Reserved |             |             | Reserved                                                                                                                                                                              |
+| `3`                | WFIFOL   | R           | `1'b0`      | Write FIFO level is higher than the threshold set in `WIRQT` <br/>[0]: Write FIFO level is less or equal to the threshold. <br/>[1]: Write FIFO level is higher than the threshold.   |
+| `2`                | RFIFOL   | R           | `1'b0`      | Read FIFO level is higher than the threshold set in `RIRQT` <br/>[0]: Write Read level is less or equal to the threshold. <br/>[1]: Read FIFO level is higher than the threshold.     |
+| `1`                | Full     | R           | `1'b0`      | Write FIFO is full and subsequent writes to `MBOX` are ignored <br/>[0]: Space for write data. <br/>[1]: No space for data, writes are ignored and error on transaction is generated. |
+| `0`                | Empty    | R           | `1'b1`      | Read FIFO is empty <br/>[0]: Data is available. <br/>[1]: No available data, reads respond with `axi_pkg::RESP_SLVERR`.                                                               |
+
+
+### ERROR Register
+
+Mailbox error register. This read only register contains information if from an empty read FIFO was read, or to a full FIFO was data written and ignored. This register is cleared on read.
+
+| Bit(s)             | Name     | Access Type | Reset Value | Description                                                                          |
+|:------------------:|:--------:|:-----------:|:-----------:|:-------------------------------------------------------------------------------------|
+| `AxiDataWidth-1:2` | Reserved |             |             | Reserved                                                                             |
+| `1`                | Full     | R           | `1'b0`      | Attempted write to a full `MBOX`. <br/>[0]: No Error. <br/>[1]: `MBOX` write error.  |
+| `0`                | Empty    | R           | `1'b1`      | Attempted read from an empty `MBOX` <br/>[0]: No Error. <br/>[1]: `MBOX` read error. |
+
+
+### WIRQT Register
+
+Write interrupt request threshold register for a slave port. The corresponding [STATUS register](#status-register) bit is set, when the usage pointer of the FIFO connected to the W channel passes this value.
+When a value larger or equal than the parameter `MailboxDepth` is written to this register, it gets reduced to `MailboxDepth - 2` to ensure an interrupt request trigger on FIFO usage.
+
+| Bit(s)                                | Name     | Access Type | Reset Value | Description                                  |
+|:-------------------------------------:|:--------:|:-----------:|:-----------:|:---------------------------------------------|
+| `AxiDataWidth-1:$clog2(MailboxDepth)` | Reserved |             |             | Reserved                                     |
+| `$clog2(MailboxDepth)-1:0`            | `WIRQT`  | R/W         | `'0`        | The lower $clog2(MailboxDepth) bits are used |
+
+
+### RIRQT Register
+
+Read interrupt request threshold register for a slave port. The corresponding [STATUS register](#status-register) bit is set, when the fill pointer of the FIFO connected to the R channel passes this value.
+When a value larger or equal than the parameter `MailboxDepth` is written to this register, it gets reduced to `MailboxDepth - 2` to ensure an interrupt request trigger on FIFO usage.
+
+| Bit(s)                                | Name     | Access Type | Reset Value | Description                                  |
+|:-------------------------------------:|:--------:|:-----------:|:-----------:|:---------------------------------------------|
+| `AxiDataWidth-1:$clog2(MailboxDepth)` | Reserved |             |             | Reserved                                     |
+| `$clog2(MailboxDepth)-1:0`            | `RIRQT`  | R/W         | `'0`        | The lower $clog2(MailboxDepth) bits are used |
+
+### IRQS Register
+
+Interrupt request status register. This register holds the current interrupt status of this slave port. There are three types of interrupts which can be enabled in the [IRQEN register](#irqen-register). The bits inside this register are sticky and get set when the trigger condition is fulfilled. This register has to be cleared explicitly by acknowledging the interrupt request status described below. This register will also fire, when the respective interrupt is not enabled.
+* `EIRQ`:  Error interrupt request, is set to high, when there was an attempted read from an empty `MBOX` or to write on a full `MBOX`.
+* `RTIRQ`: Read threshold interrupt request, is set to high when the fill pointer of the FIFO connected to the R channel is higher than the threshold set in `RIRQT`.
+* `WEIRQ`: Write error interrupt request, is set to high, when there was an attempted write to a full write FIFO. Will not change when the interrupt is not enabled in `IRQEN`.
+This register allows acknowledgment of the respective interrupts. To acknowledge an interrupt request write a `1'b1` to the corresponding bit described in following table.
+
+| Bit(s)             | Name     | Access Type | Reset Value | Description                                                                                                                                                                     |
+|:------------------:|:--------:|:-----------:|:-----------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `AxiDataWidth-1:3` | Reserved |             |             | Reserved                                                                                                                                                                        |
+| `2`                | `EIRQ`   | R/W         | 1'b0        | On read: <br/>[0]: No interrupt request <br/>[1]: Error on MBOX access                <br/>On write: <br/>[0]: No acknowledge <br/>[1]: Acknowledge and clear interrupt request |
+| `1`                | `RTIRQ`  | R/W         | 1'b0        | On read: <br/>[0]: No interrupt request <br/>[1]: Usage level threshold in read MBOX  <br/>On write: <br/>[0]: No acknowledge <br/>[1]: Acknowledge and clear interrupt request |
+| `0`                | `WTIRQ`  | R/W         | 1'b0        | On read: <br/>[0]: No interrupt request <br/>[1]: Usage level threshold in write MBOX <br/>On write: <br/>[0]: No acknowledge <br/>[1]: Acknowledge and clear interrupt request |
+
+### IRQEN Register
+
+Interrupt request enable register. Here the four interrupts from [IRQS](#irqs-register) can be enabled by writing to the corresponding bit in following table.
+
+| Bit(s)             | Name     | Access Type | Reset Value | Description                                                         |
+|:------------------:|:--------:|:-----------:|:-----------:|:--------------------------------------------------------------------|
+| `AxiDataWidth-1:3` | Reserved |             |             | Reserved                                                            |
+| `2`                | `EIRQ`   | R/W         | 1'b0        | [0]: Interrupt request disabled <br/>[1]: Interrupt request enabled |
+| `1`                | `RTIRQ`  | R/W         | 1'b0        | [0]: Interrupt request disabled <br/>[1]: Interrupt request enabled |
+| `0`                | `WTIRQ`  | R/W         | 1'b0        | [0]: Interrupt request disabled <br/>[1]: Interrupt request enabled |
+
+### IRQP Register
+
+Interrupt request pending register. This register holds the pending interrupts for this slave port and is read only. It is generated by the bitwise and of the [IRQS](#irqs-register) and [IRQEN](#irqen-register) registers.
+An interrupt gets triggered by the OR of the bits of this register.
+
+| Bit(s)             | Name     | Access Type | Reset Value | Description                                                           |
+|:------------------:|:--------:|:-----------:|:-----------:|:----------------------------------------------------------------------|
+| `AxiDataWidth-1:3` | Reserved |             |             | Reserved                                                              |
+| `2`                | `EIRQ`   | R           | 1'b0        | [0]: Interrupt request pending <br/>[1]: Error pending                |
+| `1`                | `RTIRQ`  | R           | 1'b0        | [0]: Interrupt request pending <br/>[1]: MBOX read threshold pending  |
+| `0`                | `WTIRQ`  | R           | 1'b0        | [0]: Interrupt request pending <br/>[1]: MBOX write threshold pending |
+
+### CTRL Register
+
+Mailbox control register. Here the FIFOs can be cleared from each interface. The flush signal at each FIFO is the OR combination of the respective bits of this register at each slave port. On register write, the FIFO is cleared and the register is reset.
+
+| Bit(s)             | Name     | Access Type | Reset Value | Description                                  |
+|:------------------:|:--------:|:-----------:|:-----------:|:---------------------------------------------|
+| `AxiDataWidth-1:2` | Reserved |             |             | Reserved                                     |
+| `1`                | `RTIRQ`  | W           | 1'b0        | Flush the read MBOX FIFO for this port       |
+| `0`                | `WTIRQ`  | W           | 1'b0        | Flush the write MBOX FIFO for this port      |

--- a/doc/axi_lite_mailbox.md
+++ b/doc/axi_lite_mailbox.md
@@ -88,7 +88,7 @@ Mailbox error register. This read only register contains information if from an 
 ### WIRQT Register
 
 Write interrupt request threshold register for a slave port. The corresponding [STATUS register](#status-register) bit is set, when the usage pointer of the FIFO connected to the W channel passes this value.
-When a value larger or equal than the parameter `MailboxDepth` is written to this register, it gets reduced to `MailboxDepth - 2` to ensure an interrupt request trigger on FIFO usage.
+When a value larger or equal than the parameter `MailboxDepth` is written to this register, it gets reduced to `MailboxDepth - 1` to ensure an interrupt request trigger on FIFO usage, when the write FIFO is full.
 
 | Bit(s)                                | Name     | Access Type | Reset Value | Description                                  |
 |:-------------------------------------:|:--------:|:-----------:|:-----------:|:---------------------------------------------|
@@ -99,7 +99,7 @@ When a value larger or equal than the parameter `MailboxDepth` is written to thi
 ### RIRQT Register
 
 Read interrupt request threshold register for a slave port. The corresponding [STATUS register](#status-register) bit is set, when the fill pointer of the FIFO connected to the R channel passes this value.
-When a value larger or equal than the parameter `MailboxDepth` is written to this register, it gets reduced to `MailboxDepth - 2` to ensure an interrupt request trigger on FIFO usage.
+When a value larger or equal than the parameter `MailboxDepth` is written to this register, it gets reduced to `MailboxDepth - 1` to ensure an interrupt request trigger on FIFO usage, when the read FIFO is full.
 
 | Bit(s)                                | Name     | Access Type | Reset Value | Description                                  |
 |:-------------------------------------:|:--------:|:-----------:|:-----------:|:---------------------------------------------|

--- a/scripts/run_vsim.sh
+++ b/scripts/run_vsim.sh
@@ -34,3 +34,4 @@ call_vsim tb_axi_xbar -t 1ns -coverage -voptargs="+acc +cover=bcesfx"
 call_vsim tb_axi_lite_xbar -t 1ns -coverage -voptargs="+acc +cover=bcesfx"
 call_vsim tb_axi_cdc
 call_vsim tb_axi_lite_to_apb -t 1ns -coverage -voptargs="+acc +cover=bcesfx"
+call_vsim tb_axi_lite_mailbox -t 1ns -coverage -voptargs="+acc +cover=bcesfx"

--- a/src/axi_lite_mailbox.sv
+++ b/src/axi_lite_mailbox.sv
@@ -1,0 +1,604 @@
+// Copyright (c) 2020 ETH Zurich and University of Bologna
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Wolfgang Roenninger <wroennin@ethz.ch>
+
+// Description: A mailbox with two AXI4-Lite slave ports and associated interrupt requests.
+//              See `doc/axi_lite_mailbox.md` for the documentation, including the definition
+//              of parameters and ports.
+
+`include "common_cells/registers.svh"
+
+module axi_lite_mailbox #(
+  parameter int unsigned MailboxDepth = 32'd0,
+  parameter bit unsigned IrqEdgeTrig  = 1'b0,
+  parameter bit unsigned IrqActHigh   = 1'b1,
+  parameter int unsigned AxiAddrWidth = 32'd0,
+  parameter int unsigned AxiDataWidth = 32'd0,
+  parameter type         req_lite_t   = logic,
+  parameter type         resp_lite_t  = logic,
+  // DEPENDENT PARAMETERS, DO NOT OVERRIDE!
+  parameter type         addr_t       = logic [AxiAddrWidth-1:0]
+) (
+  input  logic             clk_i,       // Clock
+  input  logic             rst_ni,      // Asynchronous reset active low
+  input  logic             test_i,      // Testmode enable
+  // slave ports [1:0]
+  input  req_lite_t  [1:0] slv_reqs_i,
+  output resp_lite_t [1:0] slv_resps_o,
+  output logic       [1:0] irq_o,       // interrupt output for each port
+  input  addr_t      [1:0] base_addr_i  // base address for each port
+);
+
+  typedef logic [AxiDataWidth-1:0]         data_t;
+  // usage type of the mailbox FIFO, also the type of the threshold comparison
+  typedef logic [$clog2(MailboxDepth)-1:0] usage_t;
+
+  // signal declaration for the mailbox FIFO's, signal index is the port
+  logic   [1:0] mbox_full,    mbox_empty;   // index is the instantiated mailbox FIFO
+  logic   [1:0] mbox_push,    mbox_pop;     // index is port
+  logic   [1:0] w_mbox_flush, r_mbox_flush; // index is port
+  data_t  [1:0] mbox_w_data,  mbox_r_data;  // index is port
+  usage_t [1:0] mbox_usage;                 // index is the instantiated mailbox FIFO
+  // interrupt request from this slave port, level triggered, active high --> convert
+  logic   [1:0] slv_irq;
+
+  axi_lite_mailbox_slave #(
+    .MailboxDepth ( MailboxDepth ),
+    .AxiAddrWidth ( AxiAddrWidth ),
+    .AxiDataWidth ( AxiDataWidth ),
+    .req_lite_t   ( req_lite_t   ),
+    .resp_lite_t  ( resp_lite_t  ),
+    .addr_t       ( addr_t       ),
+    .data_t       ( data_t       ),
+    .usage_t      ( usage_t      )  // fill pointer from MBOX FIFO
+  ) i_slv_port_0 (
+    .clk_i,   // Clock
+    .rst_ni,  // Asynchronous reset active low
+    // slave port
+    .slv_req_i      ( slv_reqs_i[0]   ),
+    .slv_resp_o     ( slv_resps_o[0]  ),
+    .base_addr_i    ( base_addr_i[0]  ), // base address for the slave port
+    // write FIFO port
+    .mbox_w_data_o  ( mbox_w_data[0]  ),
+    .mbox_w_full_i  ( mbox_full[0]    ),
+    .mbox_w_push_o  ( mbox_push[0]    ),
+    .mbox_w_flush_o ( w_mbox_flush[0] ),
+    .mbox_w_usage_i ( mbox_usage[0]   ),
+    // read FIFO port
+    .mbox_r_data_i  ( mbox_r_data[0]  ),
+    .mbox_r_empty_i ( mbox_empty[1]   ),
+    .mbox_r_pop_o   ( mbox_pop[0]     ),
+    .mbox_r_flush_o ( r_mbox_flush[0] ),
+    .mbox_r_usage_i ( mbox_usage[1]   ),
+    // interrupt output, level triggered, active high, conversion in top
+    .irq_o          ( slv_irq[0]      )
+  );
+
+  axi_lite_mailbox_slave #(
+    .MailboxDepth ( MailboxDepth ),
+    .AxiAddrWidth ( AxiAddrWidth ),
+    .AxiDataWidth ( AxiDataWidth ),
+    .req_lite_t   ( req_lite_t   ),
+    .resp_lite_t  ( resp_lite_t  ),
+    .addr_t       ( addr_t       ),
+    .data_t       ( data_t       ),
+    .usage_t      ( usage_t      )  // fill pointer from MBOX FIFO
+  ) i_slv_port_1 (
+    .clk_i,   // Clock
+    .rst_ni,  // Asynchronous reset active low
+    // slave port
+    .slv_req_i      ( slv_reqs_i[1]   ),
+    .slv_resp_o     ( slv_resps_o[1]  ),
+    .base_addr_i    ( base_addr_i[1]  ), // base address for the slave port
+    // write FIFO port
+    .mbox_w_data_o  ( mbox_w_data[1]  ),
+    .mbox_w_full_i  ( mbox_full[1]    ),
+    .mbox_w_push_o  ( mbox_push[1]    ),
+    .mbox_w_flush_o ( w_mbox_flush[1] ),
+    .mbox_w_usage_i ( mbox_usage[1]   ),
+    // read FIFO port
+    .mbox_r_data_i  ( mbox_r_data[1]  ),
+    .mbox_r_empty_i ( mbox_empty[0]   ),
+    .mbox_r_pop_o   ( mbox_pop[1]     ),
+    .mbox_r_flush_o ( r_mbox_flush[1] ),
+    .mbox_r_usage_i ( mbox_usage[0]   ),
+    // interrupt output, level triggered, active high, conversion in top
+    .irq_o          ( slv_irq[1]      )
+  );
+
+  fifo_v3 #(
+    .FALL_THROUGH ( 1'b0         ),
+    .DEPTH        ( MailboxDepth ),
+    .dtype        ( data_t       )
+  ) i_mbox_0_to_1 (
+    .clk_i,
+    .rst_ni,
+    .testmode_i( test_i                            ),
+    .flush_i   ( w_mbox_flush[0] | r_mbox_flush[1] ),
+    .full_o    ( mbox_full[0]                      ),
+    .empty_o   ( mbox_empty[0]                     ),
+    .usage_o   ( mbox_usage[0]                     ),
+    .data_i    ( mbox_w_data[0]                    ),
+    .push_i    ( mbox_push[0]                      ),
+    .data_o    ( mbox_r_data[1]                    ),
+    .pop_i     ( mbox_pop[1]                       )
+  );
+
+  fifo_v3 #(
+    .FALL_THROUGH ( 1'b0         ),
+    .DEPTH        ( MailboxDepth ),
+    .dtype        ( data_t       )
+  ) i_mbox_1_to_0 (
+    .clk_i,
+    .rst_ni,
+    .testmode_i( test_i                            ),
+    .flush_i   ( w_mbox_flush[1] | r_mbox_flush[0] ),
+    .full_o    ( mbox_full[1]                      ),
+    .empty_o   ( mbox_empty[1]                     ),
+    .usage_o   ( mbox_usage[1]                     ),
+    .data_i    ( mbox_w_data[1]                    ),
+    .push_i    ( mbox_push[1]                      ),
+    .data_o    ( mbox_r_data[0]                    ),
+    .pop_i     ( mbox_pop[0]                       )
+  );
+
+  for (genvar i = 0; i < 2; i++) begin : gen_irq_conversion
+    if (IrqEdgeTrig) begin : gen_irq_edge
+      logic irq_q, irq_d, update_irq;
+
+      always_comb begin
+        irq_d      = irq_q;
+        update_irq = 1'b0;
+        if (slv_irq[i] ^ irq_q) begin
+          irq_d      = ~irq_q;
+          update_irq = 1'b1;
+        end
+      end
+      assign irq_o[i] = (IrqActHigh) ? (slv_irq[i] && !irq_q) : ~(slv_irq[i] && !irq_q);
+
+      `FFLARN( irq_q, irq_d, update_irq, '0, clk_i, rst_ni )
+    end else begin : gen_irq_level
+      assign irq_o[i] = (IrqActHigh) ? slv_irq[i] : ~slv_irq[i];
+    end
+  end
+
+  // pragma translate_off
+  `ifndef VERILATOR
+  initial begin : proc_check_params
+    mailbox_depth:  assert (MailboxDepth > 1) else $fatal(1, "MailboxDepth has to be at least 2");
+    axi_addr_width: assert (AxiAddrWidth > 0) else $fatal(1, "AxiAddrWidth has to be > 0");
+    axi_data_width: assert (AxiDataWidth > 0) else $fatal(1, "AxiDataWidth has to be > 0");
+  end
+  `endif
+  // pragma translate_on
+endmodule
+
+`include "axi/typedef.svh"
+
+// slave port module
+module axi_lite_mailbox_slave #(
+  parameter int unsigned MailboxDepth = 32'd16,
+  parameter int unsigned AxiAddrWidth = 32'd32,
+  parameter int unsigned AxiDataWidth = 32'd32,
+  parameter type         req_lite_t   = logic,
+  parameter type         resp_lite_t  = logic,
+  parameter type         addr_t       = logic [AxiAddrWidth-1:0],
+  parameter type         data_t       = logic [AxiDataWidth-1:0],
+  parameter type         usage_t      = logic                     // fill pointer from MBOX FIFO
+) (
+  input  logic       clk_i,   // Clock
+  input  logic       rst_ni,  // Asynchronous reset active low
+  // slave port
+  input  req_lite_t  slv_req_i,
+  output resp_lite_t slv_resp_o,
+  input  addr_t      base_addr_i, // base address for the slave port
+  // write FIFO port
+  output data_t      mbox_w_data_o,
+  input  logic       mbox_w_full_i,
+  output logic       mbox_w_push_o,
+  output logic       mbox_w_flush_o,
+  input  usage_t     mbox_w_usage_i,
+  // read FIFO port
+  input  data_t      mbox_r_data_i,
+  input  logic       mbox_r_empty_i,
+  output logic       mbox_r_pop_o,
+  output logic       mbox_r_flush_o,
+  input  usage_t     mbox_r_usage_i,
+  // interrupt output, level triggered, active high, conversion in top
+  output logic       irq_o
+);
+
+  `AXI_LITE_TYPEDEF_B_CHAN_T ( b_chan_lite_t         )
+  `AXI_LITE_TYPEDEF_R_CHAN_T ( r_chan_lite_t, data_t )
+
+  localparam int unsigned NoRegs = 32'd10;
+  typedef enum logic [3:0] {
+    MBOXW  = 4'd0, // Mailbox write register
+    MBOXR  = 4'd1, // Mailbox read register
+    STATUS = 4'd2, // Mailbox status register
+    ERROR  = 4'd3, // Mailbox error register
+    WIRQT  = 4'd4, // Write interrupt request threshold register
+    RIRQT  = 4'd5, // Read interrupt request threshold register
+    IRQS   = 4'd6, // Interrupt request status register
+    IRQEN  = 4'd7, // Interrupt request enable register
+    IRQP   = 4'd8, // Interrupt request pending register
+    CTRL   = 4'd9  // Mailbox control register
+  } reg_e;
+  // address map rule struct, as required from `addr_decode` from `common_cells`
+  typedef struct packed {
+    int unsigned idx;
+    addr_t       start_addr;
+    addr_t       end_addr;
+  } rule_t;
+  // output type of the address decoders, to be casted onto the enum type `reg_e`
+  typedef logic [$clog2(NoRegs)-1:0] idx_t;
+
+  // LITE response signals, go into the output spill registers to prevent combinational response
+  logic         b_valid, b_ready;
+  b_chan_lite_t b_chan;
+  logic         r_valid, r_ready;
+  r_chan_lite_t r_chan;
+  // address map generation
+  rule_t [NoRegs-1:0] addr_map;
+  for (genvar i = 0; i < NoRegs; i++) begin : gen_addr_map
+    assign addr_map[i] = '{
+        idx:        i,
+        start_addr: base_addr_i +  i      * (AxiDataWidth / 8),
+        end_addr:   base_addr_i + (i + 1) * (AxiDataWidth / 8),
+        default:    '0
+    };
+  end
+  // address decode flags
+  idx_t w_reg_idx,   r_reg_idx;
+  logic dec_w_valid, dec_r_valid;
+
+  // mailbox register signal declarations, get extended when read, some of these regs
+  // are build combinationally, indicated by the absence of the `*_d` signal
+
+  logic [3:0] status_q;           // mailbox status register (read only)
+  logic [1:0] error_q,   error_d; // mailbox error register
+  data_t      wirqt_q,   wirqt_d; // write interrupt request threshold register
+  data_t      rirqt_q,   rirqt_d; // read interrupt request threshold register
+  logic [2:0] irqs_q,    irqs_d;  // interrupt request status register
+  logic [2:0] irqen_q,   irqen_d; // interrupt request enable register
+  logic [2:0] irqp_q;             // interrupt request pending register (read only)
+  logic [1:0] ctrl_q;             // mailbox control register
+  logic       update_regs;        // register enable signal
+
+  // register instantiation
+  `FFLARN( error_q, error_d, update_regs, '0, clk_i, rst_ni )
+  `FFLARN( wirqt_q, wirqt_d, update_regs, '0, clk_i, rst_ni )
+  `FFLARN( rirqt_q, rirqt_d, update_regs, '0, clk_i, rst_ni )
+  `FFLARN( irqs_q,  irqs_d,  update_regs, '0, clk_i, rst_ni )
+  `FFLARN( irqen_q, irqen_d, update_regs, '0, clk_i, rst_ni )
+
+  // Mailbox FIFO data assignments
+  for (genvar i = 0; i < (AxiDataWidth/8); i++) begin : gen_w_mbox_data
+    assign mbox_w_data_o[i*8+:8] = slv_req_i.w.strb[i] ? slv_req_i.w.data[i*8+:8] : '0;
+  end
+
+  // combinational mailbox register assignments, for the read only registers
+  assign status_q = { mbox_r_usage_i > usage_t'(rirqt_q),
+                      mbox_w_usage_i > usage_t'(wirqt_q),
+                      mbox_w_full_i,
+                      mbox_r_empty_i };
+  assign irqp_q   = irqs_q & irqen_q;                 // interrupt request pending is bit wise and
+  assign ctrl_q   = {mbox_r_flush_o, mbox_w_flush_o}; // read ctrl_q is flush signals
+  assign irq_o    = |irqp_q;                          // generate an active-high level irq
+
+  always_comb begin
+    // slave port channel outputs for the AW, W and R channel, other driven from spill register
+    slv_resp_o.aw_ready = 1'b0;
+    slv_resp_o.w_ready  = 1'b0;
+    b_chan              = '{resp: axi_pkg::RESP_SLVERR};
+    b_valid             = 1'b0;
+    slv_resp_o.ar_ready = 1'b0;
+    r_chan              = '{data: '0, resp: axi_pkg::RESP_SLVERR};
+    r_valid             = 1'b0;
+    // Default assignments for the internal registers
+    error_d     = error_q;   // mailbox error register
+    wirqt_d     = wirqt_q;   // write interrupt request threshold register
+    rirqt_d     = rirqt_q;   // read interrupt request threshold register
+    irqs_d      = irqs_q;    // interrupt request status register
+    irqen_d     = irqen_q;   // interrupt request enable register
+    update_regs = 1'b0;      // register update enable signal
+    // MBOX FIFO control signals
+    mbox_w_push_o  = 1'b0;
+    mbox_w_flush_o = 1'b0;
+    mbox_r_pop_o   = 1'b0;
+    mbox_r_flush_o = 1'b0;
+
+    // -------------------------------------------
+    // Set the read and write interrupt FF (irqs), when the threshold triggers
+    // -------------------------------------------
+    // strict threshold interrupt these fields get cleared by acknowledge on write onto the register
+    // read trigger, see status_q above
+    if (!irqs_q[1] && status_q[3]) begin
+      irqs_d[1]   = 1'b1;
+      update_regs = 1'b1;
+    end
+    // write trigger, see status_q above
+    if (!irqs_q[0] && status_q[2]) begin
+      irqs_d[0]   = 1'b1;
+      update_regs = 1'b1;
+    end
+
+    // -------------------------------------------
+    // Read registers
+    // -------------------------------------------
+    // The logic of the read and write channels have to be in the same `always_comb` block.
+    // The reason is that the error register could be cleared in the same cycle as a read from
+    // the mailbox FIFO generates a new error. In this case the error is NOT cleared. Instead
+    // it will generate a new irq when it is edge triggered, or the level will stay at its
+    // active state.
+
+    // Check if there is a pending read request on the slave port.
+    if (slv_req_i.ar_valid) begin
+      // set the right read channel output depending on the address decoding
+      if (dec_r_valid) begin
+        // when decode not valid, send the default slaveerror
+        // read the right register when the transfer happens and decode is valid
+        unique case (reg_e'(r_reg_idx))
+          MBOXW: r_chan = '{data: data_t'( 32'hFEEDC0DE ), resp: axi_pkg::RESP_OKAY};
+          MBOXR: begin
+            if (!mbox_r_empty_i) begin
+              r_chan       = '{data: data_t'( mbox_r_data_i ), resp: axi_pkg::RESP_OKAY};
+              mbox_r_pop_o = 1'b1;
+            end else begin
+              // read mailbox is empty, set the read error Flip flop and respond with error
+              r_chan      = '{data: data_t'( 32'hFEEDDEAD ), resp: axi_pkg::RESP_SLVERR};
+              error_d[0]  = 1'b1;
+              irqs_d[2]   = 1'b1;
+              update_regs = 1'b1;
+            end
+          end
+          STATUS: r_chan = '{data: data_t'( status_q ), resp: axi_pkg::RESP_OKAY};
+          ERROR: begin // clear the error register
+            r_chan      = '{data: data_t'( error_q  ), resp: axi_pkg::RESP_OKAY};
+            error_d     = '0;
+            update_regs = 1'b1;
+          end
+          WIRQT: r_chan = '{data: data_t'( wirqt_q  ), resp: axi_pkg::RESP_OKAY};
+          RIRQT: r_chan = '{data: data_t'( rirqt_q  ), resp: axi_pkg::RESP_OKAY};
+          IRQS:  r_chan = '{data: data_t'( irqs_q   ), resp: axi_pkg::RESP_OKAY};
+          IRQEN: r_chan = '{data: data_t'( irqen_q  ), resp: axi_pkg::RESP_OKAY};
+          IRQP:  r_chan = '{data: data_t'( irqp_q   ), resp: axi_pkg::RESP_OKAY};
+          CTRL:  r_chan = '{data: data_t'( ctrl_q   ), resp: axi_pkg::RESP_OKAY};
+        endcase
+      end
+      r_valid = 1'b1;
+      if (r_ready) begin
+        slv_resp_o.ar_ready = 1'b1;
+      end
+    end // read register
+
+    // -------------------------------------------
+    // Write registers
+    // -------------------------------------------
+    // Wait for control and write data to be valid.
+    if (slv_req_i.aw_valid && slv_req_i.w_valid) begin
+      // Can do the handshake here as the b response goes into a spill register with latency one.
+      // Without the B spill register, the B channel would violate the AXI stable requirement.
+      b_valid = 1'b1;
+      if (b_ready) begin
+        // write to the register if required
+        if (dec_w_valid) begin
+          case (reg_e'(w_reg_idx))
+            MBOXW:  begin
+              if (!mbox_w_full_i) begin
+                mbox_w_push_o = 1'b1;
+                b_chan        = '{resp: axi_pkg::RESP_OKAY};
+              end else begin
+                // response with default error and set the error FF
+                error_d[1]  = 1'b1;
+                irqs_d[2]   = 1'b1;
+                update_regs = 1'b1;
+              end
+            end
+            // MBOXR:  read only
+            // STATUS: read only
+            // ERROR:  read only
+            WIRQT:  begin
+              for (int unsigned i = 0; i < AxiDataWidth/8; i++) begin
+                wirqt_d[i*8+:8] = slv_req_i.w.strb[i] ? slv_req_i.w.data[i*8+:8] : 8'b0000_0000;
+              end
+              if (wirqt_d >= data_t'(MailboxDepth)) begin
+                // the `-2` is to prevent interrupt not firing when there is an rollover in the
+                // usage pointer when the FIFO is full and the threshold is set
+                wirqt_d = MailboxDepth - 2; // Threshold to maximal value
+              end
+              update_regs = 1'b1;
+              b_chan      = '{resp: axi_pkg::RESP_OKAY};
+            end
+            RIRQT:  begin
+              for (int unsigned i = 0; i < AxiDataWidth/8; i++) begin
+                rirqt_d[i*8+:8] = slv_req_i.w.strb[i] ? slv_req_i.w.data[i*8+:8] : 8'b0000_0000;
+              end
+              if (rirqt_d >= data_t'(MailboxDepth)) begin
+              // Threshold to maximal value, minus two to prevent overflow in usage
+                rirqt_d = MailboxDepth - 2;
+              end
+              update_regs = 1'b1;
+              b_chan      = '{resp: axi_pkg::RESP_OKAY};
+            end
+            IRQS:   begin
+              // Acknowledge and clear the register by asserting the respective one
+              if (slv_req_i.w.strb[0]) begin
+                // *_d signal is set in the beginning of this process, prevent accidental
+                // overwrite of not acknowledged irq
+                irqs_d[2]   = slv_req_i.w.data[2] ? 1'b0 : irqs_d[2]; // Error irq status
+                irqs_d[1]   = slv_req_i.w.data[1] ? 1'b0 : irqs_d[1]; // Read  irq status
+                irqs_d[0]   = slv_req_i.w.data[0] ? 1'b0 : irqs_d[0]; // Write irq status
+                update_regs = 1'b1;
+              end
+              b_chan = '{resp: axi_pkg::RESP_OKAY};
+            end
+            IRQEN:  begin
+              if (slv_req_i.w.strb[0]) begin
+                irqen_d[2:0]  = slv_req_i.w.data[2:0]; // set the irq enable bits
+                update_regs = 1'b1;
+              end
+              b_chan = '{resp: axi_pkg::RESP_OKAY};
+            end
+            // IRQP: read only
+            CTRL:   begin
+              if (slv_req_i.w.strb[0]) begin
+                mbox_r_flush_o = slv_req_i.w.data[1]; // Flush read  FIFO
+                mbox_w_flush_o = slv_req_i.w.data[0]; // Flush write FIFO
+              end
+              b_chan = '{resp: axi_pkg::RESP_OKAY};
+            end
+            default : /* use default b_chan */;
+          endcase
+        end
+        slv_resp_o.aw_ready = 1'b1;
+        slv_resp_o.w_ready  = 1'b1;
+      end // if (b_ready): Does not violate AXI spec, because the ready comes from an internal
+          // spill register and does not propagate the ready dependency onto the b channel.
+    end // write register
+  end
+
+  // address decoder and response FIFOs for the LITE channel, the port can take a new transaction if
+  // these FIFOs are not full, not fall through to prevent combinational paths to the return path
+  addr_decode #(
+    .NoIndices( NoRegs ),
+    .NoRules  ( NoRegs ),
+    .addr_t   ( addr_t ),
+    .rule_t   ( rule_t )
+  ) i_waddr_decode (
+    .addr_i           ( slv_req_i.aw.addr ),
+    .addr_map_i       ( addr_map          ),
+    .idx_o            ( w_reg_idx         ),
+    .dec_valid_o      ( dec_w_valid       ),
+    .dec_error_o      ( /*not used*/      ),
+    .en_default_idx_i ( 1'b0              ),
+    .default_idx_i    ( '0                )
+  );
+  spill_register #(
+    .T ( b_chan_lite_t )
+  ) i_b_chan_outp (
+    .clk_i,
+    .rst_ni,
+    .valid_i ( b_valid            ),
+    .ready_o ( b_ready            ),
+    .data_i  ( b_chan             ),
+    .valid_o ( slv_resp_o.b_valid ),
+    .ready_i ( slv_req_i.b_ready  ),
+    .data_o  ( slv_resp_o.b       )
+  );
+  addr_decode #(
+    .NoIndices( NoRegs ),
+    .NoRules  ( NoRegs ),
+    .addr_t   ( addr_t ),
+    .rule_t   ( rule_t )
+  ) i_raddr_decode (
+    .addr_i           ( slv_req_i.ar.addr ),
+    .addr_map_i       ( addr_map          ),
+    .idx_o            ( r_reg_idx         ),
+    .dec_valid_o      ( dec_r_valid       ),
+    .dec_error_o      ( /*not used*/      ),
+    .en_default_idx_i ( 1'b0              ),
+    .default_idx_i    ( '0                )
+  );
+  spill_register #(
+    .T ( r_chan_lite_t )
+  ) i_r_chan_outp (
+    .clk_i,
+    .rst_ni,
+    .valid_i ( r_valid            ),
+    .ready_o ( r_ready            ),
+    .data_i  ( r_chan             ),
+    .valid_o ( slv_resp_o.r_valid ),
+    .ready_i ( slv_req_i.r_ready  ),
+    .data_o  ( slv_resp_o.r       )
+  );
+  // pragma translate_off
+  `ifndef VERILATOR
+  initial begin : proc_check_params
+    assert (AxiAddrWidth == $bits(slv_req_i.aw.addr)) else $fatal(1, "AW AxiAddrWidth mismatch");
+    assert (AxiDataWidth == $bits(slv_req_i.w.data))  else $fatal(1, " W AxiDataWidth mismatch");
+    assert (AxiAddrWidth == $bits(slv_req_i.ar.addr)) else $fatal(1, "AR AxiAddrWidth mismatch");
+    assert (AxiDataWidth == $bits(slv_resp_o.r.data)) else $fatal(1, " R AxiDataWidth mismatch");
+  end
+  `endif
+  // pragma translate_on
+endmodule
+
+`include "axi/assign.svh"
+
+module axi_lite_mailbox_intf #(
+  parameter int unsigned MAILBOX_DEPTH  = 32'd0,
+  parameter bit unsigned IRQ_EDGE_TRIG  = 1'b0,
+  parameter bit unsigned IRQ_ACT_HIGH   = 1'b1,
+  parameter int unsigned AXI_ADDR_WIDTH = 32'd0,
+  parameter int unsigned AXI_DATA_WIDTH = 32'd0,
+  // DEPENDENT PARAMETERS, DO NOT OVERRIDE!
+  parameter type addr_t               = logic [AXI_ADDR_WIDTH-1:0]
+) (
+  input  logic         clk_i,      // Clock
+  input  logic         rst_ni,     // Asynchronous reset active low
+  input  logic         test_i,     // Testmode enable
+  AXI_LITE.Slave       slv [1:0],  // slave ports [1:0]
+  output logic   [1:0] irq_o,      // interrupt output for each port
+  input  addr_t  [1:0] base_addr_i // base address for each port
+);
+  typedef logic [AXI_DATA_WIDTH-1:0]   data_t;
+  typedef logic [AXI_DATA_WIDTH/8-1:0] strb_t;
+  `AXI_LITE_TYPEDEF_AW_CHAN_T ( aw_chan_lite_t, addr_t         )
+  `AXI_LITE_TYPEDEF_W_CHAN_T  (  w_chan_lite_t, data_t, strb_t )
+  `AXI_LITE_TYPEDEF_B_CHAN_T  (  b_chan_lite_t                 )
+  `AXI_LITE_TYPEDEF_AR_CHAN_T ( ar_chan_lite_t, addr_t         )
+  `AXI_LITE_TYPEDEF_R_CHAN_T  (  r_chan_lite_t, data_t         )
+  `AXI_LITE_TYPEDEF_REQ_T  ( req_lite_t, aw_chan_lite_t, w_chan_lite_t, ar_chan_lite_t )
+  `AXI_LITE_TYPEDEF_RESP_T ( resp_lite_t, b_chan_lite_t, r_chan_lite_t                 )
+
+  req_lite_t  [1:0] slv_reqs;
+  resp_lite_t [1:0] slv_resps;
+
+  for (genvar i = 0; i < 2; i++) begin : gen_port_assign
+    `AXI_LITE_ASSIGN_TO_REQ    ( slv_reqs[i], slv[i]       )
+    `AXI_LITE_ASSIGN_FROM_RESP ( slv[i],      slv_resps[i] )
+  end
+
+  axi_lite_mailbox #(
+    .MailboxDepth ( MAILBOX_DEPTH  ),
+    .IrqEdgeTrig  ( IRQ_EDGE_TRIG  ),
+    .IrqActHigh   ( IRQ_ACT_HIGH   ),
+    .AxiAddrWidth ( AXI_ADDR_WIDTH ),
+    .AxiDataWidth ( AXI_DATA_WIDTH ),
+    .req_lite_t   ( req_lite_t     ),
+    .resp_lite_t  ( resp_lite_t    )
+  ) i_axi_lite_mailbox (
+    .clk_i,      // Clock
+    .rst_ni,     // Asynchronous reset active low
+    .test_i,     // Testmode enable
+    // slave ports [1:0]
+    .slv_reqs_i  ( slv_reqs  ),
+    .slv_resps_o ( slv_resps ),
+    .irq_o,      // interrupt output for each port
+    .base_addr_i // base address for each port
+  );
+
+  // pragma translate_off
+  `ifndef VERILATOR
+  initial begin
+    assert (slv[0].AXI_ADDR_WIDTH == AXI_ADDR_WIDTH)
+        else $fatal(1, "LITE Interface [0] AXI_ADDR_WIDTH missmatch!");
+    assert (slv[1].AXI_ADDR_WIDTH == AXI_ADDR_WIDTH)
+        else $fatal(1, "LITE Interface [1] AXI_ADDR_WIDTH missmatch!");
+    assert (slv[0].AXI_DATA_WIDTH == AXI_DATA_WIDTH)
+        else $fatal(1, "LITE Interface [0] AXI_DATA_WIDTH missmatch!");
+    assert (slv[1].AXI_DATA_WIDTH == AXI_DATA_WIDTH)
+        else $fatal(1, "LITE Interface [1] AXI_DATA_WIDTH missmatch!");
+  end
+  `endif
+  // pragma translate_on
+endmodule

--- a/test/tb_axi_lite_mailbox.sv
+++ b/test/tb_axi_lite_mailbox.sv
@@ -201,6 +201,19 @@ module tb_axi_lite_mailbox;
     // -------------------------------
     repeat (50) @(posedge clk);
     $info("Test sending data from one to the other slave interface");
+    $display("%0t MST_0> Set write threshold to 100, truncates to depth ", $time());
+    lite_axi_master.write(WIRQT, 64'd100, 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Read out write threshold ", $time());
+    lite_axi_master.read(WIRQT, data, resp);
+    assert (data == data_t'(MailboxDepth - 1)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Set write threshold to 0", $time());
+    lite_axi_master.write(WIRQT, 64'd0, 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
 
     $display("%0t MST_0> Set Read threshold to 100, truncates to depth ", $time());
     lite_axi_master.write(RIRQT, 64'd100, 8'hFF, resp);
@@ -208,7 +221,7 @@ module tb_axi_lite_mailbox;
 
     $display("%0t MST_0> Read out read threshold ", $time());
     lite_axi_master.read(RIRQT, data, resp);
-    assert (data == data_t'(MailboxDepth - 2)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (data == data_t'(MailboxDepth - 1)) else begin test_failed[0]++; $error("Unexpected result"); end
     assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
 
     $display("%0t MST_0> Set Read threshold to 64'd2 ", $time());

--- a/test/tb_axi_lite_mailbox.sv
+++ b/test/tb_axi_lite_mailbox.sv
@@ -422,9 +422,13 @@ module tb_axi_lite_mailbox;
   initial begin : proc_stop_sim
     wait (&end_of_sim);
     repeat (50) @(posedge clk);
-    $info("Simulation stopped as all Masters transferred their data, Success.",);
     $display("Slave port 0 failed tests: %0d", test_failed[0]);
     $display("Slave port 1 failed tests: %0d", test_failed[1]);
+    if (test_failed[0] > 0 || test_failed[1] > 0) begin
+        $fatal(1, "Simulation stopped as assertion errors have been encountered, Failure!!!");
+    end else begin
+        $info("Simulation stopped as all Masters transferred their data, Success.",);
+    end
     $stop();
   end
 

--- a/test/tb_axi_lite_mailbox.sv
+++ b/test/tb_axi_lite_mailbox.sv
@@ -1,0 +1,446 @@
+// Copyright (c) 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Wolfgang Roenninger <wroennin@ethz.ch>
+
+// Directed Verification Testbench for `axi_lite_mailbox`.
+// - On port 0 all registers get read and the expected results asserted.
+// - Read from an empty read FIFO on Port 0 and clear its interrupt
+// - Request some data from the other port.
+//    - Port 0 sends one data_t to the other and sets its read threshold and waits until
+//      port 1 fills the FIFO to a certain value. Port one waits for its interrupt, sets a
+//      write threshold and fills the FIFO, until it reaches it. While the FIFO is filling,
+//      port 0 starts emptying the read FIFO, however is slower than port 1 pushing, as port
+//      0 checks if the FIFO is empty. Port 1 stops sending, when the interrupt for its write
+//      threshold is recieved. Port 0 empties the FIFO completely and resets its read interrupt.
+// - Port 0 flushes both FIFOs
+// - Port 0 enables error interrupt and pushes data until the FIFO errors, then clears it by
+//   flushing the FIFOs and reading the `ERROR` register.
+// - Port 0 makes an unmapped read and write access, and some targeted accesses to get the branch
+//   coverage to 96.25%, the not taken branches have to do with the stalling
+//   capabilities of the slave, when the response path is not ready.
+// Each of these tests has the respective AXI Lite transaction asserted in the expected output.
+// Simulation end tells the number of failed assertions.
+
+`include "axi/typedef.svh"
+`include "axi/assign.svh"
+
+module tb_axi_lite_mailbox;
+  // timing parameters
+  localparam time CyclTime = 10ns;
+  localparam time ApplTime =  2ns;
+  localparam time TestTime =  8ns;
+  // axi configuration
+  localparam int unsigned AxiAddrWidth      =  32'd32;    // Axi Address Width
+  localparam int unsigned AxiDataWidth      =  32'd64;    // Axi Data Width
+
+  // mailbox params
+  localparam int unsigned MailboxDepth = 32'd16;
+
+  typedef logic [AxiAddrWidth-1:0] addr_t; // for sign extension
+  typedef logic [AxiDataWidth-1:0] data_t; // for sign extension
+
+  typedef enum addr_t {
+    MBOXW  = addr_t'(0 * AxiDataWidth/8),
+    MBOXR  = addr_t'(1 * AxiDataWidth/8),
+    STATUS = addr_t'(2 * AxiDataWidth/8),
+    ERROR  = addr_t'(3 * AxiDataWidth/8),
+    WIRQT  = addr_t'(4 * AxiDataWidth/8),
+    RIRQT  = addr_t'(5 * AxiDataWidth/8),
+    IRQS   = addr_t'(6 * AxiDataWidth/8),
+    IRQEN  = addr_t'(7 * AxiDataWidth/8),
+    IRQP   = addr_t'(8 * AxiDataWidth/8),
+    CTRL   = addr_t'(9 * AxiDataWidth/8)
+  } reg_addr_e;
+
+  typedef axi_test::rand_axi_lite_master #(
+    // AXI interface parameters
+    .AW ( AxiAddrWidth        ),
+    .DW ( AxiDataWidth        ),
+    // Stimuli application and test time
+    .TA ( ApplTime            ),
+    .TT ( TestTime            ),
+    .MIN_ADDR ( 32'h0000_0000 ),
+    .MAX_ADDR ( 32'h0001_3000 ),
+    .MAX_READ_TXNS  ( 10 ),
+    .MAX_WRITE_TXNS ( 10 )
+  ) rand_lite_master_t;
+
+  // -------------
+  // DUT signals
+  // -------------
+  logic       clk;
+  // DUT signals
+  logic       rst_n;
+  logic [1:0] end_of_sim;
+
+  logic [1:0] irq;
+
+  int unsigned test_failed [1:0];
+
+  // -------------------------------
+  // AXI Interfaces
+  // -------------------------------
+  AXI_LITE #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth      ),
+    .AXI_DATA_WIDTH ( AxiDataWidth      )
+  ) master [1:0] ();
+  AXI_LITE_DV #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth      ),
+    .AXI_DATA_WIDTH ( AxiDataWidth      )
+  ) master_dv [1:0] (clk);
+  for (genvar i = 0; i < 2; i++) begin : gen_conn_dv_masters
+    `AXI_LITE_ASSIGN           ( master[i],      master_dv[i]    )
+  end
+
+  // Masters control simulation run time
+  initial begin : proc_master_0
+    automatic rand_lite_master_t lite_axi_master = new ( master_dv[0], "MST_0");
+    automatic data_t          data = '0;
+    automatic axi_pkg::resp_t resp = axi_pkg::RESP_SLVERR;
+    // automatic int unsigned    test_failed[0] = 0;
+    automatic int unsigned    loop        = 0;
+    end_of_sim[0] <= 1'b0;
+    lite_axi_master.reset();
+    @(posedge rst_n);
+
+    // -------------------------------
+    // Read all registers anf compare their results
+    // -------------------------------
+    $info("Initial test by reading each register");
+    $display("%0t MST_0> Read register MBOXW ", $time());
+    lite_axi_master.read(MBOXW, data, resp);
+    assert (data == data_t'(32'hFEEDC0DE)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Read register MBOXR, this generates an error ", $time());
+    lite_axi_master.read(MBOXR, data, resp);
+    assert (data == data_t'(32'hFEEDDEAD)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_SLVERR) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Read register STATUS", $time());
+    lite_axi_master.read(STATUS, data, resp);
+    assert (data == data_t'(1)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Read register ERROR ", $time());
+    lite_axi_master.read(ERROR, data, resp);
+    assert (data == data_t'(1)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Read register WIRQT ", $time());
+    lite_axi_master.read(WIRQT, data, resp);
+    assert (data == data_t'(0)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Read register RIRQT ", $time());
+    lite_axi_master.read(RIRQT, data, resp);
+    assert (data == data_t'(0)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Read register IRQS  ", $time());
+    lite_axi_master.read(IRQS, data, resp);
+    assert (data == data_t'(3'b100)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Acknowledge Error by writing to IRQS", $time());
+    lite_axi_master.write(IRQS, 64'h4, 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Read register IRQEN ", $time());
+    lite_axi_master.read(IRQEN, data, resp);
+    assert (data == data_t'(0)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Read register IRQP  ", $time());
+    lite_axi_master.read(IRQP, data, resp);
+    assert (data == data_t'(0)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Read register CTRL  ", $time());
+    lite_axi_master.read(CTRL, data, resp);
+    assert (data == data_t'(0)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    // -------------------------------
+    // Test Read error interrupt on port 0
+    // -------------------------------
+    repeat (50) @(posedge clk);
+    $info("Test error interrupt");
+    $display("%0t MST_0> Enable Error interrupt  ", $time());
+    lite_axi_master.write(IRQEN, data_t'(3'b100), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Read register MBOXR, this generates an error ", $time());
+    lite_axi_master.read(MBOXR, data, resp);
+    assert (data == data_t'(32'hFEEDDEAD)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_SLVERR) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Read register ERROR ", $time());
+    lite_axi_master.read(ERROR, data, resp);
+    assert (data == data_t'(1)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Acknowledge Error by writing to IRQS", $time());
+    lite_axi_master.write(IRQS, data_t'(3'b100), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Disable interrupt", $time());
+    lite_axi_master.write(IRQEN, data_t'(0), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    // -------------------------------
+    // Send data to the other port, and enable interrupt for recieving
+    // -------------------------------
+    repeat (50) @(posedge clk);
+    $info("Test sending data from one to the other slave interface");
+
+    $display("%0t MST_0> Set Read threshold to 100, truncates to depth ", $time());
+    lite_axi_master.write(RIRQT, 64'd100, 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Read out read threshold ", $time());
+    lite_axi_master.read(RIRQT, data, resp);
+    assert (data == data_t'(MailboxDepth - 2)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Set Read threshold to 64'd2 ", $time());
+    lite_axi_master.write(RIRQT, 64'd2, 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Enable Read threshold interrupt  ", $time());
+    lite_axi_master.write(IRQEN, 64'h2, 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    $display("%0t MST_0> Send to slave 1 data  ", $time());
+    lite_axi_master.write(MBOXW, data_t'(32'hFEEDFEED), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    // wait for interrupt
+    wait (irq[0]);
+    $display("%0t MST_0> interrupt recieved, test that it is the expected one  ", $time());
+    lite_axi_master.read(IRQP, data, resp);
+    assert (data == data_t'(3'b010)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.read(STATUS, data, resp);
+    assert (data == data_t'(4'b1000)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+    $display("%0t MST_0> empty data from port  ", $time());
+    while (!data[0]) begin
+      lite_axi_master.read(MBOXR, data, resp);
+      assert (data == data_t'(loop)) else begin test_failed[0]++; $error("Unexpected result"); end
+      assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+      loop ++;
+      lite_axi_master.read(STATUS, data, resp);
+    end
+    $display("%0t MST_0> FIFO is now empty, clear interrupt and disable it  ", $time());
+    lite_axi_master.write(IRQS, data_t'(3'b111), 8'hFF, resp);
+    lite_axi_master.write(IRQEN, data_t'(0), 8'hFF, resp);
+    lite_axi_master.write(RIRQT, data_t'(0), 8'hFF, resp);
+
+    // -------------------------------
+    // Test Flush
+    // -------------------------------
+    repeat (50) @(posedge clk);
+    $info("%0t MST_0> Test Flush all FIFOs  ", $time());
+    lite_axi_master.write(CTRL, data_t'('1), 8'h00, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    lite_axi_master.write(CTRL, data_t'('1), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    // -------------------------------
+    // Fill the write FIFO, until write error interrupt, then flush and clear interrupt
+    // -------------------------------
+    repeat (50) @(posedge clk);
+    $info("%0t MST_0> Test Write error interrupt  ", $time());
+    lite_axi_master.write(IRQEN, data_t'(3'b100), 8'hFF, resp);
+    loop = 0;
+    while (!irq[0]) begin
+      lite_axi_master.write(MBOXW, data_t'(loop), 8'hFF, resp);
+    end
+    lite_axi_master.read(IRQP, data, resp);
+    assert (data == data_t'(3'b100)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.read(ERROR, data, resp);
+    assert (data == data_t'(2'b10)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.write(CTRL, data_t'(2'h01), 8'h01, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.write(IRQS, data_t'(3'b111), 8'h01, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.read(STATUS, data, resp);
+    assert (data == data_t'(4'b0001)) else begin test_failed[0]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    // -------------------------------
+    // Make an unmapped read and write access
+    // -------------------------------
+    repeat (50) @(posedge clk);
+    $info("%0t MST_0> Make an unmapped access read and write ", $time());
+    lite_axi_master.read(addr_t'(16'hDEAD), data, resp);
+    assert (resp == axi_pkg::RESP_SLVERR) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.write(addr_t'(16'hDEAD), data_t'(16'hDEAD), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_SLVERR) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.write(ERROR, data_t'(16'hDEAD), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_SLVERR) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.write(IRQEN, data_t'(16'hDEAD), 8'h00, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.write(IRQS, data_t'(16'hDEAD), 8'h00, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.write(WIRQT, data_t'('1), 8'h00, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.write(WIRQT, data_t'('1), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.write(WIRQT, data_t'('0), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.write(RIRQT, data_t'('1), 8'h00, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.write(RIRQT, data_t'('1), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+    lite_axi_master.write(WIRQT, data_t'('0), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
+
+    end_of_sim[0] <= 1'b1;
+  end
+
+  initial begin : proc_master_1
+    automatic rand_lite_master_t lite_axi_master = new ( master_dv[1], "MST_1");
+    //automatic int unsigned    test_failed = 0;
+    automatic data_t          data        = '0;
+    automatic axi_pkg::resp_t resp        = axi_pkg::RESP_SLVERR;
+    automatic int unsigned    loop        = 0;
+    end_of_sim[1] <= 1'b0;
+    lite_axi_master.reset();
+    @(posedge rst_n);
+
+    // -------------------------------
+    // Test Flush seperately
+    // -------------------------------
+    $display("%0t MST_1> Flush Read MBOX ", $time());
+    lite_axi_master.write(CTRL, data_t'(2'b10), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+
+    $display("%0t MST_1> Flush Write MBOX ", $time());
+    lite_axi_master.write(CTRL, data_t'(2'b01), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+
+    // -------------------------------
+    // Set read and write thresholds, wait for reflect some data
+    // -------------------------------
+    $display("%0t MST_1> Set Read threshold to 64'd0 ", $time());
+    lite_axi_master.write(RIRQT, data_t'(0), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+
+    $display("%0t MST_1> Enable Read threshold interrupt  ", $time());
+    lite_axi_master.write(IRQEN, data_t'(2), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+
+    $display("%0t MST_1> Wait for Read threshold interrupt  ", $time());
+    wait (irq[1]);
+    $display("%0t MST_1> Interrupt Recieved, read pending register and Acknowledge irq ", $time());
+    lite_axi_master.read(IRQP, data, resp);
+    assert (data == data_t'(2)) else begin test_failed[1]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+    lite_axi_master.read(IRQS, data, resp);
+    assert (data == data_t'(2)) else begin test_failed[1]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+    lite_axi_master.read(MBOXR, data, resp);
+    assert (data == data_t'(32'hFEEDFEED)) else begin test_failed[1]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+    lite_axi_master.write(IRQS, data_t'(2), 8'h1, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+
+    $display("%0t MST_1> Enable write threshold interrupt ", $time());
+    lite_axi_master.write(WIRQT, 32'h8, 8'h1, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+    lite_axi_master.write(IRQEN, data_t'(1), 8'hFF, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+
+    $display("%0t MST_1> Write back looping answer ", $time());
+    while (!irq[1]) begin
+      lite_axi_master.write(MBOXW, data_t'(loop), 8'hFF, resp);
+      assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+      loop++;
+    end
+    $display("%0t MST_1> Stop looping answer and clear interrupt", $time());
+    lite_axi_master.read(IRQP, data, resp);
+    assert (data == data_t'(1)) else begin test_failed[1]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+    lite_axi_master.read(IRQS, data, resp);
+    assert (data == data_t'(1)) else begin test_failed[1]++; $error("Unexpected result"); end
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+    // clear the interrupt, if the Write FIFO is status reg is below threshold
+    lite_axi_master.read(STATUS, data, resp);
+    while (data[3]) begin
+      repeat (10) @(posedge clk);
+      lite_axi_master.read(STATUS, data, resp);
+      assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+    end
+    lite_axi_master.write(IRQS, data_t'(2), 8'h1, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+    lite_axi_master.write(IRQEN, data_t'(0), 8'h1, resp);
+    assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[1]++; $error("Unexpected result"); end
+
+    end_of_sim[1] <= 1'b1;
+  end
+
+  initial begin : proc_monitor_irq_0
+    forever begin
+      @(posedge irq[0]);
+      $info("Recieved interrupt from slave port 0");
+    end
+  end
+
+  initial begin : proc_monitor_irq_1
+    forever begin
+      @(posedge irq[1]);
+      $info("Recieved interrupt from slave port 1");
+    end
+  end
+
+  initial begin : proc_stop_sim
+    wait (&end_of_sim);
+    repeat (50) @(posedge clk);
+    $info("Simulation stopped as all Masters transferred their data, Success.",);
+    $display("Slave port 0 failed tests: %0d", test_failed[0]);
+    $display("Slave port 1 failed tests: %0d", test_failed[1]);
+    $stop();
+  end
+
+  //-----------------------------------
+  // Clock generator
+  //-----------------------------------
+  clk_rst_gen #(
+    .CLK_PERIOD    ( CyclTime ),
+    .RST_CLK_CYCLES( 5        )
+  ) i_clk_gen (
+    .clk_o (clk),
+    .rst_no(rst_n)
+  );
+
+  //-----------------------------------
+  // DUT
+  //-----------------------------------
+  axi_lite_mailbox_intf #(
+    .MAILBOX_DEPTH  ( MailboxDepth ),
+    .IRQ_EDGE_TRIG  ( 1'b0         ),
+    .IRQ_ACT_HIGH   ( 1'b1         ),
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( AxiDataWidth )
+  ) i_mailbox_dut (
+    .clk_i       ( clk       ),
+    .rst_ni      ( rst_n     ),
+    .test_i      ( 1'b0      ),
+    .slv         ( master    ),
+    .irq_o       ( irq       ),
+    .base_addr_i ( '0        ) // set base address to '0
+  );
+endmodule

--- a/test/tb_axi_lite_mailbox.sv
+++ b/test/tb_axi_lite_mailbox.sv
@@ -272,7 +272,7 @@ module tb_axi_lite_mailbox;
     lite_axi_master.read(ERROR, data, resp);
     assert (data == data_t'(2'b10)) else begin test_failed[0]++; $error("Unexpected result"); end
     assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
-    lite_axi_master.write(CTRL, data_t'(2'h01), 8'h01, resp);
+    lite_axi_master.write(CTRL, data_t'(2'b01), 8'h01, resp);
     assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end
     lite_axi_master.write(IRQS, data_t'(3'b111), 8'h01, resp);
     assert (resp == axi_pkg::RESP_OKAY) else begin test_failed[0]++; $error("Unexpected result"); end

--- a/test/tb_axi_lite_mailbox.wave.do
+++ b/test/tb_axi_lite_mailbox.wave.do
@@ -1,0 +1,63 @@
+log -r /*
+onerror {resume}
+quietly WaveActivateNextPane {} 0
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/clk_i
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/rst_ni
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/test_i
+add wave -noupdate -divider Ports
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/slv_reqs_i
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/slv_resps_o
+add wave -noupdate -divider IRQ
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/irq_o
+add wave -noupdate -divider {Mailbox FIFO status}
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/mbox_full
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/mbox_empty
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/mbox_push
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/mbox_pop
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/w_mbox_flush
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/r_mbox_flush
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/mbox_w_data
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/mbox_r_data
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/mbox_usage
+add wave -noupdate -divider {Port 0 internal}
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_0/w_reg_idx
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_0/r_reg_idx
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_0/status_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_0/error_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_0/wirqt_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_0/rirqt_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_0/irqs_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_0/irqen_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_0/irqp_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_0/ctrl_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_0/update_regs
+add wave -noupdate -divider {Port 1 internal}
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_1/w_reg_idx
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_1/r_reg_idx
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_1/status_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_1/error_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_1/wirqt_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_1/rirqt_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_1/irqs_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_1/irqen_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_1/irqp_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_1/ctrl_q
+add wave -noupdate /tb_axi_lite_mailbox/i_mailbox_dut/i_axi_lite_mailbox/i_slv_port_1/update_regs
+TreeUpdate [SetDefaultTree]
+WaveRestoreCursors {{Cursor 1} {2613 ns} 0}
+quietly wave cursor active 1
+configure wave -namecolwidth 415
+configure wave -valuecolwidth 123
+configure wave -justifyvalue left
+configure wave -signalnamewidth 0
+configure wave -snapdistance 10
+configure wave -datasetprefix 0
+configure wave -rowmargin 4
+configure wave -childrowmargin 2
+configure wave -gridoffset 0
+configure wave -gridperiod 1
+configure wave -griddelta 40
+configure wave -timeline 0
+configure wave -timelineunits ns
+update
+WaveRestoreZoom {0 ns} {5103 ns}


### PR DESCRIPTION
Added an AXI LITE Mailbox.
Has two AXI LITE slave ports. The write of on port is connected to the other port via a FIFO and vice versa.
Each port has its own `irq_o` which can be configured to trigger on different conditions.
The irq's are `write threshold`, `read threshold` and `mailbox error`.
The added documentation in /doc/axi_lite_mailbox.md goes in detail over the usage of the module registers.
(Note: this pull request depends on the axi_test/rand_axi_lite_master from the axi_lite_xbar branch)