### PR TITLE
Fix axi_atop_filter and improve verification master/slave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_lite_to_apb`: Fix the interface version (`axi_lite_to_apb_intf`) to match the changes from
   version `0.15.0`.
 - `axi_demux`: When `MaxTrans` was 1, the `IdCounterWidth` became 0.  This has been fixed.
-- `rand_axi_master` (in `axi_test`): Fix infinite wait in `send_ws` task.
+- `rand_axi_master` (in `axi_test`):
+  - Fix infinite wait in `send_ws` task.
+  - Decouple generation of AWs from sending them.  This allows to apply W beats before or
+    simultaneous with AW beats.
 
 
 ## 0.15.0 - 2020-02-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - The master interface of this module in one case depended on `aw_ready` before applying
     `w_valid`, which is a violation of the AXI specification that can lead to deadlocks.  This issue
     has been fixed by removing that dependency.
-  - The slave interface of this module could illegally change the value of R beats between valid and
-    handshake.  This has been fixed.
+  - The slave interface of this module could illegally change the value of B and R beats between
+    valid and handshake.  This has been fixed.
 - `rand_axi_master` (in `axi_test`):
   - Fix infinite wait in `send_ws` task.
   - Decouple generation of AWs from sending them.  This allows to apply W beats before or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_lite_to_apb`: Fix the interface version (`axi_lite_to_apb_intf`) to match the changes from
   version `0.15.0`.
 - `axi_demux`: When `MaxTrans` was 1, the `IdCounterWidth` became 0.  This has been fixed.
-- `axi_top_filter`:
+- `axi_atop_filter`:
   - The master interface of this module in one case depended on `aw_ready` before applying
     `w_valid`, which is a violation of the AXI specification that can lead to deadlocks.  This issue
     has been fixed by removing that dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+- `axi_intf`: Add single-channel assertions to `AXI_BUS_DV`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
-- `axi_top_filter`: The master interface of this module in one case depended on `aw_ready` before
-  applying `w_valid`, which is a violation of the AXI specification that can lead to deadlocks.
-  This issue has been fixed by removing that dependency.
 - `axi_lite_to_apb`: Fix the interface version (`axi_lite_to_apb_intf`) to match the changes from
   version `0.15.0`.
 - `axi_demux`: When `MaxTrans` was 1, the `IdCounterWidth` became 0.  This has been fixed.
+- `axi_top_filter`:
+  - The master interface of this module in one case depended on `aw_ready` before applying
+    `w_valid`, which is a violation of the AXI specification that can lead to deadlocks.  This issue
+    has been fixed by removing that dependency.
+  - The slave interface of this module could illegally change the value of R beats between valid and
+    handshake.  This has been fixed.
 - `rand_axi_master` (in `axi_test`):
   - Fix infinite wait in `send_ws` task.
   - Decouple generation of AWs from sending them.  This allows to apply W beats before or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Fix infinite wait in `send_ws` task.
   - Decouple generation of AWs from sending them.  This allows to apply W beats before or
     simultaneous with AW beats.
+- `rand_axi_slave` (in `axi_test`):
+  - Decouple receiving of Ws from receiving of AWs.  This allows to receive W beats independent of
+    AW beats.
 
 
 ## 0.15.0 - 2020-02-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_lite_to_apb`: Fix the interface version (`axi_lite_to_apb_intf`) to match the changes from
   version `0.15.0`.
 - `axi_demux`: When `MaxTrans` was 1, the `IdCounterWidth` became 0.  This has been fixed.
+- `rand_axi_master` (in `axi_test`): Fix infinite wait in `send_ws` task.
 
 
 ## 0.15.0 - 2020-02-28

--- a/src/axi_atop_filter.sv
+++ b/src/axi_atop_filter.sv
@@ -55,11 +55,11 @@ module axi_atop_filter #(
 
   typedef enum logic [2:0] {
     W_FEEDTHROUGH, BLOCK_AW, ABSORB_W, HOLD_B, INJECT_B, WAIT_R
-  } w_state_t;
-  w_state_t   w_state_d, w_state_q;
+  } w_state_e;
+  w_state_e   w_state_d, w_state_q;
 
-  typedef enum logic [1:0] { R_FEEDTHROUGH, INJECT_R, R_HOLD } r_state_t;
-  r_state_t   r_state_d, r_state_q;
+  typedef enum logic [1:0] { R_FEEDTHROUGH, INJECT_R, R_HOLD } r_state_e;
+  r_state_e   r_state_d, r_state_q;
 
   typedef logic [AxiIdWidth-1:0] id_t;
   id_t  id_d, id_q;

--- a/src/axi_atop_filter.sv
+++ b/src/axi_atop_filter.sv
@@ -50,7 +50,7 @@ module axi_atop_filter #(
 );
 
   localparam int unsigned COUNTER_WIDTH = $clog2(AxiMaxWriteTxns+1);
-  typedef logic [COUNTER_WIDTH-1:0] cnt_t;
+  typedef logic [COUNTER_WIDTH:0] cnt_t; // one extra bit to capture over/underflow
   cnt_t   w_cnt_d, w_cnt_q;
 
   typedef enum logic [2:0] { W_FEEDTHROUGH, BLOCK_AW, ABSORB_W, INJECT_B, WAIT_R } w_state_t;
@@ -99,10 +99,12 @@ module axi_atop_filter #(
           mst_req_o.aw_valid  = slv_req_i.aw_valid;
           slv_resp_o.aw_ready = mst_resp_i.aw_ready;
         end
-        // Feed W channel through if at least one AW request is outstanding or a new non-ATOP AW is
-        // being applied.
-        if ((w_cnt_q > 0) ||
-            (slv_req_i.aw_valid && slv_req_i.aw.atop[5:4] == axi_pkg::ATOP_NONE)) begin
+        // Feed W channel through if ..
+        if (((w_cnt_q > 0) && !w_cnt_q[COUNTER_WIDTH]) || // at least one AW request is outstanding
+                                                          // and there is no counter underflow, OR
+            (slv_req_i.aw_valid && slv_req_i.aw.atop[5:4] == axi_pkg::ATOP_NONE))
+                                                          // a new non-ATOP AW is being applied
+        begin
           mst_req_o.w_valid  = slv_req_i.w_valid;
           slv_resp_o.w_ready = mst_resp_i.w_ready;
         end
@@ -262,7 +264,7 @@ module axi_atop_filter #(
     if (mst_req_o.aw_valid && mst_resp_i.aw_ready) begin
       w_cnt_d += 1;
     end
-    if (mst_resp_i.b_valid && mst_req_o.b_ready) begin
+    if (mst_req_o.w_valid && mst_resp_i.w_ready && mst_req_o.w.last) begin
       w_cnt_d -= 1;
     end
   end

--- a/src/axi_atop_filter.sv
+++ b/src/axi_atop_filter.sv
@@ -215,8 +215,6 @@ module axi_atop_filter #(
   end
   assign mst_req_o.w = slv_req_i.w;
 
-
-
   // Manage R channel.
   always_comb begin
     // Defaults:

--- a/src/axi_atop_filter.sv
+++ b/src/axi_atop_filter.sv
@@ -77,7 +77,7 @@ module axi_atop_filter #(
         r_resp_cmd_push_valid,  r_resp_cmd_push_ready,
         r_resp_cmd_pop_valid,   r_resp_cmd_pop_ready;
 
-  // A AW without a complete W burst is in-flight downstream if the W counter is > 0 and not
+  // An AW without a complete W burst is in-flight downstream if the W counter is > 0 and not
   // overflowed.
   assign aw_without_complete_w_downstream = !w_cnt_q[COUNTER_WIDTH] && (w_cnt_q > 0);
   // A complete W burst without AW is in-flight downstream if the W counter is -1.

--- a/src/axi_intf.sv
+++ b/src/axi_intf.sv
@@ -22,7 +22,7 @@ interface AXI_BUS #(
   parameter AXI_ID_WIDTH   = -1,
   parameter AXI_USER_WIDTH = -1
 );
-  
+
   import axi_pkg::*;
 
   localparam AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8;

--- a/src/axi_intf.sv
+++ b/src/axi_intf.sv
@@ -188,6 +188,53 @@ interface AXI_BUS_DV #(
     output r_id, r_data, r_resp, r_last, r_user, r_valid, input r_ready
   );
 
+  // Single-Channel Assertions: Signals including valid must not change between valid and handshake.
+  // AW
+  assert property (@(posedge clk_i) (aw_valid && !aw_ready |=> $stable(aw_id)));
+  assert property (@(posedge clk_i) (aw_valid && !aw_ready |=> $stable(aw_addr)));
+  assert property (@(posedge clk_i) (aw_valid && !aw_ready |=> $stable(aw_len)));
+  assert property (@(posedge clk_i) (aw_valid && !aw_ready |=> $stable(aw_size)));
+  assert property (@(posedge clk_i) (aw_valid && !aw_ready |=> $stable(aw_burst)));
+  assert property (@(posedge clk_i) (aw_valid && !aw_ready |=> $stable(aw_lock)));
+  assert property (@(posedge clk_i) (aw_valid && !aw_ready |=> $stable(aw_cache)));
+  assert property (@(posedge clk_i) (aw_valid && !aw_ready |=> $stable(aw_prot)));
+  assert property (@(posedge clk_i) (aw_valid && !aw_ready |=> $stable(aw_qos)));
+  assert property (@(posedge clk_i) (aw_valid && !aw_ready |=> $stable(aw_region)));
+  assert property (@(posedge clk_i) (aw_valid && !aw_ready |=> $stable(aw_atop)));
+  assert property (@(posedge clk_i) (aw_valid && !aw_ready |=> $stable(aw_user)));
+  assert property (@(posedge clk_i) (aw_valid && !aw_ready |=> aw_valid));
+  // W
+  assert property (@(posedge clk_i) ( w_valid && ! w_ready |=> $stable(w_data)));
+  assert property (@(posedge clk_i) ( w_valid && ! w_ready |=> $stable(w_strb)));
+  assert property (@(posedge clk_i) ( w_valid && ! w_ready |=> $stable(w_last)));
+  assert property (@(posedge clk_i) ( w_valid && ! w_ready |=> $stable(w_user)));
+  assert property (@(posedge clk_i) ( w_valid && ! w_ready |=> w_valid));
+  // B
+  assert property (@(posedge clk_i) ( b_valid && ! b_ready |=> $stable(b_id)));
+  assert property (@(posedge clk_i) ( b_valid && ! b_ready |=> $stable(b_resp)));
+  assert property (@(posedge clk_i) ( b_valid && ! b_ready |=> $stable(b_user)));
+  assert property (@(posedge clk_i) ( b_valid && ! b_ready |=> b_valid));
+  // AR
+  assert property (@(posedge clk_i) (ar_valid && !ar_ready |=> $stable(ar_id)));
+  assert property (@(posedge clk_i) (ar_valid && !ar_ready |=> $stable(ar_addr)));
+  assert property (@(posedge clk_i) (ar_valid && !ar_ready |=> $stable(ar_len)));
+  assert property (@(posedge clk_i) (ar_valid && !ar_ready |=> $stable(ar_size)));
+  assert property (@(posedge clk_i) (ar_valid && !ar_ready |=> $stable(ar_burst)));
+  assert property (@(posedge clk_i) (ar_valid && !ar_ready |=> $stable(ar_lock)));
+  assert property (@(posedge clk_i) (ar_valid && !ar_ready |=> $stable(ar_cache)));
+  assert property (@(posedge clk_i) (ar_valid && !ar_ready |=> $stable(ar_prot)));
+  assert property (@(posedge clk_i) (ar_valid && !ar_ready |=> $stable(ar_qos)));
+  assert property (@(posedge clk_i) (ar_valid && !ar_ready |=> $stable(ar_region)));
+  assert property (@(posedge clk_i) (ar_valid && !ar_ready |=> $stable(ar_user)));
+  assert property (@(posedge clk_i) (ar_valid && !ar_ready |=> ar_valid));
+  // R
+  assert property (@(posedge clk_i) ( r_valid && ! r_ready |=> $stable(r_id)));
+  assert property (@(posedge clk_i) ( r_valid && ! r_ready |=> $stable(r_data)));
+  assert property (@(posedge clk_i) ( r_valid && ! r_ready |=> $stable(r_resp)));
+  assert property (@(posedge clk_i) ( r_valid && ! r_ready |=> $stable(r_last)));
+  assert property (@(posedge clk_i) ( r_valid && ! r_ready |=> $stable(r_user)));
+  assert property (@(posedge clk_i) ( r_valid && ! r_ready |=> r_valid));
+
 endinterface
 
 /// An asynchronous AXI4 interface.

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -1049,7 +1049,7 @@ package axi_test;
         automatic ax_beat_t aw_beat;
         automatic addr_t addr;
         static logic rand_success;
-        wait (aw_queue.size() > 0);
+        wait (aw_queue.size() > 0 || (aw_done && aw_queue.size() == 0));
         aw_beat = aw_queue.pop_front();
         addr = aw_beat.ax_addr;
         for (int unsigned i = 0; i < aw_beat.ax_len + 1; i++) begin

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -642,6 +642,7 @@ package axi_test;
     semaphore cnt_sem;
 
     ax_beat_t aw_queue[$],
+              w_queue[$],
               excl_queue[$];
 
     typedef struct packed {
@@ -1004,7 +1005,7 @@ package axi_test;
       end
     endtask
 
-    task send_aws(input int n_writes);
+    task create_aws(input int n_writes);
       automatic logic rand_success;
       repeat (n_writes) begin
         automatic bit excl = 1'b0;
@@ -1039,18 +1040,27 @@ package axi_test;
         end
         tot_w_flight_cnt++;
         aw_queue.push_back(aw_beat);
+        w_queue.push_back(aw_beat);
+      end
+    endtask
+
+    task send_aws(ref logic aw_done);
+      while (!(aw_done && aw_queue.size() == 0)) begin
+        automatic ax_beat_t aw_beat;
+        wait (aw_queue.size() > 0 || (aw_done && aw_queue.size() == 0));
+        aw_beat = aw_queue.pop_front();
         rand_wait(AX_MIN_WAIT_CYCLES, AX_MAX_WAIT_CYCLES);
         drv.send_aw(aw_beat);
       end
     endtask
 
     task send_ws(ref logic aw_done);
-      while (!(aw_done && aw_queue.size() == 0)) begin
+      while (!(aw_done && w_queue.size() == 0)) begin
         automatic ax_beat_t aw_beat;
         automatic addr_t addr;
         static logic rand_success;
-        wait (aw_queue.size() > 0 || (aw_done && aw_queue.size() == 0));
-        aw_beat = aw_queue.pop_front();
+        wait (w_queue.size() > 0 || (aw_done && w_queue.size() == 0));
+        aw_beat = w_queue.pop_front();
         addr = aw_beat.ax_addr;
         for (int unsigned i = 0; i < aw_beat.ax_len + 1; i++) begin
           automatic w_beat_t w_beat = new;
@@ -1103,9 +1113,10 @@ package axi_test;
         end
         recv_rs(ar_done, aw_done);
         begin
-          send_aws(n_writes);
+          create_aws(n_writes);
           aw_done = 1'b1;
         end
+        send_aws(aw_done);
         send_ws(aw_done);
         recv_bs(aw_done);
       join

--- a/test/tb_axi_atop_filter.sv
+++ b/test/tb_axi_atop_filter.sv
@@ -176,6 +176,25 @@ module tb_axi_atop_filter #(
     .DW(AXI_DATA_WIDTH), .UW(AXI_USER_WIDTH)
   ) w_beat_t;
 
+  // Put W beats into transfer queue or drop them and inject B responses based on W command.
+  function automatic void process_w_beat(w_beat_t w_beat, ref w_cmd_t w_cmd_queue[$],
+      ref w_beat_t w_xfer_queue[$], ref b_beat_t b_inject_queue[$]
+  );
+    w_cmd_t w_cmd = w_cmd_queue[0];
+    if (w_cmd.thru) begin
+      w_xfer_queue.push_back(w_beat);
+    end
+    if (w_beat.w_last) begin
+      if (!w_cmd.thru) begin
+        automatic b_beat_t b_beat = new;
+        b_beat.b_id = w_cmd.id;
+        b_beat.b_resp = RESP_SLVERR;
+        b_inject_queue.push_back(b_beat);
+      end
+      void'(w_cmd_queue.pop_front());
+    end
+  endfunction
+
   // Monitor and check responses of filter.
   initial begin
     static ax_beat_t  ar_xfer_queue[$],
@@ -186,6 +205,7 @@ module tb_axi_atop_filter #(
                       r_xfer_queue[$];
     static w_cmd_t    w_cmd_queue[$];
     static w_beat_t   w_act_queue[$],
+                      w_undecided_queue[$],
                       w_xfer_queue[$];
     forever begin
       @(posedge clk);
@@ -243,28 +263,22 @@ module tb_axi_atop_filter #(
           end
         end
       end
-      // Push upstream Ws that must go through into transfer queue; push to B and R inject queue for
-      // completed W bursts that must not go through.
+      // Handle undecided upstream W beats if possible.
+      while (w_undecided_queue.size() > 0 && w_cmd_queue.size() > 0) begin
+        automatic w_beat_t w_beat = w_undecided_queue.pop_front();
+        process_w_beat(w_beat, w_cmd_queue, w_xfer_queue, b_inject_queue);
+      end
+      // Process upstream W beats or put them into queue of undecided W beats.
       if (upstream.w_valid && upstream.w_ready) begin
         automatic w_beat_t w_beat = new;
-        automatic w_cmd_t w_cmd;
         w_beat.w_data = upstream.w_data;
         w_beat.w_strb = upstream.w_strb;
         w_beat.w_last = upstream.w_last;
         w_beat.w_user = upstream.w_user;
-        assert (w_cmd_queue.size() > 0) else $fatal(1, "upstream.W: Undecided beat!");
-        w_cmd = w_cmd_queue[0];
-        if (w_cmd.thru) begin
-          w_xfer_queue.push_back(w_beat);
-        end
-        if (w_beat.w_last) begin
-          if (!w_cmd.thru) begin
-            automatic b_beat_t b_beat = new;
-            b_beat.b_id = w_cmd.id;
-            b_beat.b_resp = RESP_SLVERR;
-            b_inject_queue.push_back(b_beat);
-          end
-          void'(w_cmd_queue.pop_front());
+        if (w_cmd_queue.size() > 0) begin
+          process_w_beat(w_beat, w_cmd_queue, w_xfer_queue, b_inject_queue);
+        end else begin
+          w_undecided_queue.push_back(w_beat);
         end
       end
       // Push downstream Rs into transfer queue.


### PR DESCRIPTION
This fixes a couple of issues with the ATOP filter:
- A [recent change](https://github.com/pulp-platform/axi/commit/c4f97d9ac9c923ef7606da7033a7b0c557b2b2fa) broke the internal controller, which needs to relate W bursts to AW beats, not to W beats. Reverting this, however, led to underflows in an internal counter, due to [another recent change](https://github.com/pulp-platform/axi/pull/64). Counter underflows are now prevented through [additional conditions](https://github.com/pulp-platform/axi/commit/6bb4d4bf723549d38537e9b900a106fface860c2).
- The filter injected B and R responses even when the handshake of a beat signaled valid had not been completed yet.

The TB of the ATOP filter has been updated to cope with B bursts being fed through before AW beats.

Additionally, this PR improves our verification modules:
- It adds stability property assertions to the verification interface.
- It fixes an infinite wait in `rand_axi_master`.
- It decouples the generation of AWs from sending them in `rand_axi_master`, so W bursts can now "overtake" AW beats.
- It decouples receiving Ws from receiving AWs in `rand_axi_slave`, so W bursts can now "overtake" AW beats.