### PR TITLE
axi_lite_to_axi: Add Data Width parameter to fix synthesis in Xcelium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- `axi_lite_to_axi`: Add mandatory `AxiDataWidth` parameter to enable fix mentioned below.
 
 ### Fixed
+- `axi_lite_to_axi`: Improve compatibility with Xcelium by removing unsupported hierarchical
+  argument to `$bits()` function.
 
 
 ## 0.16.3 - 2020-03-19

--- a/src/axi_lite_xbar.sv
+++ b/src/axi_lite_xbar.sv
@@ -165,10 +165,11 @@ module axi_lite_xbar #(
     // connect the decode error module to the last index of the demux master port
     // typedef as the decode error slave uses full axi
     axi_lite_to_axi #(
-      .req_lite_t  ( req_t       ),
-      .resp_lite_t ( resp_t      ),
-      .req_t       ( full_req_t  ),
-      .resp_t      ( full_resp_t )
+      .AxiDataWidth ( Cfg.AxiDataWidth  ),
+      .req_lite_t   ( req_t             ),
+      .resp_lite_t  ( resp_t            ),
+      .req_t        ( full_req_t        ),
+      .resp_t       ( full_resp_t       )
     ) i_dec_err_conv (
       .slv_req_lite_i  ( slv_reqs[i][Cfg.NoMstPorts]  ),
       .slv_resp_lite_o ( slv_resps[i][Cfg.NoMstPorts] ),

--- a/test/synth_bench.sv
+++ b/test/synth_bench.sv
@@ -140,7 +140,9 @@ module synth_slice #(
     .slv        (a_full.Slave),
     .mst        (a_lite.Master)
   );
-  axi_lite_to_axi_intf b (
+  axi_lite_to_axi_intf #(
+    .AXI_DATA_WIDTH (DW)
+  ) b (
     .in   (b_lite.Slave),
     .out  (b_full.Master)
   );

--- a/test/tb_axi_lite_to_axi.sv
+++ b/test/tb_axi_lite_to_axi.sv
@@ -54,7 +54,9 @@ module tb_axi_lite_to_axi;
 
   `AXI_ASSIGN(axi_dv, axi)
 
-  axi_lite_to_axi_intf i_dut (
+  axi_lite_to_axi_intf #(
+    .AXI_DATA_WIDTH (DW)
+  ) i_dut (
     .in   ( axi_lite ),
     .out  ( axi      )
   );


### PR DESCRIPTION
Reportedly, Xcelium (version unknown) cannot handle hierarchical expressions (e.g., `mst_req_o.w.data`) as argument to the `$bits()` function. I propose to fix this in this PR by adding a parameter for the data width.  The disadvantage is that this is a backwards-incompatible "API" change. I am open to backwards-compatible suggestions, of course.

As we currently do not have regression tests for Xcelium, -- at the moment we cannot verify every version of every tool with its own flavor of SystemVerilog -- I suggest to fix similar issues reactively on a per-case basis.