### PR TITLE
axi_atop_filter: Fix W handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
-- `axi_top_filter`: Connect W channel to the master port on non Atop AW requests (`aw_valid == 1`). Fix for when the slave wants AW and W valid before asserting its ready.
+- `axi_top_filter`: The master interface of this module in one case depended on `aw_ready` before
+  applying `w_valid`, which is a violation of the AXI specification that can lead to deadlocks.
+  This issue has been fixed by removing that dependency.
 
 
 ## 0.15.0 - 2020-02-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- `axi_top_filter`: Connect W channel to the master port on non Atop AW requests (`aw_valid == 1`). Fix for when the slave wants AW and W valid before asserting its ready.
 
 
 ## 0.15.0 - 2020-02-28

--- a/src/axi_atop_filter.sv
+++ b/src/axi_atop_filter.sv
@@ -99,10 +99,12 @@ module axi_atop_filter #(
           mst_req_o.aw_valid  = slv_req_i.aw_valid;
           slv_resp_o.aw_ready = mst_resp_i.aw_ready;
         end
-        // Feed W channel through if at least one AW request is outstanding or a new non atop AW is
-        // initiated.
-        if (((w_cnt_q > 0) && !w_cnt_q[COUNTER_WIDTH]) ||
-            (slv_req_i.aw_valid && slv_req_i.aw.atop[5:4] == axi_pkg::ATOP_NONE)) begin
+        // Feed W channel through if ..
+        if (((w_cnt_q > 0) && !w_cnt_q[COUNTER_WIDTH]) || // at least one AW request is outstanding
+                                                          // and there is no counter underflow, OR
+            (slv_req_i.aw_valid && slv_req_i.aw.atop[5:4] == axi_pkg::ATOP_NONE))
+                                                          // a new non-ATOP AW is being applied
+        begin
           mst_req_o.w_valid  = slv_req_i.w_valid;
           slv_resp_o.w_ready = mst_resp_i.w_ready;
         end

--- a/src/axi_atop_filter.sv
+++ b/src/axi_atop_filter.sv
@@ -50,7 +50,7 @@ module axi_atop_filter #(
 );
 
   localparam int unsigned COUNTER_WIDTH = $clog2(AxiMaxWriteTxns+1);
-  typedef logic [COUNTER_WIDTH:0] cnt_t;
+  typedef logic [COUNTER_WIDTH:0] cnt_t; // one extra bit to capture over/underflow
   cnt_t   w_cnt_d, w_cnt_q;
 
   typedef enum logic [2:0] { W_FEEDTHROUGH, BLOCK_AW, ABSORB_W, INJECT_B, WAIT_R } w_state_t;

--- a/src/axi_atop_filter.sv
+++ b/src/axi_atop_filter.sv
@@ -49,8 +49,8 @@ module axi_atop_filter #(
   input  resp_t mst_resp_i
 );
 
-  localparam int unsigned CounterWidth = $clog2(AxiMaxWriteTxns+1);
-  typedef logic [CounterWidth:0] cnt_t;
+  localparam int unsigned COUNTER_WIDTH = $clog2(AxiMaxWriteTxns+1);
+  typedef logic [COUNTER_WIDTH:0] cnt_t;
   cnt_t   w_cnt_d, w_cnt_q;
 
   typedef enum logic [2:0] { W_FEEDTHROUGH, BLOCK_AW, ABSORB_W, INJECT_B, WAIT_R } w_state_t;
@@ -101,7 +101,7 @@ module axi_atop_filter #(
         end
         // Feed W channel through if at least one AW request is outstanding or a new non atop AW is
         // initiated.
-        if (((w_cnt_q > 0) && !w_cnt_q[CounterWidth]) ||
+        if (((w_cnt_q > 0) && !w_cnt_q[COUNTER_WIDTH]) ||
             (slv_req_i.aw_valid && slv_req_i.aw.atop[5:4] == axi_pkg::ATOP_NONE)) begin
           mst_req_o.w_valid  = slv_req_i.w_valid;
           slv_resp_o.w_ready = mst_resp_i.w_ready;


### PR DESCRIPTION
When the connected slave module wants both AW and W to be valid before asserting thier readys, `axi_atop_filter` was stalling forever and did not let the W valid through.
Added a second condition for when AW is valid and non ATOP then the W handshake gets connected.