### PR TITLE
axi_demux: Add `unique` to `case` distinction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_to_axi_lite`: Rework module to structs and add burst support.
 
 ### Fixed
+- `axi_demux`: The `case` statement controlling the counters had not been specified `unique` even
+  though it qualified for it.  This has been fixed.
 
 
 ## 0.14.0 - 2020-02-24

--- a/src/axi_demux.sv
+++ b/src/axi_demux.sv
@@ -578,7 +578,7 @@ module axi_demux_id_counters #(
     logic cnt_en, cnt_down, overflow;
     cnt_t cnt_delta, in_flight;
     always_comb begin
-      case ({push_en[i], inject_en[i], pop_en[i]})
+      unique case ({push_en[i], inject_en[i], pop_en[i]})
         3'b001  : begin // pop_i = -1
           cnt_en    = 1'b1;
           cnt_down  = 1'b1;


### PR DESCRIPTION
The `case` statement controlling the counters had not been specified `unique` even though it qualified for it.  This has been fixed.