### PR TITLE
Small improvements to atop_filter, demux, id_prepend, and xbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   has a single bit, and both values were correctly handled in synthesis.  However, when starting
   simulation, the signal has an undefined value, and ModelSim threw warnings that this violated the
   `unique` condition.
+- `axi_id_prepend`: Fix text of some assertion messages.
 - `tb_axi_xbar`: Fix for localparam `AxiIdWidthSlaves` to be dependent on the number of masters.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   has a single bit, and both values were correctly handled in synthesis.  However, when starting
   simulation, the signal has an undefined value, and ModelSim threw warnings that this violated the
   `unique` condition.
-- `axi_id_prepend`: Fix text of some assertion messages.
+- `axi_id_prepend`:
+  - Fix text of some assertion messages.
+  - Fix case of prepending a single-bit ID.
 - `tb_axi_xbar`: Fix for localparam `AxiIdWidthSlaves` to be dependent on the number of masters.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+- `axi_xbar_intf`: Add interface variant of crossbar.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   has a single bit, and both values were correctly handled in synthesis.  However, when starting
   simulation, the signal has an undefined value, and ModelSim threw warnings that this violated the
   `unique` condition.
+- `axi_demux`: Move `typedef` outside `generate` for compatibility with VCS.
 - `axi_id_prepend`:
   - Fix text of some assertion messages.
   - Fix case of prepending a single-bit ID.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- `axi_atop_filter`: Fix ModelSim warnings by adding `default` statement.  The signal in the `case`
+  has a single bit, and both values were correctly handled in synthesis.  However, when starting
+  simulation, the signal has an undefined value, and ModelSim threw warnings that this violated the
+  `unique` condition.
 - `tb_axi_xbar`: Fix for localparam `AxiIdWidthSlaves` to be dependent on the number of masters.
 
 

--- a/src/axi_atop_filter.sv
+++ b/src/axi_atop_filter.sv
@@ -246,6 +246,8 @@ module axi_atop_filter #(
           end
         end
       end
+
+      default: r_state_d = R_FEEDTHROUGH;
     endcase
   end
   // Feed all signals on AR through.

--- a/src/axi_demux.sv
+++ b/src/axi_demux.sv
@@ -51,24 +51,25 @@ module axi_demux #(
 
   localparam int unsigned IdCounterWidth = $clog2(MaxTrans);
 
+  //--------------------------------------
+  // Typedefs for the FIFOs / Queues
+  //--------------------------------------
+  typedef logic [AxiIdWidth-1:0] axi_id_t;
+  typedef struct packed {
+    aw_chan_t aw_chan;
+    select_t  aw_select;
+  } aw_chan_select_t;
+  typedef struct packed {
+    ar_chan_t ar_chan;
+    select_t  ar_select;
+  } ar_chan_select_t;
+
   // pass through if only one master port
   if (NoMstPorts == 32'h1) begin : gen_no_demux
     assign mst_reqs_o[0] = slv_req_i;
     assign slv_resp_o    = mst_resps_i;
   // other non degenerate cases
   end else begin : gen_demux
-    //--------------------------------------
-    // Typedefs for the Fifo's / Queues
-    //--------------------------------------
-    typedef logic [AxiIdWidth-1:0] axi_id_t;
-    typedef struct packed {
-      aw_chan_t aw_chan;
-      select_t  aw_select;
-    } aw_chan_select_t;
-    typedef struct packed {
-      ar_chan_t ar_chan;
-      select_t  ar_select;
-    } ar_chan_select_t;
 
     //--------------------------------------
     //--------------------------------------

--- a/src/axi_id_prepend.sv
+++ b/src/axi_id_prepend.sv
@@ -133,15 +133,15 @@ module axi_id_prepend #(
 
   ar_id   : assert final(
       mst_ar_chans_o[0].id[$bits(slv_ar_chans_i[0].id)-1:0] === slv_ar_chans_i[0].id)
-        else $fatal (1, "Something with the AW channel ID prepending went wrong.");
+        else $fatal (1, "Something with the AR channel ID prepending went wrong.");
   ar_addr : assert final(mst_ar_chans_o[0].addr === slv_ar_chans_i[0].addr)
-      else $fatal (1, "Something with the AW channel ID prepending went wrong.");
+      else $fatal (1, "Something with the AR channel ID prepending went wrong.");
   ar_len  : assert final(mst_ar_chans_o[0].len === slv_ar_chans_i[0].len)
-      else $fatal (1, "Something with the AW channel ID prepending went wrong.");
+      else $fatal (1, "Something with the AR channel ID prepending went wrong.");
   ar_size : assert final(mst_ar_chans_o[0].size === slv_ar_chans_i[0].size)
-      else $fatal (1, "Something with the AW channel ID prepending went wrong.");
+      else $fatal (1, "Something with the AR channel ID prepending went wrong.");
   ar_qos  : assert final(mst_ar_chans_o[0].qos === slv_ar_chans_i[0].qos)
-      else $fatal (1, "Something with the AW channel ID prepending went wrong.");
+      else $fatal (1, "Something with the AR channel ID prepending went wrong.");
 
   r_id    : assert final(mst_r_chans_i[0].id[$bits(slv_r_chans_o[0].id)-1:0] === slv_r_chans_o[0].id)
       else $fatal (1, "Something with the R channel ID stripping went wrong.");


### PR DESCRIPTION
### Added
- `axi_xbar_intf`: Add interface variant of crossbar.

### Fixed
- `axi_atop_filter`: Fix ModelSim warnings by adding `default` statement.  The signal in the `case`   has a single bit, and both values were correctly handled in synthesis.  However, when starting   simulation, the signal has an undefined value, and ModelSim threw warnings that this violated the   `unique` condition.
- `axi_demux`: Move `typedef` outside `generate` for compatibility with VCS.
- `axi_id_prepend`:
  - Fix text of some assertion messages.
  - Fix case of prepending a single-bit ID.