### PR TITLE
rand_axi_master: Fix stuck on read receive in ATOP mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_modify_address`: Fix unconnected `w_valid`.
 - `axi_dw_converter`: Fix internal inversion of up- and downconversion, which led to incorrect lane
   steering and serialization.
+- `rand_axi_master` (in `axi_test`): In ATOP mode, this module could get stuck receiving an R beat
+  when only writes (without ATOP read responses) were left to complete.  This has been fixed.
 
 
 ## 0.18.0 - 2020-03-24

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -991,16 +991,18 @@ package axi_test;
       )) begin
         automatic r_beat_t r_beat;
         rand_wait(RESP_MIN_WAIT_CYCLES, RESP_MAX_WAIT_CYCLES);
-        drv.recv_r(r_beat);
-        if (r_beat.r_last) begin
-          cnt_sem.get();
-          if (atop_resp_r[r_beat.r_id]) begin
-            atop_resp_r[r_beat.r_id] = 1'b0;
-          end else begin
-            r_flight_cnt[r_beat.r_id]--;
-            tot_r_flight_cnt--;
+        if (tot_r_flight_cnt > 0 || atop_resp_r > 0) begin
+          drv.recv_r(r_beat);
+          if (r_beat.r_last) begin
+            cnt_sem.get();
+            if (atop_resp_r[r_beat.r_id]) begin
+              atop_resp_r[r_beat.r_id] = 1'b0;
+            end else begin
+              r_flight_cnt[r_beat.r_id]--;
+              tot_r_flight_cnt--;
+            end
+            cnt_sem.put();
           end
-          cnt_sem.put();
         end
       end
     endtask


### PR DESCRIPTION
`axi_test`: `rand_axi_master`: Fix for stuck on read receive in ATOP mode
Scenario was:
* Have `rand_axi_master` in `ATOP` mode.
* Issue `.run()`
* Reads complete, but writes are still continuing, read is ready as a new ATOP with read response could follow
* No ATOP with read response follows -> master waits for read response forever