### PR TITLE
axi_pkg::beat_addr: Add support for all burst types

### DIFF
--- a/.ci/Memora.yml
+++ b/.ci/Memora.yml
@@ -22,6 +22,18 @@ artifacts:
     outputs:
       - build/synth.completed
 
+  axi_addr_test:
+    inputs:
+      - Bender.yml
+      - include
+      - scripts/run_vsim.sh
+      - src/axi_pkg.sv
+      - src/axi_intf.sv
+      - src/axi_test.sv
+      - test/tb_axi_addr_test.sv
+    outputs:
+      - build/axi_addr_test.tested
+
   axi_atop_filter:
     inputs:
       - Bender.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,6 +36,11 @@ synopsys_dc:
         memora insert $TEST_MODULE
       fi
 
+axi_addr_test:
+  <<: *test_module
+  variables:
+    TEST_MODULE: axi_addr_test
+
 axi_atop_filter:
   <<: *test_module
   variables:

--- a/Bender.yml
+++ b/Bender.yml
@@ -62,6 +62,7 @@ sources:
   - target: test
     files:
       - test/tb_axi_atop_filter.sv
+      - test/tb_axi_addr_test.sv
       - test/tb_axi_cdc.sv
       - test/tb_axi_delayer.sv
       - test/tb_axi_dw_downsizer.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+- `axi_pkg::wrap_boundary`: Add function to calculate the wrap boundary of a burst with type
+  `axi_pkg::BURST_WRAP`. Function inputs are `largest_addr_t addr`, `size_t size` and `len_t len`.
 
 ### Changed
+- `axi_pkg::beat_addr`: Add support for all burst types. Add function inputs `len_t len` and
+  `burst_t burst`. Update all occurrences in other files.
+- `axi_pkg::beat_lower_byte`: Add function inputs `len_t len` and `burst_t burst`.
+- `axi_pkg::beat_upper_byte`: Add function inputs `len_t len` and `burst_t burst`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `axi_pkg::wrap_boundary`: Add function to calculate the wrap boundary of a burst with type
-  `axi_pkg::BURST_WRAP`. Function inputs are `largest_addr_t addr`, `size_t size` and `len_t len`.
+- `axi_pkg::BURST_WRAP`. Function inputs are `largest_addr_t addr`, `size_t size` and `len_t len`.
 
 ### Changed
 - `axi_pkg::beat_addr`: Add support for all burst types. Add function inputs `len_t len` and
   `burst_t burst`. Update all occurrences in other files.
 - `axi_pkg::beat_lower_byte`: Add function inputs `len_t len` and `burst_t burst`.
 - `axi_pkg::beat_upper_byte`: Add function inputs `len_t len` and `burst_t burst`.
+- `axi_test::rand_axi_master`: Add parameter `AXI_BURST_FIXED`, `AXI_BURST_FIXED` and
+  `AXI_BURST_FIXED`. When enabled master will emit bursts of this type.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
-- `axi_pkg::wrap_boundary`: Add function to calculate the wrap boundary of a burst with type
-- `axi_pkg::BURST_WRAP`. Function inputs are `largest_addr_t addr`, `size_t size` and `len_t len`.
+- `axi_pkg`: Add `wrap_boundary` function to calculate the boundary of a wrapping burst.
+- `axi_test`: The random AXI master `rand_axi_master` can now emit wrapping bursts (but does not do
+  so by default).  Three new parameters control the burst types of the emitted transactions; not
+  setting those parameters means the random master behaves as it did before this change.
 
 ### Changed
-- `axi_pkg::beat_addr`: Add support for all burst types. Add function inputs `len_t len` and
-  `burst_t burst`. Update all occurrences in other files.
-- `axi_pkg::beat_lower_byte`: Add function inputs `len_t len` and `burst_t burst`.
-- `axi_pkg::beat_upper_byte`: Add function inputs `len_t len` and `burst_t burst`.
+- `axi_pkg:`
+  - The `beat_addr` function now supports all burst types.  Due to this, the function has two new
+    arguments (the length and type of the burst).
+  - The `beat_upper_byte` and `beat_lower_byte` functions internally call `beat_addr`, so they have
+    two new arguments as well.
 - `axi_test::rand_axi_master`: Add parameter `AXI_BURST_FIXED`, `AXI_BURST_FIXED` and
   `AXI_BURST_FIXED`. When enabled master will emit bursts of this type.
 

--- a/src/axi_dw_upsizer.sv
+++ b/src/axi_dw_upsizer.sv
@@ -372,9 +372,10 @@ module axi_dw_upsizer #(
                   // No need to upsize single-beat transactions.
                   if (r_req_d.ar.len != '0) begin
                     // Evaluate output burst length
-                    automatic addr_t start_addr = aligned_addr(r_req_d.ar.addr, AxiMstPortMaxSize)                                                    ;
-                    automatic addr_t end_addr   = aligned_addr(beat_addr(r_req_d.ar.addr, r_req_d.orig_ar_size, r_req_d.burst_len), AxiMstPortMaxSize);
-
+                    automatic addr_t start_addr = aligned_addr(r_req_d.ar.addr, AxiMstPortMaxSize);
+                    automatic addr_t end_addr   = aligned_addr(beat_addr(r_req_d.ar.addr,
+                        r_req_d.orig_ar_size, r_req_d.burst_len, r_req_d.ar.burst,
+                        r_req_d.burst_len), AxiMstPortMaxSize);
                     r_req_d.ar.len  = (end_addr - start_addr) >> AxiMstPortMaxSize;
                     r_req_d.ar.size = AxiMstPortMaxSize                           ;
                     r_state_d       = R_INCR_UPSIZE                               ;
@@ -599,8 +600,10 @@ module axi_dw_upsizer #(
               // No need to upsize single-beat transactions.
               if (slv_req_i.aw.len != '0) begin
                 // Evaluate output burst length
-                automatic addr_t start_addr = aligned_addr(slv_req_i.aw.addr, AxiMstPortMaxSize)                                                ;
-                automatic addr_t end_addr   = aligned_addr(beat_addr(slv_req_i.aw.addr, slv_req_i.aw.size, slv_req_i.aw.len), AxiMstPortMaxSize);
+                automatic addr_t start_addr = aligned_addr(slv_req_i.aw.addr, AxiMstPortMaxSize);
+                automatic addr_t end_addr   = aligned_addr(beat_addr(slv_req_i.aw.addr,
+                    slv_req_i.aw.size, slv_req_i.aw.len, slv_req_i.aw.burst, slv_req_i.aw.len),
+                    AxiMstPortMaxSize);
 
                 w_req_d.aw.len  = (end_addr - start_addr) >> AxiMstPortMaxSize;
                 w_req_d.aw.size = AxiMstPortMaxSize                           ;

--- a/src/axi_pkg.sv
+++ b/src/axi_pkg.sv
@@ -85,7 +85,7 @@ package axi_pkg;
 
   /// Maximum number of bytes per burst, as specified by `size` (see Table A3-2).
   function automatic shortint unsigned num_bytes(size_t size);
-    return 16'b1 << size;
+    return 1 << size;
   endfunction
 
   /// An overly long address type.
@@ -124,10 +124,10 @@ package axi_pkg;
     // equivalent with multiplication and division by a power of two, which conveniently are the
     // only allowed values for `len` of a `BURST_WRAP`.
     unique case (len)
-      4'b1    : wrap_addr = aligned_addr(addr, size + 1); // multiply `Number_Bytes` by `2`
-      4'b11   : wrap_addr = aligned_addr(addr, size + 2); // multiply `Number_Bytes` by `4`
-      4'b111  : wrap_addr = aligned_addr(addr, size + 3); // multiply `Number_Bytes` by `8`
-      4'b1111 : wrap_addr = aligned_addr(addr, size + 4); // multiply `Number_Bytes` by `16`
+      4'b1    : wrap_addr = (addr >> (unsigned'(size) + 1)) << (unsigned'(size) + 1); // multiply `Number_Bytes` by `2`
+      4'b11   : wrap_addr = (addr >> (unsigned'(size) + 2)) << (unsigned'(size) + 2); // multiply `Number_Bytes` by `4`
+      4'b111  : wrap_addr = (addr >> (unsigned'(size) + 3)) << (unsigned'(size) + 3); // multiply `Number_Bytes` by `8`
+      4'b1111 : wrap_addr = (addr >> (unsigned'(size) + 4)) << (unsigned'(size) + 4); // multiply `Number_Bytes` by `16`
       default : wrap_addr = '0;
     endcase
     return wrap_addr;

--- a/src/axi_pkg.sv
+++ b/src/axi_pkg.sv
@@ -109,7 +109,7 @@ package axi_pkg;
     `ifndef VERILATOR
       assume (len == len_t'(4'b1) || len == len_t'(4'b11) || len == len_t'(4'b111) ||
           len == len_t'(4'b1111)) else
-        $warning("AXI BURST_WRAP with not allowed len of: %0h", len);
+        $error("AXI BURST_WRAP with not allowed len of: %0h", len);
     `endif
     // pragma translate_on
 

--- a/src/axi_pkg.sv
+++ b/src/axi_pkg.sv
@@ -85,7 +85,7 @@ package axi_pkg;
 
   /// Maximum number of bytes per burst, as specified by `size` (see Table A3-2).
   function automatic shortint unsigned num_bytes(size_t size);
-    return 1 << size;
+    return 16'b1 << size;
   endfunction
 
   /// An overly long address type.
@@ -98,32 +98,90 @@ package axi_pkg;
     return (addr >> size) << size;
   endfunction
 
+  /// Warp boundary of a `BURST_WRAP` transfer (see A3-51).
+  /// This is the lowest address accessed within a wrapping burst.
+  /// This address is aligned to the size and length of the burst.
+  /// The length of a `BURST_WRAP` has to be 2, 4, 8, or 16 transfers.
+  function automatic largest_addr_t wrap_boundary (largest_addr_t addr, size_t size, len_t len);
+    largest_addr_t wrap_addr;
+
+    // pragma translate_off
+    `ifndef VERILATOR
+      assume (len == len_t'(4'b1) || len == len_t'(4'b11) || len == len_t'(4'b111) ||
+          len == len_t'(4'b1111)) else
+        $warning("AXI BURST_WRAP with not allowed len of: %0h", len);
+    `endif
+    // pragma translate_on
+
+    // In A3-51 the wrap boundary is defined as:
+    // `Wrap_Boundary = (INT(Start_Address / (Number_Bytes × Burst_Length))) ×
+    //    (Number_Bytes × Burst_Length)`
+    // Whereas the aligned address is defined as:
+    // `Aligned_Address = (INT(Start_Address / Number_Bytes)) × Number_Bytes`
+    // This leads to the wrap boundary using the same calculation as the aligned address, difference
+    // being the additional dependency on the burst length. The addition in the case statement
+    // is equal to the multiplication with `Burst_Length` as a shift (used by `aligned_addr`) is
+    // equivalent with multiplication and division by a power of two, which conveniently are the
+    // only allowed values for `len` of a `BURST_WRAP`.
+    unique case (len)
+      4'b1    : wrap_addr = aligned_addr(addr, size + 1); // multiply `Number_Bytes` by `2`
+      4'b11   : wrap_addr = aligned_addr(addr, size + 2); // multiply `Number_Bytes` by `4`
+      4'b111  : wrap_addr = aligned_addr(addr, size + 3); // multiply `Number_Bytes` by `8`
+      4'b1111 : wrap_addr = aligned_addr(addr, size + 4); // multiply `Number_Bytes` by `16`
+      default : wrap_addr = '0;
+    endcase
+    return wrap_addr;
+  endfunction
+
   /// Address of beat (see A3-51).
   function automatic largest_addr_t
-  beat_addr(largest_addr_t addr, size_t size, shortint unsigned i_beat);
-    if (i_beat == 0) begin
-      return addr;
-    end else begin
-      return aligned_addr(addr, size) + i_beat * num_bytes(size);
+  beat_addr(largest_addr_t addr, size_t size, len_t len, burst_t burst, shortint unsigned i_beat);
+    largest_addr_t ret_addr = addr;
+    largest_addr_t wrp_bond = '0;
+    if (burst == BURST_WRAP) begin
+      // do not trigger the function if there is no wrapping burst, to prevent assumptions firing
+      wrp_bond = wrap_boundary(addr, size, len);
     end
+    if (i_beat != 0 && burst != BURST_FIXED) begin
+      // From A3-51:
+      // For an INCR burst, and for a WRAP burst for which the address has not wrapped, this
+      // equation determines the address of any transfer after the first transfer in a burst:
+      // `Address_N = Aligned_Address + (N – 1) × Number_Bytes` (N counts from 1 to len!)
+      ret_addr = aligned_addr(addr, size) + i_beat * num_bytes(size);
+      // From A3-51:
+      // For a WRAP burst, if Address_N = Wrap_Boundary + (Number_Bytes × Burst_Length), then:
+      // * Use this equation for the current transfer:
+      //     `Address_N = Wrap_Boundary`
+      // * Use this equation for any subsequent transfers:
+      //     `Address_N = Start_Address + ((N – 1) × Number_Bytes) – (Number_Bytes × Burst_Length)`
+      // This means that the address calculation of a `BURST_WRAP` fundamentally works the same
+      // as for a `BURST_INC`, the difference is when the calculated address increments
+      // over the wrap threshold, the address wraps around by subtracting the accessed address
+      // space from the normal `BURST_INCR` address. The lower wrap boundary is equivalent to
+      // The wrap trigger condition minus the container size (`num_bytes(size) * (len + 1)`).
+      if (burst == BURST_WRAP && ret_addr >= wrp_bond + (num_bytes(size) * (len + 1))) begin
+        ret_addr = ret_addr - (num_bytes(size) * (len + 1));
+      end
+    end
+    return ret_addr;
   endfunction
 
   /// Index of lowest beat in byte (see A3-51).
   function automatic shortint unsigned
-  beat_lower_byte(largest_addr_t addr, size_t size, shortint unsigned strobe_width,
-      shortint unsigned i_beat);
-    largest_addr_t _addr = beat_addr(addr, size, i_beat);
+  beat_lower_byte(largest_addr_t addr, size_t size, len_t len, burst_t burst,
+      shortint unsigned strobe_width, shortint unsigned i_beat);
+    largest_addr_t _addr = beat_addr(addr, size, len, burst, i_beat);
     return _addr - (_addr / strobe_width) * strobe_width;
   endfunction
 
   /// Index of highest beat in byte (see A3-51).
   function automatic shortint unsigned
-  beat_upper_byte(largest_addr_t addr, size_t size, shortint unsigned strobe_width,
-      shortint unsigned i_beat);
+  beat_upper_byte(largest_addr_t addr, size_t size, len_t len, burst_t burst,
+      shortint unsigned strobe_width, shortint unsigned i_beat);
     if (i_beat == 0) begin
       return aligned_addr(addr, size) + (num_bytes(size) - 1) - (addr / strobe_width) * strobe_width;
     end else begin
-      return beat_lower_byte(addr, size, strobe_width, i_beat) + num_bytes(size) - 1;
+      return beat_lower_byte(addr, size, len, burst, strobe_width, i_beat) + num_bytes(size) - 1;
     end
   endfunction
 

--- a/test/tb_axi_addr_test.sv
+++ b/test/tb_axi_addr_test.sv
@@ -1,0 +1,64 @@
+// Copyright (c) 2019 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Wolfgang Roenninger <wroennin@ethz.ch>
+
+// Description: Simple test for showing address wrapping behavior of the function
+// `axi_pkg::beat_addr`
+
+`include "axi/typedef.svh"
+
+module tb_axi_addr_test;
+
+  typedef logic [16:0] addr_t;
+
+  localparam int unsigned NumAddr = 32'd4;
+  localparam addr_t [NumAddr-1:0] TestAddr = '{
+    16'h0000,
+    16'h0008,
+    16'h1000,
+    16'h003B
+  };
+  localparam axi_pkg::len_t [3:0] TestLen = '{
+    8'b1,
+    8'b11,
+    8'b111,
+    8'b1111
+  };
+
+  initial begin : proc_print_examples
+    automatic addr_t           addr;
+    automatic axi_pkg::burst_t burst = axi_pkg::BURST_WRAP;
+    automatic axi_pkg::len_t   len;
+    automatic axi_pkg::size_t  size  = 3'b011;
+
+    $display("Bust Type is BURST_WRAP:");
+    for (int unsigned i_addr = 0; i_addr < NumAddr; i_addr++) begin
+      addr = TestAddr[i_addr];
+      for (int unsigned i_len = 0; i_len < 4; i_len++) begin
+        len = TestLen[i_len];
+        $display("####################################################################",);
+        $display("Wrap Boundary lower:  %h", addr_t'(axi_pkg::wrap_boundary(addr, size, len)));
+        $display("Wrap Boundary higher: %h", addr_t'(axi_pkg::wrap_boundary(addr, size, len) + (axi_pkg::num_bytes(size) * (len + 1))));
+        for (axi_pkg::len_t i_beat = 0; i_beat <= len; i_beat++) begin
+
+          $display("Burst: %h Addr0: %h Beats: %0d Size: %h i_Beat: %0h Calc Addr: %h",
+              burst,
+              addr,
+              len + 1,
+              size,
+              i_beat,
+              addr_t'(axi_pkg::beat_addr(addr, size, len, burst, i_beat))
+          );
+        end
+      end
+    end
+  end
+endmodule

--- a/test/tb_axi_addr_test.sv
+++ b/test/tb_axi_addr_test.sv
@@ -14,51 +14,138 @@
 // `axi_pkg::beat_addr`
 
 `include "axi/typedef.svh"
+/// Test bench for address generation
+module tb_axi_addr_test #(
+  /// Number of calculated AX transfers
+  int unsigned NumTests = 32'd100,
+  /// Print each calculated address
+  bit          PrintDbg = 1'b0
+);
 
-module tb_axi_addr_test;
+  typedef logic [15:0] addr_t;
 
-  typedef logic [16:0] addr_t;
+  /// The data transferred on a beat on the AW/AR channels.
+  class ax_transfer;
+    rand addr_t           addr  = '0;
+    rand axi_pkg::len_t   len   = '0;
+    rand axi_pkg::size_t  size  = '0;
+    rand axi_pkg::burst_t burst = '0;
+  endclass
 
-  localparam int unsigned NumAddr = 32'd4;
-  localparam addr_t [NumAddr-1:0] TestAddr = '{
-    16'h0000,
-    16'h0008,
-    16'h1000,
-    16'h003B
-  };
-  localparam axi_pkg::len_t [3:0] TestLen = '{
-    8'b1,
-    8'b11,
-    8'b111,
-    8'b1111
-  };
 
-  initial begin : proc_print_examples
-    automatic addr_t           addr;
-    automatic axi_pkg::burst_t burst = axi_pkg::BURST_WRAP;
-    automatic axi_pkg::len_t   len;
-    automatic axi_pkg::size_t  size  = 3'b011;
+  // Test Address queue
+  ax_transfer ax_queue[$];
+  addr_t      gold_addr[$];
 
-    $display("Bust Type is BURST_WRAP:");
-    for (int unsigned i_addr = 0; i_addr < NumAddr; i_addr++) begin
-      addr = TestAddr[i_addr];
-      for (int unsigned i_len = 0; i_len < 4; i_len++) begin
-        len = TestLen[i_len];
-        $display("####################################################################",);
-        $display("Wrap Boundary lower:  %h", addr_t'(axi_pkg::wrap_boundary(addr, size, len)));
-        $display("Wrap Boundary higher: %h", addr_t'(axi_pkg::wrap_boundary(addr, size, len) + (axi_pkg::num_bytes(size) * (len + 1))));
-        for (axi_pkg::len_t i_beat = 0; i_beat <= len; i_beat++) begin
+  initial begin : generate_tests
+    automatic logic       rand_success;
+    automatic ax_transfer ax_beat;
 
-          $display("Burst: %h Addr0: %h Beats: %0d Size: %h i_Beat: %0h Calc Addr: %h",
-              burst,
-              addr,
-              len + 1,
-              size,
-              i_beat,
-              addr_t'(axi_pkg::beat_addr(addr, size, len, burst, i_beat))
-          );
+    for (int unsigned i = 0; i < NumTests; i++) begin
+      ax_beat = new;
+      rand_success = std::randomize(ax_beat) with {
+        solve ax_beat.burst before ax_beat.addr, ax_beat.len, ax_beat.size;
+        // Randomize one of three burst types
+        ax_beat.burst inside {axi_pkg::BURST_FIXED, axi_pkg::BURST_INCR, axi_pkg::BURST_WRAP};
+        // Fix lengths if burst type is wrap
+        ax_beat.burst == axi_pkg::BURST_WRAP ->
+            ax_beat.len inside {axi_pkg::len_t'(1), axi_pkg::len_t'(3),
+                                axi_pkg::len_t'(7), axi_pkg::len_t'(15)};
+        // Do not cross a 4 KiB boundary with a burst
+        //ax_beat.burst == axi_pkg::BURST_INCR ->
+        //    ((ax_beat.addr >> 12) << 12) >= ax_beat.addr + 2**ax_beat.size * (ax_beat.len + 1);
+
+      }; assert(rand_success);
+      ax_queue.push_back(ax_beat);
+    end
+  end
+
+  initial begin : proc_test
+    automatic ax_transfer ax_beat;
+    automatic addr_t      test_addr, exp_addr;
+    for (int unsigned i = 0; i < NumTests; i++) begin
+      wait (ax_queue.size());
+      // get current transfer
+      ax_beat = ax_queue.pop_front();
+      if (PrintDbg) begin
+        print_ax(ax_beat);
+      end
+      // golden model derived from pseudocode from A-52
+      data_transfer(ax_beat.addr, (2**ax_beat.size), (ax_beat.len+1), ax_beat.burst);
+      // test the calculated addresses
+      for (int unsigned i = 0; i <= ax_beat.len; i++) begin
+        test_addr = axi_pkg::beat_addr(ax_beat.addr, ax_beat.size, ax_beat.len, ax_beat.burst, i);
+        exp_addr  = gold_addr.pop_front();
+        if (PrintDbg) begin
+          print_addr(test_addr, i);
         end
+        assert (test_addr == exp_addr) else
+          begin
+            print_ax(ax_beat);
+            print_addr(test_addr, i);
+            $error("Expected ADDR: %0h was ADDR: %0h", exp_addr, test_addr);
+          end
       end
     end
   end
+
+  // golden model derived from pseudocode from A-52
+  function automatic void data_transfer(addr_t start_addr, int unsigned num_bytes,
+      int unsigned burst_length, axi_pkg::burst_t mode);
+    // define boundaries wider than the address, to finf wrapp of addr space
+    localparam int unsigned large_addr = $bits(addr_t);
+    typedef logic [large_addr:0] laddr_t;
+
+    laddr_t      addr;
+    laddr_t      aligned_addr;
+    bit          aligned;
+    int unsigned dtsize;
+    laddr_t      lower_wrap_boundary;
+    laddr_t      upper_wrap_boundary;
+    assume (mode inside {axi_pkg::BURST_FIXED, axi_pkg::BURST_INCR, axi_pkg::BURST_WRAP});
+    addr         = laddr_t'(start_addr);
+    aligned_addr = laddr_t'((addr / num_bytes) * num_bytes);
+    aligned      = (aligned_addr == addr);
+    dtsize       = num_bytes * burst_length;
+
+    if (mode == axi_pkg::BURST_WRAP) begin
+      lower_wrap_boundary = laddr_t'((addr / dtsize) * dtsize);
+      upper_wrap_boundary = lower_wrap_boundary + dtsize;
+    end
+
+    for (int unsigned n = 1; n <= burst_length; n++) begin
+      gold_addr.push_back(addr_t'(addr));
+      // increment address if necessary
+      if (mode != axi_pkg::BURST_FIXED) begin
+        if (aligned) begin
+          addr += num_bytes;
+        end else begin
+          addr    = aligned_addr + num_bytes;
+          aligned = 1'b1;
+        end
+        if (mode == axi_pkg::BURST_WRAP && (addr >= upper_wrap_boundary)) begin
+          addr = lower_wrap_boundary;
+        end
+      end
+    end
+  endfunction : data_transfer
+
+  function automatic void print_ax (ax_transfer ax);
+    $display("####################################################################",);
+    $display("AX transfer with:");
+    case (ax.burst)
+      axi_pkg::BURST_FIXED: $display("TYPE: BURST_FIXED");
+      axi_pkg::BURST_INCR:  $display("TYPE: BURST_INCR");
+      axi_pkg::BURST_WRAP:  $display("TYPE: BURST_WRAP");
+      default : $error("TYPE: NOT_DEFINED");
+    endcase
+    $display("ADDR: %0h", ax.addr);
+    $display("SIZE: %0h", ax.size);
+    $display("LEN:  %0h", ax.len);
+  endfunction : print_ax
+
+  function automatic void print_addr(addr_t addr, int unsigned i_addr);
+    $display("i_beat: %0h ADDR: %0h", i_addr, addr);
+  endfunction : print_addr
+
 endmodule


### PR DESCRIPTION
This adds support for all burst types in `axi_pkg::beat_addr`.
Function now has two more inputs as they are required to calculate the wrap boundary in a wrapping type burst:
* `axi_pkg::len_t len`
* `axi_pkg::burst_t burst`

All occurrences in this repo have been updated to the new inputs.