### PR TITLE
Bender: Bump common_cells to 1.18.0

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -8,8 +8,8 @@ package:
     - "Wolfgang Roenninger <wroennin@ethz.ch>"
 
 dependencies:
-  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.16.4 }
-  common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.1.1 }
+  common_cells:        { git: "https://github.com/pulp-platform/common_cells.git",        version: 1.18.0 }
+  common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.1.1  }
 
 export_include_dirs:
   - include

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- `Bender:` Bump `common_cells` to `1.18.0`.
 
 ### Fixed
 


### PR DESCRIPTION
Some new streaming modules from `common_cells` will be needed for #33.