### PR TITLE
AXI Serializer

### DIFF
--- a/.ci/Memora.yml
+++ b/.ci/Memora.yml
@@ -170,6 +170,19 @@ artifacts:
     outputs:
       - build/axi_lite_xbar.tested
 
+  axi_serializer:
+    inputs:
+      - Bender.yml
+      - include
+      - scripts/run_vsim.sh
+      - src/axi_pkg.sv
+      - src/axi_intf.sv
+      - src/axi_test.sv
+      - src/axi_serializer.sv
+      - test/tb_axi_serializer.sv
+    outputs:
+      - build/axi_serializer.tested
+
   axi_to_axi_lite:
     inputs:
       - Bender.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,6 +91,11 @@ axi_lite_xbar:
   variables:
     TEST_MODULE: axi_lite_xbar
 
+axi_serializer:
+  <<: *test_module
+  variables:
+    TEST_MODULE: axi_serializer
+
 axi_to_axi_lite:
   <<: *test_module
   variables:

--- a/Bender.yml
+++ b/Bender.yml
@@ -42,6 +42,7 @@ sources:
   - src/axi_lite_to_axi.sv
   - src/axi_modify_address.sv
   - src/axi_mux.sv
+  - src/axi_serializer.sv
   # Level 3
   - src/axi_err_slv.sv
   - src/axi_dw_converter.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -73,6 +73,7 @@ sources:
       - test/tb_axi_lite_to_axi.sv
       - test/tb_axi_lite_mailbox.sv
       - test/tb_axi_lite_xbar.sv
+      - test/tb_axi_serializer.sv
       - test/tb_axi_to_axi_lite.sv
       - test/tb_axi_xbar_pkg.sv
       - test/tb_axi_xbar.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+- Add `axi_serializer`, to serialize multiple transactions with different IDs to the same ID.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
-- Add `axi_serializer`, to serialize multiple transactions with different IDs to the same ID.
+- `axi_serializer`: serialize transactions with different IDs to the same ID.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This is the implementation of the AMBA AXI protocol developed as part of the PUL
 | [`axi_multicut`](src/axi_multicut.sv)                | AXI register which can be used to relax timing pressure on long AXI buses.                        |                                |
 | [`axi_mux`](src/axi_mux.sv)                          | Multiplexes the AXI4 slave ports down to one master port.                                         | [Doc](doc/axi_mux.md)          |
 | [`axi_pkg`](src/axi_pkg.sv)                          | Contains AXI definitions, common structs, and useful helper functions.                            |                                |
+| [`axi_serializer`](src/axi_serializer.sv)            | Serializes transactions with different IDs to the same ID.                                        |                                |
 | [`axi_test`](src/axi_test.sv)                        | A set of testbench utilities for AXI interfaces.                                                  |                                |
 | [`axi_to_axi_lite`](src/axi_to_axi_lite.sv)          | AXI4 to AXI4-Lite protocol converter.                                                             |                                |
 | [`axi_xbar`](src/axi_xbar.sv)                        | Fully-connected AXI4+ATOP crossbar with an arbitrary number of slave and master ports.            | [Doc](doc/axi_xbar.md)         |

--- a/src/axi_serializer.sv
+++ b/src/axi_serializer.sv
@@ -184,19 +184,19 @@ module axi_serializer #(
   default disable iff (~rst_ni);
   aw_lost : assert property( @(posedge clk_i)
       (slv_req_i.aw_valid & slv_resp_o.aw_ready |-> mst_req_o.aw_valid & mst_resp_i.aw_ready))
-    else $error ("AW beat lost.");
+    else $error("AW beat lost.");
   w_lost  : assert property( @(posedge clk_i)
       (slv_req_i.w_valid & slv_resp_o.w_ready |-> mst_req_o.w_valid & mst_resp_i.w_ready))
-    else $error ("W beat lost.");
+    else $error("W beat lost.");
   b_lost  : assert property( @(posedge clk_i)
       (mst_resp_i.b_valid & mst_req_o.b_ready |-> slv_resp_o.b_valid & slv_req_i.b_ready))
-    else $error ("B beat lost.");
+    else $error("B beat lost.");
   ar_lost : assert property( @(posedge clk_i)
       (slv_req_i.ar_valid & slv_resp_o.ar_ready |-> mst_req_o.ar_valid & mst_resp_i.ar_ready))
-    else $error ("AR beat lost.");
+    else $error("AR beat lost.");
   r_lost :  assert property( @(posedge clk_i)
       (mst_resp_i.r_valid & mst_req_o.r_ready |-> slv_resp_o.r_valid & slv_req_i.r_ready))
-    else $error ("R beat lost.");
+    else $error("R beat lost.");
 `endif
 // pragma translate_on
 endmodule

--- a/src/axi_serializer.sv
+++ b/src/axi_serializer.sv
@@ -51,7 +51,6 @@ module axi_serializer #(
   id_t    b_id,
           r_id,         ar_id;
   state_e state_q,      state_d;
-  logic   change_state;
 
   always_comb begin
     // Default assignments
@@ -140,8 +139,6 @@ module axi_serializer #(
     slv_resp_o.r_valid = mst_resp_i.r_valid & ~rd_fifo_empty;
     mst_req_o.r_ready  = slv_req_i.r_ready  & ~rd_fifo_empty;
   end
-  // State change enable
-  assign change_state = state_d != state_q;
 
   fifo_v3 #(
     .FALL_THROUGH ( 1'b0        ), // No fall-through as response has to come a cycle later anyway
@@ -183,7 +180,7 @@ module axi_serializer #(
   // Assign as this condition is needed in FSM
   assign wr_fifo_pop = slv_resp_o.b_valid & slv_req_i.b_ready;
 
-  `FFLARN(state_q, state_d, change_state, AtopIdle, clk_i, rst_ni)
+  `FFARN(state_q, state_d, AtopIdle, clk_i, rst_ni)
 
 // pragma translate_off
 `ifndef VERILATOR

--- a/src/axi_serializer.sv
+++ b/src/axi_serializer.sv
@@ -267,7 +267,7 @@ module axi_serializer_intf #(
   initial begin: p_assertions
     assert (AXI_ADDR_WIDTH  >= 1) else $fatal(1, "AXI address width must be at least 1!");
     assert (AXI_DATA_WIDTH  >= 1) else $fatal(1, "AXI data width must be at least 1!");
-    assert (AXI_ID_WIDTH    >= 1) else $fatal(1, "AXI ID   width must be at least 1!");
+    assert (AXI_ID_WIDTH    >= 1) else $fatal(1, "AXI ID width must be at least 1!");
     assert (AXI_USER_WIDTH  >= 1) else $fatal(1, "AXI user width must be at least 1!");
     assert (MAX_READ_TXNS   >= 1)
       else $fatal(1, "Maximum number of read transactions must be >= 1!");

--- a/src/axi_serializer.sv
+++ b/src/axi_serializer.sv
@@ -184,19 +184,19 @@ module axi_serializer #(
   default disable iff (~rst_ni);
   aw_lost : assert property( @(posedge clk_i)
       (slv_req_i.aw_valid & slv_resp_o.aw_ready |-> mst_req_o.aw_valid & mst_resp_i.aw_ready))
-    else $error (1, "AW beat lost.");
+    else $error ("AW beat lost.");
   w_lost  : assert property( @(posedge clk_i)
       (slv_req_i.w_valid & slv_resp_o.w_ready |-> mst_req_o.w_valid & mst_resp_i.w_ready))
-    else $error (1, "W beat lost.");
+    else $error ("W beat lost.");
   b_lost  : assert property( @(posedge clk_i)
       (mst_resp_i.b_valid & mst_req_o.b_ready |-> slv_resp_o.b_valid & slv_req_i.b_ready))
-    else $error (1, "B beat lost.");
+    else $error ("B beat lost.");
   ar_lost : assert property( @(posedge clk_i)
       (slv_req_i.ar_valid & slv_resp_o.ar_ready |-> mst_req_o.ar_valid & mst_resp_i.ar_ready))
-    else $error (1, "AR beat lost.");
+    else $error ("AR beat lost.");
   r_lost :  assert property( @(posedge clk_i)
       (mst_resp_i.r_valid & mst_req_o.r_ready |-> slv_resp_o.r_valid & slv_req_i.r_ready))
-    else $error (1, "R beat lost.");
+    else $error ("R beat lost.");
 `endif
 // pragma translate_on
 endmodule

--- a/src/axi_serializer.sv
+++ b/src/axi_serializer.sv
@@ -48,7 +48,7 @@ module axi_serializer #(
 
   logic                      rd_fifo_full, rd_fifo_empty, rd_fifo_push,
                              wr_fifo_full, wr_fifo_empty, wr_fifo_push;
-  id_t                       b_id,         aw_id,
+  id_t                       b_id,
                              r_id,         ar_id;
   state_e                    state_q,      state_d;
   logic                      change_state;
@@ -68,7 +68,6 @@ module axi_serializer #(
     mst_req_o.ar.id = '0;
 
     // Reflect upstream ID in response.
-    aw_id           = slv_req_i.aw.id;
     ar_id           = slv_req_i.ar.id;
     slv_resp_o.b.id = b_id;
     slv_resp_o.r.id = r_id;
@@ -80,7 +79,7 @@ module axi_serializer #(
     slv_resp_o.aw_ready = 1'b0;
 
     unique case (state_q)
-      AtopIdle:    begin
+      AtopIdle: begin
         // Gate AR handshake with ready output of Read FIFO.
         mst_req_o.ar_valid  = slv_req_i.ar_valid  & ~rd_fifo_full;
         slv_resp_o.ar_ready = mst_resp_i.ar_ready & ~rd_fifo_full;
@@ -101,7 +100,7 @@ module axi_serializer #(
           end
         end
       end
-      AtopDrain:   begin
+      AtopDrain: begin
         if (wr_fifo_empty && rd_fifo_empty) begin
           mst_req_o.aw_valid  = 1'b1;
           slv_resp_o.aw_ready = mst_resp_i.aw_ready;
@@ -116,7 +115,7 @@ module axi_serializer #(
           end
         end
       end
-      AtopExecute:    begin
+      AtopExecute: begin
         if (wr_fifo_empty && rd_fifo_empty) begin
           state_d = AtopIdle;
         end
@@ -162,7 +161,7 @@ module axi_serializer #(
     .rst_ni,
     .flush_i    ( 1'b0                                      ),
     .testmode_i ( 1'b0                                      ),
-    .data_i     ( aw_id                                     ),
+    .data_i     ( slv_req_i.aw.id                           ),
     .push_i     ( wr_fifo_push                              ),
     .full_o     ( wr_fifo_full                              ),
     .data_o     ( b_id                                      ),

--- a/src/axi_serializer.sv
+++ b/src/axi_serializer.sv
@@ -1,0 +1,172 @@
+// Copyright (c) 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: Andreas Kurth <akurth@iis.ee.ethz.ch>
+
+`include "axi/assign.svh"
+
+/// Serialize all AXI transactions to a single ID (zero).
+module axi_serializer #(
+  parameter int unsigned MaxReadTxns = 0,
+  parameter int unsigned MaxWriteTxns = 0,
+  parameter int unsigned AxiIdWidth = 0,
+  parameter type req_t = logic,
+  parameter type resp_t = logic
+) (
+  input  logic  clk_i,
+  input  logic  rst_ni,
+  input  req_t  slv_req_i,
+  output resp_t slv_resp_o,
+  output req_t  mst_req_o,
+  input  resp_t mst_resp_i
+);
+
+  // TODO for upstreaming: Add support for ATOPs.
+
+  typedef logic [AxiIdWidth-1:0] id_t;
+
+  logic rd_fifo_ready,  rd_fifo_valid,
+        wr_fifo_ready,  wr_fifo_valid;
+  id_t  b_id,
+        r_id;
+
+  always_comb begin
+    mst_req_o   = slv_req_i;
+    slv_resp_o  = mst_resp_i;
+
+    // Serialize transactions -> tie downstream IDs to zero.
+    mst_req_o.aw.id = '0;
+    mst_req_o.ar.id = '0;
+
+    // Reflect upstream ID in response.
+    slv_resp_o.b.id = b_id;
+    slv_resp_o.r.id = r_id;
+
+    // Gate AW handshake with ready output of Write FIFO.
+    mst_req_o.aw_valid = slv_req_i.aw_valid & wr_fifo_ready;
+    slv_resp_o.aw_ready = mst_resp_i.aw_ready & wr_fifo_ready;
+
+    // Gate B handshake with valid output of Write FIFO.
+    slv_resp_o.b_valid = mst_resp_i.b_valid & wr_fifo_valid;
+    mst_req_o.b_ready = slv_req_i.b_ready & wr_fifo_valid;
+
+    // Gate AR handshake with ready output of Read FIFO.
+    mst_req_o.ar_valid = slv_req_i.ar_valid & rd_fifo_ready;
+    slv_resp_o.ar_ready = mst_resp_i.ar_ready & rd_fifo_ready;
+
+    // Gate R handshake with valid output of Read FIFO.
+    slv_resp_o.r_valid = mst_resp_i.r_valid & rd_fifo_valid;
+    mst_req_o.r_ready = slv_req_i.r_ready & rd_fifo_valid;
+  end
+
+  stream_fifo #(
+    .FALL_THROUGH (1'b1),
+    .DEPTH        (MaxReadTxns),
+    .T            (id_t)
+  ) i_rd_id_fifo (
+    .clk_i,
+    .rst_ni,
+    .flush_i    (1'b0),
+    .testmode_i (1'b0),
+    .data_i     (slv_req_i.ar.id),
+    .valid_i    (slv_req_i.ar_valid & slv_resp_o.ar_ready),
+    .ready_o    (rd_fifo_ready),
+    .data_o     (r_id),
+    .valid_o    (rd_fifo_valid),
+    .ready_i    (slv_resp_o.r_valid & slv_req_i.r_ready & slv_resp_o.r.last),
+    .usage_o    (/* unused */)
+  );
+
+  stream_fifo #(
+    .FALL_THROUGH (1'b1),
+    .DEPTH        (MaxWriteTxns),
+    .T            (id_t)
+  ) i_wr_id_fifo (
+    .clk_i,
+    .rst_ni,
+    .flush_i    (1'b0),
+    .testmode_i (1'b0),
+    .data_i     (slv_req_i.aw.id),
+    .valid_i    (slv_req_i.aw_valid & slv_resp_o.aw_ready),
+    .ready_o    (wr_fifo_ready),
+    .data_o     (b_id),
+    .valid_o    (wr_fifo_valid),
+    .ready_i    (slv_resp_o.b_valid & slv_req_i.b_ready),
+    .usage_o    (/* unused */)
+  );
+
+endmodule
+
+`include "axi/typedef.svh"
+
+module axi_serializer_intf #(
+  parameter int unsigned AXI_ADDR_WIDTH = 0,
+  parameter int unsigned AXI_DATA_WIDTH = 0,
+  parameter int unsigned AXI_ID_WIDTH = 0,
+  parameter int unsigned AXI_USER_WIDTH = 0,
+  parameter int unsigned MAX_READ_TXNS = 0,
+  parameter int unsigned MAX_WRITE_TXNS = 0
+) (
+  input  logic    clk_i,
+  input  logic    rst_ni,
+  AXI_BUS.Slave   slv,
+  AXI_BUS.Master  mst
+);
+
+  typedef logic [AXI_ADDR_WIDTH  -1:0] addr_t;
+  typedef logic [AXI_DATA_WIDTH  -1:0] data_t;
+  typedef logic [AXI_DATA_WIDTH/8-1:0] strb_t;
+  typedef logic [AXI_ID_WIDTH    -1:0] id_t;
+  typedef logic [AXI_USER_WIDTH  -1:0] user_t;
+  `AXI_TYPEDEF_AW_CHAN_T(aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(w_chan_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(b_chan_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(ar_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(r_chan_t, data_t, id_t, user_t)
+  `AXI_TYPEDEF_REQ_T(req_t, aw_chan_t, w_chan_t, ar_chan_t)
+  `AXI_TYPEDEF_RESP_T(resp_t, b_chan_t, r_chan_t)
+  req_t  slv_req,  mst_req;
+  resp_t slv_resp, mst_resp;
+  `AXI_ASSIGN_TO_REQ(slv_req, slv)
+  `AXI_ASSIGN_FROM_RESP(slv, slv_resp)
+  `AXI_ASSIGN_FROM_REQ(mst, mst_req)
+  `AXI_ASSIGN_TO_RESP(mst_resp, mst)
+
+  axi_serializer #(
+    .MaxReadTxns  (MAX_READ_TXNS),
+    .MaxWriteTxns (MAX_WRITE_TXNS),
+    .AxiIdWidth   (AXI_ID_WIDTH),
+    .req_t        (req_t),
+    .resp_t       (resp_t)
+  ) i_axi_serializer (
+    .clk_i,
+    .rst_ni,
+    .slv_req_i  (slv_req),
+    .slv_resp_o (slv_resp),
+    .mst_req_o  (mst_req),
+    .mst_resp_i (mst_resp)
+  );
+
+// pragma translate_off
+`ifndef VERILATOR
+  initial begin: p_assertions
+    assert (AXI_ADDR_WIDTH  >= 1) else $fatal(1, "AXI address width must be at least 1!");
+    assert (AXI_DATA_WIDTH  >= 1) else $fatal(1, "AXI data width must be at least 1!");
+    assert (AXI_ID_WIDTH    >= 1) else $fatal(1, "AXI ID   width must be at least 1!");
+    assert (AXI_USER_WIDTH  >= 1) else $fatal(1, "AXI user width must be at least 1!");
+    assert (MAX_READ_TXNS   >= 1)
+      else $fatal(1, "Maximum number of read transactions must be >= 1!");
+    assert (MAX_WRITE_TXNS  >= 1)
+      else $fatal(1, "Maximum number of write transactions must be >= 1!");
+  end
+`endif
+// pragma translate_on
+
+endmodule

--- a/src_files.yml
+++ b/src_files.yml
@@ -27,6 +27,7 @@ axi:
     - src/axi_lite_to_axi.sv
     - src/axi_modify_address.sv
     - src/axi_mux.sv
+    - src/axi_serializer.sv
     # Level 3
     - src/axi_err_slv.sv
     - src/axi_dw_converter.sv

--- a/test/tb_axi_serializer.sv
+++ b/test/tb_axi_serializer.sv
@@ -1,0 +1,189 @@
+// Copyright (c) 2019 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Wolfgang Roenninger <wroennin@ethz.ch>
+
+`include "axi/typedef.svh"
+`include "axi/assign.svh"
+
+module tb_axi_serializer #(
+    parameter int unsigned NoWrites = 5000,  // How many writes per master
+    parameter int unsigned NoReads  = 3000   // How many reads per master
+  );
+  // Random master no Transactions
+  localparam int unsigned NoPendingDut = 4;
+  // Random Master Atomics
+  localparam int unsigned MaxAW      = 32'd30;
+  localparam int unsigned MaxAR      = 32'd30;
+  localparam bit          EnAtop     = 1'b1;
+  // timing parameters
+  localparam time CyclTime = 10ns;
+  localparam time ApplTime =  2ns;
+  localparam time TestTime =  8ns;
+  // AXI configuration
+  localparam int unsigned AxiIdWidth   =  4;
+  localparam int unsigned AxiAddrWidth =  32;    // Axi Address Width
+  localparam int unsigned AxiDataWidth =  64;    // Axi Data Width
+  localparam int unsigned AxiUserWidth =  5;
+  // Sim print config, how many transactions
+  localparam int unsigned PrintTnx = 500;
+
+
+  typedef axi_test::rand_axi_master #(
+    // AXI interface parameters
+    .AW ( AxiAddrWidth ),
+    .DW ( AxiDataWidth ),
+    .IW ( AxiIdWidth   ),
+    .UW ( AxiUserWidth ),
+    // Stimuli application and test time
+    .TA ( ApplTime ),
+    .TT ( TestTime ),
+    // Maximum number of read and write transactions in flight
+    .MAX_READ_TXNS  ( MaxAR  ),
+    .MAX_WRITE_TXNS ( MaxAW  ),
+    .AXI_ATOPS      ( EnAtop )
+  ) rand_axi_master_t;
+  typedef axi_test::rand_axi_slave #(
+    // AXI interface parameters
+    .AW ( AxiAddrWidth ),
+    .DW ( AxiDataWidth ),
+    .IW ( AxiIdWidth   ),
+    .UW ( AxiUserWidth ),
+    // Stimuli application and test time
+    .TA ( ApplTime ),
+    .TT ( TestTime )
+  ) rand_axi_slave_t;
+
+  // -------------
+  // DUT signals
+  // -------------
+  logic clk;
+  logic rst_n;
+  logic end_of_sim;
+
+  // interfaces
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( AxiDataWidth ),
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_USER_WIDTH ( AxiUserWidth )
+  ) master ();
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( AxiDataWidth ),
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_USER_WIDTH ( AxiUserWidth )
+  ) master_dv (clk);
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( AxiDataWidth ),
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_USER_WIDTH ( AxiUserWidth )
+  ) slave ();
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( AxiDataWidth ),
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_USER_WIDTH ( AxiUserWidth )
+  ) slave_dv (clk);
+
+  `AXI_ASSIGN           ( master,  master_dv )
+  `AXI_ASSIGN           ( slave_dv, slave    )
+
+  //-----------------------------------
+  // Clock generator
+  //-----------------------------------
+  clk_rst_gen #(
+    .CLK_PERIOD    ( CyclTime ),
+    .RST_CLK_CYCLES( 5        )
+  ) i_clk_gen (
+    .clk_o (clk),
+    .rst_no(rst_n)
+  );
+
+  //-----------------------------------
+  // DUT
+  //-----------------------------------
+  axi_serializer_intf #(
+    .MAX_READ_TXNS  ( NoPendingDut ),
+    .MAX_WRITE_TXNS ( NoPendingDut ),
+    .AXI_ID_WIDTH   ( AxiIdWidth   ), // AXI ID width
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ), // AXI address width
+    .AXI_DATA_WIDTH ( AxiDataWidth ), // AXI data width
+    .AXI_USER_WIDTH ( AxiUserWidth )  // AXI user width
+  ) i_dut (
+    .clk_i      ( clk      ), // clock
+    .rst_ni     ( rst_n    ), // asynchronous reset active low
+    .slv        ( master   ), // slave port
+    .mst        ( slave    )  // master port
+  );
+
+  initial begin : proc_axi_master
+    automatic rand_axi_master_t rand_axi_master = new(master_dv);
+    end_of_sim <= 1'b0;
+    rand_axi_master.add_memory_region(32'h0000_0000, 32'h1000_0000, axi_pkg::DEVICE_NONBUFFERABLE);
+    rand_axi_master.add_memory_region(32'h2000_0000, 32'h3000_0000, axi_pkg::WTHRU_NOALLOCATE);
+    rand_axi_master.add_memory_region(32'h4000_0000, 32'h5000_0000, axi_pkg::WBACK_RWALLOCATE);
+    rand_axi_master.reset();
+    @(posedge rst_n);
+    rand_axi_master.run(NoReads, NoWrites);
+    end_of_sim <= 1'b1;
+    repeat (100) @(posedge clk);
+    $stop();
+  end
+
+  initial begin : proc_axi_slave
+    automatic rand_axi_slave_t  rand_axi_slave  = new(slave_dv);
+    rand_axi_slave.reset();
+    @(posedge rst_n);
+    rand_axi_slave.run();
+  end
+
+  initial begin : proc_sim_progress
+    automatic int unsigned aw         = 0;
+    automatic int unsigned ar         = 0;
+    automatic bit          aw_printed = 1'b0;
+    automatic bit          ar_printed = 1'b0;
+
+    @(posedge rst_n);
+
+    forever begin
+      @(posedge clk);
+      #TestTime;
+      if (master.aw_valid && master.aw_ready) begin
+        aw++;
+      end
+      if (master.ar_valid && master.ar_ready) begin
+        ar++;
+      end
+
+      if ((aw % PrintTnx == 0) && ! aw_printed) begin
+        $display("%t> Transmit AW %d of %d.", $time(), aw, NoWrites);
+        aw_printed = 1'b1;
+      end
+      if ((ar % PrintTnx == 0) && !ar_printed) begin
+        $display("%t> Transmit AR %d of %d.", $time(), ar, NoReads);
+        ar_printed = 1'b1;
+      end
+
+      if (aw % PrintTnx == 1) begin
+        aw_printed = 1'b0;
+      end
+      if (ar % PrintTnx == 1) begin
+        ar_printed = 1'b0;
+      end
+
+      if (end_of_sim) begin
+        $info("All transactions completed.");
+        break;
+      end
+    end
+  end
+endmodule

--- a/test/tb_axi_serializer.sv
+++ b/test/tb_axi_serializer.sv
@@ -93,8 +93,8 @@ module tb_axi_serializer #(
     .AXI_USER_WIDTH ( AxiUserWidth )
   ) slave_dv (clk);
 
-  `AXI_ASSIGN           ( master,  master_dv )
-  `AXI_ASSIGN           ( slave_dv, slave    )
+  `AXI_ASSIGN(master, master_dv)
+  `AXI_ASSIGN(slave_dv, slave)
 
   //-----------------------------------
   // Clock generator
@@ -165,83 +165,83 @@ module tb_axi_serializer #(
   r_chan_t   r_chan[$];
 
   initial begin : proc_checker
-    automatic axi_id_t  id_tmp;
-    automatic aw_chan_t aw_tmp;
-    automatic aw_chan_t aw_test;
-    automatic w_chan_t   w_tmp;
-    automatic w_chan_t   w_test;
-    automatic b_chan_t   b_tmp;
-    automatic b_chan_t   b_test;
-    automatic ar_chan_t ar_tmp;
-    automatic ar_chan_t ar_test;
-    automatic r_chan_t   r_tmp;
-    automatic r_chan_t   r_test;
+    automatic axi_id_t  id_exp; // expected ID
+    automatic aw_chan_t aw_exp; // expected AW
+    automatic aw_chan_t aw_act; // actual AW
+    automatic w_chan_t   w_exp; // expected W
+    automatic w_chan_t   w_act; // actual W
+    automatic b_chan_t   b_exp; // expected B
+    automatic b_chan_t   b_act; // actual B
+    automatic ar_chan_t ar_exp; // expected AR
+    automatic ar_chan_t ar_act; // actual AR
+    automatic r_chan_t   r_exp; // expected R
+    automatic r_chan_t   r_act; // actual R
     forever begin
       @(posedge clk);
       #TestTime;
       // All FIFOs get populated if there is something to put in
       if (master.aw_valid && master.aw_ready) begin
-        `AXI_TO_AW(, aw_tmp, master)
-        aw_tmp.id = '0;
-        id_tmp    = master.aw_id;
-        aw_chan.push_back(aw_tmp);
-        aw_queue.push_back(id_tmp);
+        `AXI_TO_AW(, aw_exp, master)
+        aw_exp.id = '0;
+        id_exp    = master.aw_id;
+        aw_chan.push_back(aw_exp);
+        aw_queue.push_back(id_exp);
         if (master.aw_atop[axi_pkg::ATOP_R_RESP]) begin
-          ar_queue.push_back(id_tmp);
+          ar_queue.push_back(id_exp);
         end
       end
       if (master.w_valid && master.w_ready) begin
-        `AXI_TO_W(, w_tmp, master)
-        w_chan.push_back(w_tmp);
+        `AXI_TO_W(, w_exp, master)
+        w_chan.push_back(w_exp);
       end
       if (slave.b_valid && slave.b_ready) begin
-        id_tmp = aw_queue.pop_front();
-        `AXI_TO_B(, b_tmp, slave)
-        b_tmp.id = id_tmp;
-        b_chan.push_back(b_tmp);
+        id_exp = aw_queue.pop_front();
+        `AXI_TO_B(, b_exp, slave)
+        b_exp.id = id_exp;
+        b_chan.push_back(b_exp);
       end
       if (master.ar_valid && master.ar_ready) begin
-        `AXI_TO_AR(, ar_tmp, master)
-        ar_tmp.id = '0;
-        id_tmp    = master.ar_id;
-        ar_chan.push_back(ar_tmp);
-        ar_queue.push_back(id_tmp);
+        `AXI_TO_AR(, ar_exp, master)
+        ar_exp.id = '0;
+        id_exp    = master.ar_id;
+        ar_chan.push_back(ar_exp);
+        ar_queue.push_back(id_exp);
       end
       if (slave.r_valid && slave.r_ready) begin
-        `AXI_TO_R(, r_tmp, slave)
+        `AXI_TO_R(, r_exp, slave)
         if (slave.r_last) begin
-          id_tmp = ar_queue.pop_front();
+          id_exp = ar_queue.pop_front();
         end else begin
-          id_tmp = ar_queue[0];
+          id_exp = ar_queue[0];
         end
-        r_tmp.id = id_tmp;
-        r_chan.push_back(r_tmp);
+        r_exp.id = id_exp;
+        r_chan.push_back(r_exp);
       end
       // Check that all channels match the expected response
       if (slave.aw_valid && slave.aw_ready) begin
-        aw_test = aw_chan.pop_front();
-        `AXI_TO_AW(, aw_tmp, slave)
-        assert(aw_test == aw_tmp) else $error("AW Measured: %h Expected: %h", aw_tmp, aw_test);
+        aw_exp = aw_chan.pop_front();
+        `AXI_TO_AW(, aw_act, slave)
+        assert(aw_act == aw_exp) else $error("AW Measured: %h Expected: %h", aw_act, aw_exp);
       end
       if (slave.w_valid && slave.w_ready) begin
-        w_test = w_chan.pop_front();
-        `AXI_TO_W(, w_tmp, slave)
-        assert(w_test == w_tmp) else $error("AW Measured: %h Expected: %h", w_tmp, w_test);
+        w_exp = w_chan.pop_front();
+        `AXI_TO_W(, w_act, slave)
+        assert(w_act == w_exp) else $error("W Measured: %h Expected: %h", w_act, w_exp);
       end
       if (master.b_valid && master.b_ready) begin
-        b_test = b_chan.pop_front();
-        `AXI_TO_B(, b_tmp, master)
-        assert(b_test == b_tmp) else $error("AW Measured: %h Expected: %h", b_tmp, b_test);
+        b_exp = b_chan.pop_front();
+        `AXI_TO_B(, b_act, master)
+        assert(b_act == b_exp) else $error("B Measured: %h Expected: %h", b_act, b_exp);
       end
       if (slave.ar_valid && slave.ar_ready) begin
-        ar_test = ar_chan.pop_front();
-        `AXI_TO_AR(, ar_tmp, slave)
-        assert(ar_test == ar_tmp) else $error("AW Measured: %h Expected: %h", ar_tmp, ar_test);
+        ar_exp = ar_chan.pop_front();
+        `AXI_TO_AR(, ar_act, slave)
+        assert(ar_act == ar_exp) else $error("AR Measured: %h Expected: %h", ar_act, ar_exp);
       end
       if (master.r_valid && master.r_ready) begin
-        r_test = r_chan.pop_front();
-        `AXI_TO_R(, r_tmp, master)
-        assert(r_test == r_tmp) else $error("AW Measured: %h Expected: %h", r_tmp, r_test);
+        r_exp = r_chan.pop_front();
+        `AXI_TO_R(, r_act, master)
+        assert(r_act == r_exp) else $error("R Measured: %h Expected: %h", r_act, r_exp);
       end
     end
   end

--- a/test/tb_axi_serializer.sv
+++ b/test/tb_axi_serializer.sv
@@ -33,8 +33,7 @@ module tb_axi_serializer #(
   localparam int unsigned AxiDataWidth =  64;    // Axi Data Width
   localparam int unsigned AxiUserWidth =  5;
   // Sim print config, how many transactions
-  localparam int unsigned PrintTnx = 500;
-
+  localparam int unsigned PrintTxn = 500;
 
   typedef axi_test::rand_axi_master #(
     // AXI interface parameters
@@ -146,6 +145,107 @@ module tb_axi_serializer #(
     rand_axi_slave.run();
   end
 
+  // Checker
+  typedef logic [AxiIdWidth-1:0] axi_id_t;
+  typedef logic [AxiIdWidth-1:0] axi_addr_t;
+  typedef logic [AxiIdWidth-1:0] axi_data_t;
+  typedef logic [AxiIdWidth-1:0] axi_strb_t;
+  typedef logic [AxiIdWidth-1:0] axi_user_t;
+  `AXI_TYPEDEF_AW_CHAN_T(aw_chan_t, axi_addr_t,  axi_id_t,  axi_user_t)
+  `AXI_TYPEDEF_W_CHAN_T(w_chan_t,  axi_data_t,  axi_strb_t,  axi_user_t)
+  `AXI_TYPEDEF_B_CHAN_T(b_chan_t,  axi_id_t,  axi_user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(ar_chan_t,  axi_addr_t,  axi_id_t,  axi_user_t)
+  `AXI_TYPEDEF_R_CHAN_T(r_chan_t,  axi_data_t,  axi_id_t,  axi_user_t)
+  axi_id_t  aw_queue[$];
+  axi_id_t  ar_queue[$];
+  aw_chan_t aw_chan[$];
+  w_chan_t   w_chan[$];
+  b_chan_t   b_chan[$];
+  ar_chan_t ar_chan[$];
+  r_chan_t   r_chan[$];
+
+  initial begin : proc_checker
+    automatic axi_id_t  id_tmp;
+    automatic aw_chan_t aw_tmp;
+    automatic aw_chan_t aw_test;
+    automatic w_chan_t   w_tmp;
+    automatic w_chan_t   w_test;
+    automatic b_chan_t   b_tmp;
+    automatic b_chan_t   b_test;
+    automatic ar_chan_t ar_tmp;
+    automatic ar_chan_t ar_test;
+    automatic r_chan_t   r_tmp;
+    automatic r_chan_t   r_test;
+    forever begin
+      @(posedge clk);
+      #TestTime;
+      // All FIFOs get populated if there is something to put in
+      if (master.aw_valid && master.aw_ready) begin
+        `AXI_TO_AW(, aw_tmp, master)
+        aw_tmp.id = '0;
+        id_tmp    = master.aw_id;
+        aw_chan.push_back(aw_tmp);
+        aw_queue.push_back(id_tmp);
+        if (master.aw_atop[axi_pkg::ATOP_R_RESP]) begin
+          ar_queue.push_back(id_tmp);
+        end
+      end
+      if (master.w_valid && master.w_ready) begin
+        `AXI_TO_W(, w_tmp, master)
+        w_chan.push_back(w_tmp);
+      end
+      if (slave.b_valid && slave.b_ready) begin
+        id_tmp = aw_queue.pop_front();
+        `AXI_TO_B(, b_tmp, slave)
+        b_tmp.id = id_tmp;
+        b_chan.push_back(b_tmp);
+      end
+      if (master.ar_valid && master.ar_ready) begin
+        `AXI_TO_AR(, ar_tmp, master)
+        ar_tmp.id = '0;
+        id_tmp    = master.ar_id;
+        ar_chan.push_back(ar_tmp);
+        ar_queue.push_back(id_tmp);
+      end
+      if (slave.r_valid && slave.r_ready) begin
+        `AXI_TO_R(, r_tmp, slave)
+        if (slave.r_last) begin
+          id_tmp = ar_queue.pop_front();
+        end else begin
+          id_tmp = ar_queue[0];
+        end
+        r_tmp.id = id_tmp;
+        r_chan.push_back(r_tmp);
+      end
+      // Check that all channels match the expected response
+      if (slave.aw_valid && slave.aw_ready) begin
+        aw_test = aw_chan.pop_front();
+        `AXI_TO_AW(, aw_tmp, slave)
+        assert(aw_test == aw_tmp) else $error("AW Measured: %h Expected: %h", aw_tmp, aw_test);
+      end
+      if (slave.w_valid && slave.w_ready) begin
+        w_test = w_chan.pop_front();
+        `AXI_TO_W(, w_tmp, slave)
+        assert(w_test == w_tmp) else $error("AW Measured: %h Expected: %h", w_tmp, w_test);
+      end
+      if (master.b_valid && master.b_ready) begin
+        b_test = b_chan.pop_front();
+        `AXI_TO_B(, b_tmp, master)
+        assert(b_test == b_tmp) else $error("AW Measured: %h Expected: %h", b_tmp, b_test);
+      end
+      if (slave.ar_valid && slave.ar_ready) begin
+        ar_test = ar_chan.pop_front();
+        `AXI_TO_AR(, ar_tmp, slave)
+        assert(ar_test == ar_tmp) else $error("AW Measured: %h Expected: %h", ar_tmp, ar_test);
+      end
+      if (master.r_valid && master.r_ready) begin
+        r_test = r_chan.pop_front();
+        `AXI_TO_R(, r_tmp, master)
+        assert(r_test == r_tmp) else $error("AW Measured: %h Expected: %h", r_tmp, r_test);
+      end
+    end
+  end
+
   initial begin : proc_sim_progress
     automatic int unsigned aw         = 0;
     automatic int unsigned ar         = 0;
@@ -164,19 +264,19 @@ module tb_axi_serializer #(
         ar++;
       end
 
-      if ((aw % PrintTnx == 0) && ! aw_printed) begin
+      if ((aw % PrintTxn == 0) && ! aw_printed) begin
         $display("%t> Transmit AW %d of %d.", $time(), aw, NoWrites);
         aw_printed = 1'b1;
       end
-      if ((ar % PrintTnx == 0) && !ar_printed) begin
+      if ((ar % PrintTxn == 0) && !ar_printed) begin
         $display("%t> Transmit AR %d of %d.", $time(), ar, NoReads);
         ar_printed = 1'b1;
       end
 
-      if (aw % PrintTnx == 1) begin
+      if (aw % PrintTxn == 1) begin
         aw_printed = 1'b0;
       end
-      if (ar % PrintTnx == 1) begin
+      if (ar % PrintTxn == 1) begin
         ar_printed = 1'b0;
       end
 

--- a/test/tb_axi_serializer.wave.do
+++ b/test/tb_axi_serializer.wave.do
@@ -12,8 +12,6 @@ add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/rd_fifo_push
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/wr_fifo_full
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/wr_fifo_empty
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/wr_fifo_push
-add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/rd_usage
-add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/wr_usage
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/b_id
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/r_id
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/state_q

--- a/test/tb_axi_serializer.wave.do
+++ b/test/tb_axi_serializer.wave.do
@@ -9,14 +9,15 @@ add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/mst_resp_i
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/rd_fifo_full
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/rd_fifo_empty
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/rd_fifo_push
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/rd_fifo_pop
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/wr_fifo_full
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/wr_fifo_empty
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/wr_fifo_push
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/wr_fifo_pop
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/b_id
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/r_id
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/state_q
 add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/state_d
-add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/change_state
 add wave -noupdate /tb_axi_serializer/end_of_sim
 TreeUpdate [SetDefaultTree]
 WaveRestoreCursors {{Cursor 1} {0 ns} 0}

--- a/test/tb_axi_serializer.wave.do
+++ b/test/tb_axi_serializer.wave.do
@@ -1,0 +1,40 @@
+onerror {resume}
+quietly WaveActivateNextPane {} 0
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/clk_i
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/rst_ni
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/slv_req_i
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/slv_resp_o
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/mst_req_o
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/mst_resp_i
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/rd_fifo_full
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/rd_fifo_empty
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/rd_fifo_push
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/wr_fifo_full
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/wr_fifo_empty
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/wr_fifo_push
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/rd_usage
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/wr_usage
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/b_id
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/r_id
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/state_q
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/state_d
+add wave -noupdate /tb_axi_serializer/i_dut/i_axi_serializer/change_state
+add wave -noupdate /tb_axi_serializer/end_of_sim
+TreeUpdate [SetDefaultTree]
+WaveRestoreCursors {{Cursor 1} {0 ns} 0}
+quietly wave cursor active 1
+configure wave -namecolwidth 279
+configure wave -valuecolwidth 100
+configure wave -justifyvalue left
+configure wave -signalnamewidth 0
+configure wave -snapdistance 10
+configure wave -datasetprefix 0
+configure wave -rowmargin 4
+configure wave -childrowmargin 2
+configure wave -gridoffset 0
+configure wave -gridperiod 1
+configure wave -griddelta 40
+configure wave -timeline 0
+configure wave -timelineunits ns
+update
+WaveRestoreZoom {0 ns} {112225215 ns}


### PR DESCRIPTION
* Adds `axi_serializer` from #91.
* Adds ATOP support to the module `axi_serializer`.
* Functional and Synthesis testbench for `axi_serializer`.