### PR TITLE
axi_demux: Fix case when `MaxTrans` is 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   This issue has been fixed by removing that dependency.
 - `axi_lite_to_apb`: Fix the interface version (`axi_lite_to_apb_intf`) to match the changes from
   version `0.15.0`.
+- `axi_demux`: When `MaxTrans` was 1, the `IdCounterWidth` became 0.  This has been fixed.
 
 
 ## 0.15.0 - 2020-02-28

--- a/src/axi_demux.sv
+++ b/src/axi_demux.sv
@@ -49,7 +49,7 @@ module axi_demux #(
   input  resp_t   [NoMstPorts-1:0] mst_resps_i
 );
 
-  localparam int unsigned IdCounterWidth = $clog2(MaxTrans);
+  localparam int unsigned IdCounterWidth = MaxTrans > 1 ? $clog2(MaxTrans) : 1;
 
   //--------------------------------------
   // Typedefs for the FIFOs / Queues


### PR DESCRIPTION
In case the `MaxTrans` parameter was set to 1, the `IdCounterWidth` was calculated to be 0.