### PR TITLE
AXI4-Lite to APB4 Bridge: Update interface version to match changed req ports 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_top_filter`: The master interface of this module in one case depended on `aw_ready` before
   applying `w_valid`, which is a violation of the AXI specification that can lead to deadlocks.
   This issue has been fixed by removing that dependency.
+- `axi_lite_to_apb`: Fix the interface version (`axi_lite_to_apb_intf`) to match the changes from
+  version `0.15.0`.
 
 
 ## 0.15.0 - 2020-02-28


### PR DESCRIPTION
- Change the interface version of the `axi_lite_to_apb` version to match the changes done in #59 