### PR TITLE
Fix demux intf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_cdc`: Add a safe AXI clock domain crossing (CDC) implementation.
 
 ### Changed
+- The interface variants of `axi_demux` and `axi_mux` have been changed to match the convention for
+  interface variants in this repository:
+  - `axi_demux_wrap`: Change name to `axi_demux_intf` and change parameter names to ALL_CAPS.
+  - `axi_mux_wrap`: Change name to `axi_mux_intf`, and change parameter names to ALL_CAPS.
+- `axi_demux`: Default parameters to `0`.
 
 ### Fixed
+- `axi_demux`: Add parameter case for `NoMstPorts == 1`.
 
 
 ## 0.10.2 - 2020-02-13

--- a/src/axi_mux.sv
+++ b/src/axi_mux.sv
@@ -24,7 +24,7 @@
 
 module axi_mux #(
   // AXI parameter and channel types
-  parameter int unsigned SlvAxiIDWidth = 0,     // AXI ID width, slave ports
+  parameter int unsigned SlvAxiIDWidth = 32'd0, // AXI ID width, slave ports
   parameter type         slv_aw_chan_t = logic, // AW Channel Type, slave ports
   parameter type         mst_aw_chan_t = logic, // AW Channel Type, master port
   parameter type         w_chan_t      = logic, //  W Channel Type, all ports
@@ -38,9 +38,9 @@ module axi_mux #(
   parameter type         slv_resp_t    = logic, // Slave port response type
   parameter type         mst_req_t     = logic, // Master ports request type
   parameter type         mst_resp_t    = logic, // Master ports response type
-  parameter int unsigned NoSlvPorts    = 0,     // Number of slave ports
+  parameter int unsigned NoSlvPorts    = 32'd0, // Number of slave ports
   // Maximum number of outstanding transactions per write
-  parameter int unsigned MaxWTrans     = 8,
+  parameter int unsigned MaxWTrans     = 32'd8,
   // If enabled, this multiplexer is purely combinatorial
   parameter bit          FallThrough   = 1'b0,
   // add spill register on write master ports, adds a cycle latency on write channels
@@ -419,95 +419,95 @@ endmodule
 // interface wrap
 `include "axi/assign.svh"
 `include "axi/typedef.svh"
-module axi_mux_wrap #(
-  parameter int unsigned SlvAxiIDWidth = 0, // Synopsys DC requires a default value for parameters.
-  parameter int unsigned MstAxiIDWidth = 0,
-  parameter int unsigned AxiAddrWidth  = 0,
-  parameter int unsigned AxiDataWidth  = 0,
-  parameter int unsigned AxiUserWidth  = 0,
-  parameter int unsigned NoSlvPorts    = 0, // Number of slave ports
+module axi_mux_intf #(
+  parameter int unsigned SLV_AXI_ID_WIDTH = 32'd0, // Synopsys DC requires default value for params
+  parameter int unsigned MST_AXI_ID_WIDTH = 32'd0,
+  parameter int unsigned AXI_ADDR_WIDTH   = 32'd0,
+  parameter int unsigned AXI_DATA_WIDTH   = 32'd0,
+  parameter int unsigned AXI_USER_WIDTH   = 32'd0,
+  parameter int unsigned NO_SLV_PORTS     = 32'd0, // Number of slave ports
   // Maximum number of outstanding transactions per write
-  parameter int unsigned MaxWTrans     = 8,
+  parameter int unsigned MAX_W_TRANS      = 32'd8,
   // if enabled, this multiplexer is purely combinatorial
-  parameter bit          FallThrough   = 1'b0,
+  parameter bit          FALL_THROUGH     = 1'b0,
   // add spill register on write master ports, adds a cycle latency on write channels
-  parameter bit          SpillAw       = 1'b1,
-  parameter bit          SpillW        = 1'b0,
-  parameter bit          SpillB        = 1'b0,
+  parameter bit          SPILL_AW         = 1'b1,
+  parameter bit          SPILL_W          = 1'b0,
+  parameter bit          SPILL_B          = 1'b0,
   // add spill register on read master ports, adds a cycle latency on read channels
-  parameter bit          SpillAr       = 1'b1,
-  parameter bit          SpillR        = 1'b0
+  parameter bit          SPILL_AR         = 1'b1,
+  parameter bit          SPILL_R          = 1'b0
 ) (
-  input  logic   clk_i,                // Clock
-  input  logic   rst_ni,               // Asynchronous reset active low
-  input  logic   test_i,               // Testmode enable
-  AXI_BUS.Slave  slv [NoSlvPorts-1:0], // slave ports
-  AXI_BUS.Master mst                   // master port
+  input  logic   clk_i,                  // Clock
+  input  logic   rst_ni,                 // Asynchronous reset active low
+  input  logic   test_i,                 // Testmode enable
+  AXI_BUS.Slave  slv [NO_SLV_PORTS-1:0], // slave ports
+  AXI_BUS.Master mst                     // master port
 );
 
-  typedef logic [SlvAxiIDWidth-1:0]  slv_id_t;
-  typedef logic [MstAxiIDWidth-1:0]  mst_id_t;
-  typedef logic [AxiAddrWidth-1:0]   addr_t;
-  typedef logic [AxiDataWidth-1:0]   data_t;
-  typedef logic [AxiDataWidth/8-1:0] strb_t;
-  typedef logic [AxiUserWidth-1:0]   user_t;
+  typedef logic [SLV_AXI_ID_WIDTH-1:0] slv_id_t;
+  typedef logic [MST_AXI_ID_WIDTH-1:0] mst_id_t;
+  typedef logic [AXI_ADDR_WIDTH -1:0]  addr_t;
+  typedef logic [AXI_DATA_WIDTH-1:0]   data_t;
+  typedef logic [AXI_DATA_WIDTH/8-1:0] strb_t;
+  typedef logic [AXI_USER_WIDTH-1:0]   user_t;
   // channels typedef
-  `AXI_TYPEDEF_AW_CHAN_T( slv_aw_chan_t, addr_t, slv_id_t,         user_t);
-  `AXI_TYPEDEF_AW_CHAN_T( mst_aw_chan_t, addr_t, mst_id_t,         user_t);
+  `AXI_TYPEDEF_AW_CHAN_T( slv_aw_chan_t, addr_t, slv_id_t, user_t )
+  `AXI_TYPEDEF_AW_CHAN_T( mst_aw_chan_t, addr_t, mst_id_t, user_t )
 
-  `AXI_TYPEDEF_W_CHAN_T (      w_chan_t, data_t,       strb_t, user_t);
+  `AXI_TYPEDEF_W_CHAN_T (      w_chan_t, data_t,   strb_t, user_t )
 
-  `AXI_TYPEDEF_B_CHAN_T (  slv_b_chan_t,         slv_id_t,         user_t);
-  `AXI_TYPEDEF_B_CHAN_T (  mst_b_chan_t,         mst_id_t,         user_t);
+  `AXI_TYPEDEF_B_CHAN_T (  slv_b_chan_t,         slv_id_t, user_t )
+  `AXI_TYPEDEF_B_CHAN_T (  mst_b_chan_t,         mst_id_t, user_t )
 
-  `AXI_TYPEDEF_AR_CHAN_T( slv_ar_chan_t, addr_t, slv_id_t,         user_t);
-  `AXI_TYPEDEF_AR_CHAN_T( mst_ar_chan_t, addr_t, mst_id_t,         user_t);
+  `AXI_TYPEDEF_AR_CHAN_T( slv_ar_chan_t, addr_t, slv_id_t, user_t )
+  `AXI_TYPEDEF_AR_CHAN_T( mst_ar_chan_t, addr_t, mst_id_t, user_t )
 
-  `AXI_TYPEDEF_R_CHAN_T (  slv_r_chan_t, data_t, slv_id_t,         user_t);
-  `AXI_TYPEDEF_R_CHAN_T (  mst_r_chan_t, data_t, mst_id_t,         user_t);
+  `AXI_TYPEDEF_R_CHAN_T (  slv_r_chan_t, data_t, slv_id_t, user_t )
+  `AXI_TYPEDEF_R_CHAN_T (  mst_r_chan_t, data_t, mst_id_t, user_t )
 
-  `AXI_TYPEDEF_REQ_T    (     slv_req_t, slv_aw_chan_t, w_chan_t, slv_ar_chan_t);
-  `AXI_TYPEDEF_RESP_T   (    slv_resp_t,  slv_b_chan_t, slv_r_chan_t) ;
+  `AXI_TYPEDEF_REQ_T    (     slv_req_t, slv_aw_chan_t, w_chan_t, slv_ar_chan_t )
+  `AXI_TYPEDEF_RESP_T   (    slv_resp_t,  slv_b_chan_t, slv_r_chan_t )
 
-  `AXI_TYPEDEF_REQ_T    (     mst_req_t, mst_aw_chan_t, w_chan_t, mst_ar_chan_t);
-  `AXI_TYPEDEF_RESP_T   (    mst_resp_t,  mst_b_chan_t, mst_r_chan_t) ;
+  `AXI_TYPEDEF_REQ_T    (     mst_req_t, mst_aw_chan_t, w_chan_t, mst_ar_chan_t )
+  `AXI_TYPEDEF_RESP_T   (    mst_resp_t,  mst_b_chan_t, mst_r_chan_t )
 
-  slv_req_t     [NoSlvPorts-1:0] slv_reqs;
-  slv_resp_t    [NoSlvPorts-1:0] slv_resps;
-  mst_req_t                      mst_req;
-  mst_resp_t                     mst_resp;
+  slv_req_t  [NO_SLV_PORTS-1:0] slv_reqs;
+  slv_resp_t [NO_SLV_PORTS-1:0] slv_resps;
+  mst_req_t                     mst_req;
+  mst_resp_t                    mst_resp;
 
-  for (genvar i = 0; i < NoSlvPorts; i++) begin : gen_assign_slv_ports
-    `AXI_ASSIGN_TO_REQ    ( slv_reqs[i],  slv[i]       );
-    `AXI_ASSIGN_FROM_RESP ( slv[i],       slv_resps[i] );
+  for (genvar i = 0; i < NO_SLV_PORTS; i++) begin : gen_assign_slv_ports
+    `AXI_ASSIGN_TO_REQ    ( slv_reqs[i],  slv[i]       )
+    `AXI_ASSIGN_FROM_RESP ( slv[i],       slv_resps[i] )
   end
 
-  `AXI_ASSIGN_FROM_REQ  ( mst     , mst_req  );
-  `AXI_ASSIGN_TO_RESP   ( mst_resp, mst      );
+  `AXI_ASSIGN_FROM_REQ  ( mst     , mst_req  )
+  `AXI_ASSIGN_TO_RESP   ( mst_resp, mst      )
 
   axi_mux #(
-    .SlvAxiIDWidth ( SlvAxiIDWidth ),
-    .slv_aw_chan_t ( slv_aw_chan_t ), // AW Channel Type, slave ports
-    .mst_aw_chan_t ( mst_aw_chan_t ), // AW Channel Type, master port
-    .w_chan_t      ( w_chan_t      ), //  W Channel Type, all ports
-    .slv_b_chan_t  ( slv_b_chan_t  ), //  B Channel Type, slave ports
-    .mst_b_chan_t  ( mst_b_chan_t  ), //  B Channel Type, master port
-    .slv_ar_chan_t ( slv_ar_chan_t ), // AR Channel Type, slave ports
-    .mst_ar_chan_t ( mst_ar_chan_t ), // AR Channel Type, master port
-    .slv_r_chan_t  ( slv_r_chan_t  ), //  R Channel Type, slave ports
-    .mst_r_chan_t  ( mst_r_chan_t  ), //  R Channel Type, master port
-    .slv_req_t     ( slv_req_t     ),
-    .slv_resp_t    ( slv_resp_t    ),
-    .mst_req_t     ( mst_req_t     ),
-    .mst_resp_t    ( mst_resp_t    ),
-    .NoSlvPorts    ( NoSlvPorts    ), // Number of slave ports
-    .MaxWTrans     ( MaxWTrans     ),
-    .FallThrough   ( FallThrough   ),
-    .SpillAw       ( SpillAw       ),
-    .SpillW        ( SpillW        ),
-    .SpillB        ( SpillB        ),
-    .SpillAr       ( SpillAr       ),
-    .SpillR        ( SpillR        )
+    .SlvAxiIDWidth ( SLV_AXI_ID_WIDTH ),
+    .slv_aw_chan_t ( slv_aw_chan_t    ), // AW Channel Type, slave ports
+    .mst_aw_chan_t ( mst_aw_chan_t    ), // AW Channel Type, master port
+    .w_chan_t      ( w_chan_t         ), //  W Channel Type, all ports
+    .slv_b_chan_t  ( slv_b_chan_t     ), //  B Channel Type, slave ports
+    .mst_b_chan_t  ( mst_b_chan_t     ), //  B Channel Type, master port
+    .slv_ar_chan_t ( slv_ar_chan_t    ), // AR Channel Type, slave ports
+    .mst_ar_chan_t ( mst_ar_chan_t    ), // AR Channel Type, master port
+    .slv_r_chan_t  ( slv_r_chan_t     ), //  R Channel Type, slave ports
+    .mst_r_chan_t  ( mst_r_chan_t     ), //  R Channel Type, master port
+    .slv_req_t     ( slv_req_t        ),
+    .slv_resp_t    ( slv_resp_t       ),
+    .mst_req_t     ( mst_req_t        ),
+    .mst_resp_t    ( mst_resp_t       ),
+    .NoSlvPorts    ( NO_SLV_PORTS     ), // Number of slave ports
+    .MaxWTrans     ( MAX_W_TRANS      ),
+    .FallThrough   ( FALL_THROUGH     ),
+    .SpillAw       ( SPILL_AW         ),
+    .SpillW        ( SPILL_W          ),
+    .SpillB        ( SPILL_B          ),
+    .SpillAr       ( SPILL_AR         ),
+    .SpillR        ( SPILL_R          )
   ) i_axi_mux (
     .clk_i       ( clk_i     ), // Clock
     .rst_ni      ( rst_ni    ), // Asynchronous reset active low


### PR DESCRIPTION
Change `axi_mux` and `axi_demux` interface wrapper name and parameters to be consistent to the other AXI modules with similar constructs.