### PR TITLE
Add fix for vivado not correctly extending enum with '1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- `axi_pkg`: Fix value of `CUT_ALL_PORTS` (in `xbar_latency_e`) in Vivado synthesis.
 
 
 ## 0.9.1 - 2020-01-18

--- a/doc/axi_xbar.md
+++ b/doc/axi_xbar.md
@@ -60,6 +60,7 @@ The other parameters are types to define the ports of the crossbar.  The `*_chan
 The `LatencyMode` parameter allows to insert spill registers after each channel (AW, W, B, AR, and R) of each master port (i.e., each multiplexer) and before each channel of each slave port (i.e., each demultiplexer).  Spill registers cut combinatorial paths, so this parameter reduces the length of combinatorial paths through the crossbar.
 
 Some common configurations are given in the `xbar_latency_e` `enum`.  The recommended configuration (`CUT_ALL_AX`) is to have a latency of 2 on the AW and AR channels because these channels have the most combinatorial logic on them.  Additionally, `FallThrough` should be set to `0` to prevent logic on the AW channel from extending combinatorial paths on the W channel.  However, it is possible to run the crossbar in a fully combinatorial configuration by setting `LatencyMode` to `NO_LATENCY` and `FallThrough` to `1`.
+If two crossbars are connected in both directions, meaning both have one of their master_ports connected to a slave_port of the other it is required to have either `CUT_SLV_PORTS`, `CUT_MST_PORTS` or `CUT_ALL_PORTS` as the configuration of the two crossbars. This is to prevent timing loops as the other configurations will lead to timing loops in simulation and synthesis on the not cut channels between the two crossbars.
 
 
 ## Ports

--- a/doc/axi_xbar.md
+++ b/doc/axi_xbar.md
@@ -60,7 +60,8 @@ The other parameters are types to define the ports of the crossbar.  The `*_chan
 The `LatencyMode` parameter allows to insert spill registers after each channel (AW, W, B, AR, and R) of each master port (i.e., each multiplexer) and before each channel of each slave port (i.e., each demultiplexer).  Spill registers cut combinatorial paths, so this parameter reduces the length of combinatorial paths through the crossbar.
 
 Some common configurations are given in the `xbar_latency_e` `enum`.  The recommended configuration (`CUT_ALL_AX`) is to have a latency of 2 on the AW and AR channels because these channels have the most combinatorial logic on them.  Additionally, `FallThrough` should be set to `0` to prevent logic on the AW channel from extending combinatorial paths on the W channel.  However, it is possible to run the crossbar in a fully combinatorial configuration by setting `LatencyMode` to `NO_LATENCY` and `FallThrough` to `1`.
-If two crossbars are connected in both directions, meaning both have one of their master_ports connected to a slave_port of the other it is required to have either `CUT_SLV_PORTS`, `CUT_MST_PORTS` or `CUT_ALL_PORTS` as the configuration of the two crossbars. This is to prevent timing loops as the other configurations will lead to timing loops in simulation and synthesis on the not cut channels between the two crossbars.
+
+If two crossbars are connected in both directions, meaning both have one of their master ports connected to a slave port of the other, the `LatencyMode` of both crossbars must be set to either `CUT_SLV_PORTS`, `CUT_MST_PORTS`, or `CUT_ALL_PORTS`.  Any other latency mode will lead to timing loops on the uncut channels between the two crossbars.  The latency mode of the two crossbars does not have to be identical.
 
 
 ## Ports

--- a/src/axi_pkg.sv
+++ b/src/axi_pkg.sv
@@ -164,13 +164,13 @@ package axi_pkg;
   localparam logic [9:0] MuxAr   = (1 << 1);
   localparam logic [9:0] MuxR    = (1 << 0);
   typedef enum logic [9:0] {
-    NO_LATENCY    = '0,
+    NO_LATENCY    = 10'b000_00_000_00,
     CUT_SLV_AX    = DemuxAw | DemuxAr,
     CUT_MST_AX    = MuxAw | MuxAr,
     CUT_ALL_AX    = DemuxAw | DemuxAr | MuxAw | MuxAr,
     CUT_SLV_PORTS = DemuxAw | DemuxW | DemuxB | DemuxAr | DemuxR,
     CUT_MST_PORTS = MuxAw | MuxW | MuxB | MuxAr | MuxR,
-    CUT_ALL_PORTS = '1
+    CUT_ALL_PORTS = 10'b111_11_111_11
   } xbar_latency_e;
   typedef struct packed {
     int unsigned   NoSlvPorts;


### PR DESCRIPTION
* Fix xbar_latency_e with explicit `CUT_ALL_PORTS`, issue is that vivado incorrectly extends 
`enum logic [9:0] LatencyMode = '1` to 10'b000000001. Workaround: explicit definition
* Add note in [doc/axi_xbar.md](https://github.com/WRoenninger/axi/blob/axi_pkg_vivado_fix/doc/axi_xbar.md) how `LatencyMode` should be configured when connecting two `axi_xbar` in duplex.