### PR TITLE
Remove global package imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_intf`: Remove global `import axi_pkg::*` and explicitly use symbols from `axi_pkg`.
 - `axi_lite_cut_intf`: Add missing assigns to and from interface ports.
 
+### Removed
+- Remove unused `AXI_ROUTING_RULES` interface.
+
 
 ## 0.15.1 - 2020-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - `axi_cdc`: Remove unused global `import axi_pkg::*`.
+- `axi_lite_cut_intf`: Add missing assigns to and from interface ports.
 
 
 ## 0.15.1 - 2020-03-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_lite_cut_intf`: Add missing assigns to and from interface ports.
 
 ### Removed
-- Remove unused `AXI_ROUTING_RULES` interface.
+- Remove unused `AXI_ARBITRATION` and `AXI_ROUTING_RULES` interfaces.
 
 
 ## 0.15.1 - 2020-03-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_cdc`: Remove unused global `import axi_pkg::*`.
 - `axi_intf`: Remove global `import axi_pkg::*` and explicitly use symbols from `axi_pkg`.
 - `axi_lite_cut_intf`: Add missing assigns to and from interface ports.
+- `tb_axi_cdc`:
+  - Remove global `import axi_pkg::*`.
+  - Define channels with `AXI_TYPEDEF` macros instead of local `typedef`s.
 
 ### Removed
 - Remove unused `AXI_ARBITRATION` and `AXI_ROUTING_RULES` interfaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - `axi_cdc`: Remove unused global `import axi_pkg::*`.
+- `axi_intf`: Remove global `import axi_pkg::*` and explicitly use symbols from `axi_pkg`.
 - `axi_lite_cut_intf`: Add missing assigns to and from interface ports.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- `axi_cdc`: Remove unused global `import axi_pkg::*`.
 
 
 ## 0.15.1 - 2020-03-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+- `axi_cdc_intf`: Add interface variant of AXI clock domain crossing.
 
 ### Changed
 

--- a/src/axi_cdc.sv
+++ b/src/axi_cdc.sv
@@ -14,7 +14,6 @@
 // Florian Zaruba <zarubaf@iis.ee.ethz.ch>
 
 `include "axi/assign.svh"
-import axi_pkg::*;
 
 /// A clock domain crossing on an AXI interface.
 ///

--- a/src/axi_cdc.sv
+++ b/src/axi_cdc.sv
@@ -190,4 +190,62 @@ module axi_cdc_intf #(
     .dst_resp_i ( dst_resp )
   );
 
-  endmodule
+endmodule
+
+module axi_lite_cdc_intf #(
+  parameter int unsigned AXI_ADDR_WIDTH = 0,
+  parameter int unsigned AXI_DATA_WIDTH = 0,
+  /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
+  parameter int unsigned LOG_DEPTH = 1
+) (
+   // slave side - clocked by `src_clk_i`
+  input  logic      src_clk_i,
+  input  logic      src_rst_ni,
+  AXI_LITE.Slave    src,
+  // master side - clocked by `dst_clk_i`
+  input  logic      dst_clk_i,
+  input  logic      dst_rst_ni,
+  AXI_LITE.Master   dst
+);
+
+  typedef logic [AXI_ADDR_WIDTH-1:0]   addr_t;
+  typedef logic [AXI_DATA_WIDTH-1:0]   data_t;
+  typedef logic [AXI_DATA_WIDTH/8-1:0] strb_t;
+  `AXI_LITE_TYPEDEF_AW_CHAN_T(aw_chan_t, addr_t)
+  `AXI_LITE_TYPEDEF_W_CHAN_T(w_chan_t, data_t, strb_t)
+  `AXI_LITE_TYPEDEF_B_CHAN_T(b_chan_t)
+  `AXI_LITE_TYPEDEF_AR_CHAN_T(ar_chan_t, addr_t)
+  `AXI_LITE_TYPEDEF_R_CHAN_T(r_chan_t, data_t)
+  `AXI_LITE_TYPEDEF_REQ_T(req_t, aw_chan_t, w_chan_t, ar_chan_t)
+  `AXI_LITE_TYPEDEF_RESP_T(resp_t, b_chan_t, r_chan_t)
+
+  req_t  src_req,  dst_req;
+  resp_t src_resp, dst_resp;
+
+  `AXI_LITE_ASSIGN_TO_REQ(src_req, src)
+  `AXI_LITE_ASSIGN_FROM_RESP(src, src_resp)
+
+  `AXI_LITE_ASSIGN_FROM_REQ(dst, dst_req)
+  `AXI_LITE_ASSIGN_TO_RESP(dst_resp, dst)
+
+  axi_cdc #(
+    .aw_chan_t  ( aw_chan_t ),
+    .w_chan_t   ( w_chan_t  ),
+    .b_chan_t   ( b_chan_t  ),
+    .ar_chan_t  ( ar_chan_t ),
+    .r_chan_t   ( r_chan_t  ),
+    .axi_req_t  ( req_t     ),
+    .axi_resp_t ( resp_t    ),
+    .LogDepth   ( LOG_DEPTH )
+  ) i_axi_cdc (
+    .src_clk_i,
+    .src_rst_ni,
+    .src_req_i  ( src_req  ),
+    .src_resp_o ( src_resp ),
+    .dst_clk_i,
+    .dst_rst_ni,
+    .dst_req_o  ( dst_req  ),
+    .dst_resp_i ( dst_resp )
+  );
+
+endmodule

--- a/src/axi_cut.sv
+++ b/src/axi_cut.sv
@@ -223,6 +223,12 @@ module axi_lite_cut_intf #(
   req_t   slv_req,  mst_req;
   resp_t  slv_resp, mst_resp;
 
+  `AXI_LITE_ASSIGN_TO_REQ(slv_req, in)
+  `AXI_LITE_ASSIGN_FROM_RESP(in, slv_resp)
+
+  `AXI_LITE_ASSIGN_FROM_REQ(out, mst_req)
+  `AXI_LITE_ASSIGN_TO_RESP(mst_resp, out)
+
   axi_cut #(
     .Bypass    (    BYPASS ),
     .aw_chan_t ( aw_chan_t ),

--- a/src/axi_intf.sv
+++ b/src/axi_intf.sv
@@ -428,26 +428,3 @@ interface AXI_LITE_DV #(
   );
 
 endinterface
-
-/// An AXI arbitration interface.
-interface AXI_ARBITRATION #(
-  /// The number of requestors.
-  parameter int NUM_REQ = -1
-);
-
-  // Incoming requests.
-  logic [NUM_REQ-1:0] in_req;
-  logic [NUM_REQ-1:0] in_ack;
-
-  // Outgoing request.
-  logic out_req;
-  logic out_ack;
-  logic [$clog2(NUM_REQ)-1:0] out_sel;
-
-  // The arbiter side of the interface.
-  modport arb(input  in_req, out_ack, output out_req, out_sel, in_ack);
-
-  // The requestor side of the interface.
-  modport req(output in_req, out_ack, input  out_req, out_sel, in_ack);
-
-endinterface

--- a/src/axi_intf.sv
+++ b/src/axi_intf.sv
@@ -429,33 +429,6 @@ interface AXI_LITE_DV #(
 
 endinterface
 
-
-/// An AXI routing table.
-///
-/// For each slave, multiple rules can be defined. Each rule consists of an
-/// address mask and a base. Addresses are masked and then compared against the
-/// base to decide where transfers need to go.
-interface AXI_ROUTING_RULES #(
-  /// The address width.
-  parameter int AXI_ADDR_WIDTH = -1,
-  /// The number of slaves in the routing table.
-  parameter int NUM_SLAVE  = -1,
-  /// The number of rules in the routing table.
-  parameter int NUM_RULES  = -1
-);
-
-  struct packed {
-    logic enabled;
-    logic [AXI_ADDR_WIDTH-1:0] mask;
-    logic [AXI_ADDR_WIDTH-1:0] base;
-  } [NUM_RULES-1:0] rules [NUM_SLAVE];
-
-  modport xbar(input rules);
-  modport cfg(output rules);
-
-endinterface
-
-
 /// An AXI arbitration interface.
 interface AXI_ARBITRATION #(
   /// The number of requestors.

--- a/src/axi_intf.sv
+++ b/src/axi_intf.sv
@@ -23,8 +23,6 @@ interface AXI_BUS #(
   parameter AXI_USER_WIDTH = -1
 );
 
-  import axi_pkg::*;
-
   localparam AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8;
 
   typedef logic [AXI_ID_WIDTH-1:0]   id_t;
@@ -33,55 +31,55 @@ interface AXI_BUS #(
   typedef logic [AXI_STRB_WIDTH-1:0] strb_t;
   typedef logic [AXI_USER_WIDTH-1:0] user_t;
 
-  id_t        aw_id;
-  addr_t      aw_addr;
-  logic [7:0] aw_len;
-  logic [2:0] aw_size;
-  burst_t     aw_burst;
-  logic       aw_lock;
-  cache_t     aw_cache;
-  prot_t      aw_prot;
-  qos_t       aw_qos;
-  region_t    aw_region;
-  logic [5:0] aw_atop;
-  user_t      aw_user;
-  logic       aw_valid;
-  logic       aw_ready;
+  id_t              aw_id;
+  addr_t            aw_addr;
+  axi_pkg::len_t    aw_len;
+  axi_pkg::size_t   aw_size;
+  axi_pkg::burst_t  aw_burst;
+  logic             aw_lock;
+  axi_pkg::cache_t  aw_cache;
+  axi_pkg::prot_t   aw_prot;
+  axi_pkg::qos_t    aw_qos;
+  axi_pkg::region_t aw_region;
+  axi_pkg::atop_t   aw_atop;
+  user_t            aw_user;
+  logic             aw_valid;
+  logic             aw_ready;
 
-  data_t      w_data;
-  strb_t      w_strb;
-  logic       w_last;
-  user_t      w_user;
-  logic       w_valid;
-  logic       w_ready;
+  data_t            w_data;
+  strb_t            w_strb;
+  logic             w_last;
+  user_t            w_user;
+  logic             w_valid;
+  logic             w_ready;
 
-  id_t        b_id;
-  resp_t      b_resp;
-  user_t      b_user;
-  logic       b_valid;
-  logic       b_ready;
+  id_t              b_id;
+  axi_pkg::resp_t   b_resp;
+  user_t            b_user;
+  logic             b_valid;
+  logic             b_ready;
 
-  id_t        ar_id;
-  addr_t      ar_addr;
-  logic [7:0] ar_len;
-  logic [2:0] ar_size;
-  burst_t     ar_burst;
-  logic       ar_lock;
-  cache_t     ar_cache;
-  prot_t      ar_prot;
-  qos_t       ar_qos;
-  region_t    ar_region;
-  user_t      ar_user;
-  logic       ar_valid;
-  logic       ar_ready;
+  id_t              ar_id;
+  addr_t            ar_addr;
+  axi_pkg::len_t    ar_len;
+  axi_pkg::size_t   ar_size;
+  axi_pkg::burst_t  ar_burst;
+  logic             ar_lock;
+  axi_pkg::cache_t  ar_cache;
+  axi_pkg::prot_t   ar_prot;
+  axi_pkg::qos_t    ar_qos;
+  axi_pkg::region_t ar_region;
+  user_t            ar_user;
+  logic             ar_valid;
+  logic             ar_ready;
 
-  id_t        r_id;
-  data_t      r_data;
-  resp_t      r_resp;
-  logic       r_last;
-  user_t      r_user;
-  logic       r_valid;
-  logic       r_ready;
+  id_t              r_id;
+  data_t            r_data;
+  axi_pkg::resp_t   r_resp;
+  logic             r_last;
+  user_t            r_user;
+  logic             r_valid;
+  logic             r_ready;
 
   modport Master (
     output aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_atop, aw_user, aw_valid, input aw_ready,
@@ -112,8 +110,6 @@ interface AXI_BUS_DV #(
   input logic clk_i
 );
 
-  import axi_pkg::*;
-
   localparam AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8;
 
   typedef logic [AXI_ID_WIDTH-1:0]   id_t;
@@ -122,55 +118,55 @@ interface AXI_BUS_DV #(
   typedef logic [AXI_STRB_WIDTH-1:0] strb_t;
   typedef logic [AXI_USER_WIDTH-1:0] user_t;
 
-  id_t        aw_id;
-  addr_t      aw_addr;
-  logic [7:0] aw_len;
-  logic [2:0] aw_size;
-  burst_t     aw_burst;
-  logic       aw_lock;
-  cache_t     aw_cache;
-  prot_t      aw_prot;
-  qos_t       aw_qos;
-  region_t    aw_region;
-  logic [5:0] aw_atop;
-  user_t      aw_user;
-  logic       aw_valid;
-  logic       aw_ready;
+  id_t              aw_id;
+  addr_t            aw_addr;
+  axi_pkg::len_t    aw_len;
+  axi_pkg::size_t   aw_size;
+  axi_pkg::burst_t  aw_burst;
+  logic             aw_lock;
+  axi_pkg::cache_t  aw_cache;
+  axi_pkg::prot_t   aw_prot;
+  axi_pkg::qos_t    aw_qos;
+  axi_pkg::region_t aw_region;
+  axi_pkg::atop_t   aw_atop;
+  user_t            aw_user;
+  logic             aw_valid;
+  logic             aw_ready;
 
-  data_t      w_data;
-  strb_t      w_strb;
-  logic       w_last;
-  user_t      w_user;
-  logic       w_valid;
-  logic       w_ready;
+  data_t            w_data;
+  strb_t            w_strb;
+  logic             w_last;
+  user_t            w_user;
+  logic             w_valid;
+  logic             w_ready;
 
-  id_t        b_id;
-  resp_t      b_resp;
-  user_t      b_user;
-  logic       b_valid;
-  logic       b_ready;
+  id_t              b_id;
+  axi_pkg::resp_t   b_resp;
+  user_t            b_user;
+  logic             b_valid;
+  logic             b_ready;
 
-  id_t        ar_id;
-  addr_t      ar_addr;
-  logic [7:0] ar_len;
-  logic [2:0] ar_size;
-  burst_t     ar_burst;
-  logic       ar_lock;
-  cache_t     ar_cache;
-  prot_t      ar_prot;
-  qos_t       ar_qos;
-  region_t    ar_region;
-  user_t      ar_user;
-  logic       ar_valid;
-  logic       ar_ready;
+  id_t              ar_id;
+  addr_t            ar_addr;
+  axi_pkg::len_t    ar_len;
+  axi_pkg::size_t   ar_size;
+  axi_pkg::burst_t  ar_burst;
+  logic             ar_lock;
+  axi_pkg::cache_t  ar_cache;
+  axi_pkg::prot_t   ar_prot;
+  axi_pkg::qos_t    ar_qos;
+  axi_pkg::region_t ar_region;
+  user_t            ar_user;
+  logic             ar_valid;
+  logic             ar_ready;
 
-  id_t        r_id;
-  data_t      r_data;
-  resp_t      r_resp;
-  logic       r_last;
-  user_t      r_user;
-  logic       r_valid;
-  logic       r_ready;
+  id_t              r_id;
+  data_t            r_data;
+  axi_pkg::resp_t   r_resp;
+  logic             r_last;
+  user_t            r_user;
+  logic             r_valid;
+  logic             r_ready;
 
   modport Master (
     output aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_atop, aw_user, aw_valid, input aw_ready,
@@ -249,57 +245,62 @@ interface AXI_BUS_ASYNC
 
   localparam AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8;
 
-  import axi_pkg::*;
+  typedef logic [AXI_ID_WIDTH-1:0]   id_t;
+  typedef logic [AXI_ADDR_WIDTH-1:0] addr_t;
+  typedef logic [AXI_DATA_WIDTH-1:0] data_t;
+  typedef logic [AXI_STRB_WIDTH-1:0] strb_t;
+  typedef logic [AXI_USER_WIDTH-1:0] user_t;
+  typedef logic [BUFFER_WIDTH-1:0]   buffer_t;
 
-  logic [AXI_ID_WIDTH-1:0]    aw_id;
-  logic [AXI_ADDR_WIDTH-1:0]  aw_addr;
-  logic [7:0]                 aw_len;
-  logic [2:0]                 aw_size;
-  logic [1:0]                 aw_burst;
-  logic                       aw_lock;
-  logic [3:0]                 aw_cache;
-  logic [2:0]                 aw_prot;
-  logic [3:0]                 aw_qos;
-  logic [3:0]                 aw_region;
-  logic [5:0]                 aw_atop;
-  logic [AXI_USER_WIDTH-1:0]  aw_user;
-  logic [BUFFER_WIDTH-1:0]    aw_writetoken;
-  logic [BUFFER_WIDTH-1:0]    aw_readpointer;
+  id_t              aw_id;
+  addr_t            aw_addr;
+  axi_pkg::len_t    aw_len;
+  axi_pkg::size_t   aw_size;
+  axi_pkg::burst_t  aw_burst;
+  logic             aw_lock;
+  axi_pkg::cache_t  aw_cache;
+  axi_pkg::prot_t   aw_prot;
+  axi_pkg::qos_t    aw_qos;
+  axi_pkg::region_t aw_region;
+  axi_pkg::atop_t   aw_atop;
+  user_t            aw_user;
+  buffer_t          aw_writetoken;
+  buffer_t          aw_readpointer;
 
-  logic [AXI_DATA_WIDTH-1:0]  w_data;
-  logic [AXI_STRB_WIDTH-1:0]  w_strb;
-  logic                       w_last;
-  logic [AXI_USER_WIDTH-1:0]  w_user;
-  logic [BUFFER_WIDTH-1:0]    w_writetoken;
-  logic [BUFFER_WIDTH-1:0]    w_readpointer;
+  data_t            w_data;
+  strb_t            w_strb;
+  logic             w_last;
+  user_t            w_user;
+  buffer_t          w_writetoken;
+  buffer_t          w_readpointer;
 
-  logic [AXI_ID_WIDTH-1:0]    b_id;
-  logic [1:0]                 b_resp;
-  logic [AXI_USER_WIDTH-1:0]  b_user;
-  logic [BUFFER_WIDTH-1:0]    b_writetoken;
-  logic [BUFFER_WIDTH-1:0]    b_readpointer;
+  id_t              b_id;
+  axi_pkg::resp_t   b_resp;
+  user_t            b_user;
+  buffer_t          b_writetoken;
+  buffer_t          b_readpointer;
 
-  logic [AXI_ID_WIDTH-1:0]    ar_id;
-  logic [AXI_ADDR_WIDTH-1:0]  ar_addr;
-  logic [7:0]                 ar_len;
-  logic [2:0]                 ar_size;
-  logic [1:0]                 ar_burst;
-  logic                       ar_lock;
-  logic [3:0]                 ar_cache;
-  logic [2:0]                 ar_prot;
-  logic [3:0]                 ar_qos;
-  logic [3:0]                 ar_region;
-  logic [AXI_USER_WIDTH-1:0]  ar_user;
-  logic [BUFFER_WIDTH-1:0]    ar_writetoken;
-  logic [BUFFER_WIDTH-1:0]    ar_readpointer;
+  id_t              ar_id;
+  addr_t            ar_addr;
+  axi_pkg::len_t    ar_len;
+  axi_pkg::size_t   ar_size;
+  axi_pkg::burst_t  ar_burst;
+  logic             ar_lock;
+  axi_pkg::cache_t  ar_cache;
+  axi_pkg::prot_t   ar_prot;
+  axi_pkg::qos_t    ar_qos;
+  axi_pkg::region_t ar_region;
+  user_t            ar_user;
+  buffer_t          ar_writetoken;
+  buffer_t          ar_readpointer;
 
-  logic [AXI_ID_WIDTH-1:0]    r_id;
-  logic [AXI_DATA_WIDTH-1:0]  r_data;
-  logic [1:0]                 r_resp;
-  logic                       r_last;
-  logic [AXI_USER_WIDTH-1:0]  r_user;
-  logic [BUFFER_WIDTH-1:0]    r_writetoken;
-  logic [BUFFER_WIDTH-1:0]    r_readpointer;
+  id_t              r_id;
+  data_t            r_data;
+  axi_pkg::resp_t   r_resp;
+  logic             r_last;
+  user_t            r_user;
+  buffer_t          r_writetoken;
+  buffer_t          r_readpointer;
 
   modport Master (
     output aw_id, aw_addr, aw_len, aw_size, aw_burst, aw_lock, aw_cache, aw_prot, aw_qos, aw_region, aw_atop, aw_user, aw_writetoken, input aw_readpointer,
@@ -326,8 +327,6 @@ interface AXI_LITE #(
   parameter AXI_DATA_WIDTH = -1
 );
 
-  import axi_pkg::*;
-
   localparam AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8;
 
   typedef logic [AXI_ADDR_WIDTH-1:0] addr_t;
@@ -335,27 +334,27 @@ interface AXI_LITE #(
   typedef logic [AXI_STRB_WIDTH-1:0] strb_t;
 
   // AW channel
-  addr_t aw_addr;
-  logic  aw_valid;
-  logic  aw_ready;
+  addr_t          aw_addr;
+  logic           aw_valid;
+  logic           aw_ready;
 
-  data_t w_data;
-  strb_t w_strb;
-  logic  w_valid;
-  logic  w_ready;
+  data_t          w_data;
+  strb_t          w_strb;
+  logic           w_valid;
+  logic           w_ready;
 
-  resp_t b_resp;
-  logic  b_valid;
-  logic  b_ready;
+  axi_pkg::resp_t b_resp;
+  logic           b_valid;
+  logic           b_ready;
 
-  addr_t ar_addr;
-  logic  ar_valid;
-  logic  ar_ready;
+  addr_t          ar_addr;
+  logic           ar_valid;
+  logic           ar_ready;
 
-  data_t r_data;
-  resp_t r_resp;
-  logic  r_valid;
-  logic  r_ready;
+  data_t          r_data;
+  axi_pkg::resp_t r_resp;
+  logic           r_valid;
+  logic           r_ready;
 
   modport Master (
     output aw_addr, aw_valid, input aw_ready,
@@ -383,8 +382,6 @@ interface AXI_LITE_DV #(
   input logic clk_i
 );
 
-  import axi_pkg::*;
-
   localparam AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8;
 
   typedef logic [AXI_ADDR_WIDTH-1:0] addr_t;
@@ -392,27 +389,27 @@ interface AXI_LITE_DV #(
   typedef logic [AXI_STRB_WIDTH-1:0] strb_t;
 
   // AW channel
-  addr_t aw_addr;
-  logic  aw_valid;
-  logic  aw_ready;
+  addr_t          aw_addr;
+  logic           aw_valid;
+  logic           aw_ready;
 
-  data_t w_data;
-  strb_t w_strb;
-  logic  w_valid;
-  logic  w_ready;
+  data_t          w_data;
+  strb_t          w_strb;
+  logic           w_valid;
+  logic           w_ready;
 
-  resp_t b_resp;
-  logic  b_valid;
-  logic  b_ready;
+  axi_pkg::resp_t b_resp;
+  logic           b_valid;
+  logic           b_ready;
 
-  addr_t ar_addr;
-  logic  ar_valid;
-  logic  ar_ready;
+  addr_t          ar_addr;
+  logic           ar_valid;
+  logic           ar_ready;
 
-  data_t r_data;
-  resp_t r_resp;
-  logic  r_valid;
-  logic  r_ready;
+  data_t          r_data;
+  axi_pkg::resp_t r_resp;
+  logic           r_valid;
+  logic           r_ready;
 
   modport Master (
     output aw_addr, aw_valid, input aw_ready,

--- a/test/tb_axi_cdc.sv
+++ b/test/tb_axi_cdc.sv
@@ -10,8 +10,8 @@
 
 // Testbench for axi_cdc
 
+`include "axi/typedef.svh"
 `include "axi/assign.svh"
-import axi_pkg::*;
 
 module tb_axi_cdc #(
   // AXI Parameters
@@ -109,51 +109,12 @@ module tb_axi_cdc #(
   typedef logic [AXI_IW-1:0]    id_t;
   typedef logic [AXI_DW/8-1:0]  strb_t;
   typedef logic [AXI_UW-1:0]    user_t;
-  typedef struct packed {
-    id_t     id;
-    addr_t   addr;
-    len_t    len;
-    size_t   size;
-    burst_t  burst;
-    logic    lock;
-    cache_t  cache;
-    prot_t   prot;
-    qos_t    qos;
-    region_t region;
-    atop_t   atop;
-    user_t   user;
-  } aw_chan_t;
-  typedef struct packed {
-    data_t data;
-    strb_t strb;
-    user_t user;
-    logic  last;
-  } w_chan_t;
-  typedef struct packed {
-    id_t   id;
-    resp_t resp;
-    user_t user;
-  } b_chan_t;
-  typedef struct packed {
-    id_t     id;
-    addr_t   addr;
-    len_t    len;
-    size_t   size;
-    burst_t  burst;
-    logic    lock;
-    cache_t  cache;
-    prot_t   prot;
-    qos_t    qos;
-    region_t region;
-    user_t   user;
-  } ar_chan_t;
-  typedef struct packed {
-    id_t   id;
-    data_t data;
-    resp_t resp;
-    user_t user;
-    logic  last;
-  } r_chan_t;
+
+  `AXI_TYPEDEF_AW_CHAN_T(aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(w_chan_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(b_chan_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(ar_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(r_chan_t, data_t, id_t, user_t)
 
   axi_cdc_intf #(
     .AXI_ADDR_WIDTH (AXI_AW),


### PR DESCRIPTION
This PR removes the global package imports of `axi_pkg` in synthesizable modules. I ran into issues with Verilator, where the global namespace was broken due to the package defining `resp_t` and subsequest modules defining a parameter `resp_t` in thier definition.
I further did some port naming cleanup and removed interfaces which are no longer used by the modules in this repo.
Changes:
### Added
- `axi_cdc`: Add AXI4-Lite interface wrap.
- `axi_intf`: Add AXI4-Lite `prot_t` signal, adapted macros accordingly.

### Changed
- `axi_cdc`: Change ports `src` and `dst` to `slv` and `mst`.
- `axi_cut`: Change ports `in` and `out` to `slv` and `mst`.
- `axi_multicut`: Change ports `in` and `out` to `slv` and `mst`.
- `axi_intf`: Removed global `import axi_pkg::*;`, made package calls explicit.
- `tb_axi_cdc`: Removed global import, add typedef macros.

### Fixed
- `axi_cut`: Add missing `AXI_LITE_ASSIGN` macros in `axi_lite_cut_intf`.

### Removed
- `axi_cdc`: Removed unused global import of `axi_pkg`.
- `axi_intf`: unused interface `AXI_ROUTING_RULES`
- `axi_intf`: unused interface `AXI_ARBITRATION`

Currently the `tb_atop_filter` is broken in this PR, should however be related to #67.