### PR TITLE
WIP: AXI4+ATOP Translation Lookaside Buffer (TLB)

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -48,9 +48,11 @@ sources:
   - src/axi_err_slv.sv
   - src/axi_dw_converter.sv
   - src/axi_multicut.sv
+  - src/axi_tlb_l1.sv
   - src/axi_to_axi_lite.sv
   # Level 4
   - src/axi_lite_xbar.sv
+  - src/axi_tlb.sv
   - src/axi_xbar.sv
 
   - target: synth_test

--- a/Bender.yml
+++ b/Bender.yml
@@ -85,5 +85,6 @@ sources:
       - test/tb_axi_modify_address.sv
       - test/tb_axi_serializer.sv
       - test/tb_axi_sim_mem.sv
+      - test/tb_axi_tlb.sv
       - test/tb_axi_to_axi_lite.sv
       - test/tb_axi_xbar.sv

--- a/src/axi_intf.sv
+++ b/src/axi_intf.sv
@@ -240,6 +240,20 @@ interface AXI_BUS_DV #(
   assert property (@(posedge clk_i) ( r_valid && ! r_ready |=> $stable(r_last)));
   assert property (@(posedge clk_i) ( r_valid && ! r_ready |=> $stable(r_user)));
   assert property (@(posedge clk_i) ( r_valid && ! r_ready |=> r_valid));
+  // Address-Channel Assertions: The address of the highest byte in the last beat of a burst must be
+  // on the same 4 KiB page as the address of the lowest byte in the first beat of a burst.
+  assert property (@(posedge clk_i) aw_valid |->
+    axi_pkg::beat_addr(aw_addr, aw_size, aw_len, aw_burst, 0) >> 12 == (
+      axi_pkg::beat_addr(aw_addr, aw_size, aw_len, aw_burst, aw_len)
+      + axi_pkg::beat_upper_byte(aw_addr, aw_size, aw_len, aw_burst, AXI_STRB_WIDTH, aw_len)
+    ) >> 12
+  ) else $error("AW burst crossing 4 KiB page boundary detected, which is illegal!");
+  assert property (@(posedge clk_i) ar_valid |->
+    axi_pkg::beat_addr(ar_addr, ar_size, ar_len, ar_burst, 0) >> 12 == (
+      axi_pkg::beat_addr(ar_addr, ar_size, ar_len, ar_burst, ar_len)
+      + axi_pkg::beat_upper_byte(ar_addr, ar_size, ar_len, ar_burst, AXI_STRB_WIDTH, ar_len)
+    ) >> 12
+  ) else $error("AR burst crossing 4 KiB page boundary detected, which is illegal!");
   `endif
   // pragma translate_on
 

--- a/src/axi_tlb.sv
+++ b/src/axi_tlb.sv
@@ -41,7 +41,7 @@ module axi_tlb #(
   /// Request type of main AXI4+ATOP master port
   parameter type mst_req_t = logic,
   /// Response type of main AXI4+ATOP slave and master ports
-  parameter type resp_t = logic,
+  parameter type axi_resp_t = logic,
   /// Request type of configuration AXI4-Lite slave port
   parameter type lite_req_t = logic,
   /// Response type of configuration AXI4-Lite slave port
@@ -56,11 +56,11 @@ module axi_tlb #(
   /// Main slave port request
   input  slv_req_t    slv_req_i,
   /// Main slave port response
-  output resp_t       slv_resp_o,
+  output axi_resp_t   slv_resp_o,
   /// Main master port request
   output mst_req_t    mst_req_o,
   /// Main master port response
-  output resp_t       mst_resp_i,
+  output axi_resp_t   mst_resp_i,
   /// Configuration port request
   input  lite_req_t   cfg_req_i,
   /// Configuration port response
@@ -146,8 +146,8 @@ module axi_tlb #(
   );
 
   // Join L1 TLB responses with Ax requests into demultiplexer.
-  slv_req_t demux_req;
-  resp_t    demux_resp;
+  slv_req_t   demux_req;
+  axi_resp_t  demux_resp;
   stream_join #(
     .N_INP  ( 2 )
   ) i_aw_join (
@@ -179,8 +179,8 @@ module axi_tlb #(
   assign demux_req.r_ready = slv_req_i.r_ready;
 
   // Demultiplex between address modifier for TLB hits and error slave for TLB misses.
-  slv_req_t mod_addr_req,   err_slv_req;
-  resp_t    mod_addr_resp,  err_slv_resp;
+  slv_req_t   mod_addr_req,   err_slv_req;
+  axi_resp_t  mod_addr_resp,  err_slv_resp;
   axi_demux #(
     .AxiIdWidth   ( AxiIdWidth        ),
     .aw_chan_t    ( slv_aw_t          ),
@@ -189,7 +189,7 @@ module axi_tlb #(
     .ar_chan_t    ( slv_ar_t          ),
     .r_chan_t     ( r_t               ),
     .req_t        ( slv_req_t         ),
-    .resp_t       ( resp_t            ),
+    .resp_t       ( axi_resp_t        ),
     .NoMstPorts   ( 2                 ),
     .MaxTrans     ( AxiSlvPortMaxTxns ),
     .AxiLookBits  ( AxiIdWidth        ),
@@ -226,10 +226,10 @@ module axi_tlb #(
   axi_modify_address #(
     .slv_addr_t ( slv_addr_t  ),
     .slv_req_t  ( slv_req_t   ),
-    .slv_resp_t ( resp_t      ),
+    .slv_resp_t ( axi_resp_t  ),
     .mst_addr_t ( mst_addr_t  ),
     .mst_req_t  ( mst_req_t   ),
-    .mst_resp_t ( resp_t      )
+    .mst_resp_t ( axi_resp_t  )
   ) i_mod_addr (
     .slv_req_i      ( mod_addr_req            ),
     .slv_resp_o     ( mod_addr_resp           ),
@@ -245,7 +245,7 @@ module axi_tlb #(
   axi_err_slv #(
     .AxiIdWidth   ( AxiIdWidth            ),
     .req_t        ( slv_req_t             ),
-    .resp_t       ( resp_t                ),
+    .resp_t       ( axi_resp_t            ),
     .Resp         ( axi_pkg::RESP_SLVERR  ),
     .RespWidth    ( 32'd32                ),
     .RespData     ( 32'hDEC0FFEE          ),

--- a/src/axi_tlb.sv
+++ b/src/axi_tlb.sv
@@ -224,21 +224,17 @@ module axi_tlb #(
 
   // Handle TLB hits: Replace address and forward to master port.
   axi_modify_address #(
-    .slv_addr_t ( slv_addr_t  ),
     .slv_req_t  ( slv_req_t   ),
-    .slv_resp_t ( axi_resp_t  ),
     .mst_addr_t ( mst_addr_t  ),
     .mst_req_t  ( mst_req_t   ),
-    .mst_resp_t ( axi_resp_t  )
+    .axi_resp_t ( axi_resp_t  )
   ) i_mod_addr (
     .slv_req_i      ( mod_addr_req            ),
     .slv_resp_o     ( mod_addr_resp           ),
-    .slv_aw_addr_o  ( /* unused */            ),
-    .slv_ar_addr_o  ( /* unused */            ),
-    .mst_req_o,
-    .mst_resp_i,
     .mst_aw_addr_i  ( l1_tlb_wr_res_addr_buf  ),
-    .mst_ar_addr_i  ( l1_tlb_rd_res_addr_buf  )
+    .mst_ar_addr_i  ( l1_tlb_rd_res_addr_buf  ),
+    .mst_req_o,
+    .mst_resp_i
   );
 
   // Handle TLB misses: Absorb burst and respond with slave error.

--- a/src/axi_tlb.sv
+++ b/src/axi_tlb.sv
@@ -1,0 +1,265 @@
+// Copyright (c) 2020 ETH Zurich, University of Bologna
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Andreas Kurth  <akurth@iis.ee.ethz.ch>
+
+`include "axi/typedef.svh"
+`include "common_cells/registers.svh"
+
+/// AXI4+ATOP Translation Lookaside Buffer (TLB)
+module axi_tlb #(
+  /// Address width of main AXI4+ATOP slave port
+  parameter int unsigned AxiSlvPortAddrWidth = 0,
+  /// Address width of main AXI4+ATOP master port
+  parameter int unsigned AxiMstPortAddrWidth = 0,
+  /// Data width of main AXI4+ATOP slave and master port
+  parameter int unsigned AxiDataWidth = 0,
+  /// ID width of main AXI4+ATOP slave and master port
+  parameter int unsigned AxiIdWidth = 0,
+  /// Width of user signal of main AXI4+ATOP slave and master port
+  parameter int unsigned AxiUserWidth = 0,
+  /// Maximum number of in-flight transactions on main AXI4+ATOP slave port
+  parameter int unsigned AxiSlvPortMaxTxns = 0,
+  /// Address width of configuration AXI4-Lite port
+  parameter int unsigned CfgAxiAddrWidth = 0,
+  /// Data width of configuration AXI4-Lite port
+  parameter int unsigned CfgAxiDataWidth = 0,
+  /// Number of entries in L1 TLB
+  parameter int unsigned L1NumEntries = 0,
+  /// Pipeline AW and AR channel after L1 TLB
+  parameter bit L1CutAx = 1'b1,
+  /// Request type of main AXI4+ATOP slave port
+  parameter type slv_req_t = logic,
+  /// Request type of main AXI4+ATOP master port
+  parameter type mst_req_t = logic,
+  /// Response type of main AXI4+ATOP slave and master ports
+  parameter type resp_t = logic,
+  /// Request type of configuration AXI4-Lite slave port
+  parameter type lite_req_t = logic,
+  /// Response type of configuration AXI4-Lite slave port
+  parameter type lite_resp_t = logic
+) (
+  /// Rising-edge clock of all ports
+  input  logic        clk_i,
+  /// Asynchronous reset, active low
+  input  logic        rst_ni,
+  /// Test mode enable
+  input  logic        test_en_i,
+  /// Main slave port request
+  input  slv_req_t    slv_req_i,
+  /// Main slave port response
+  output resp_t       slv_resp_o,
+  /// Main master port request
+  output mst_req_t    mst_req_o,
+  /// Main master port response
+  output resp_t       mst_resp_i,
+  /// Configuration port request
+  input  lite_req_t   cfg_req_i,
+  /// Configuration port response
+  output lite_resp_t  cfg_resp_o
+);
+
+  typedef logic [AxiSlvPortAddrWidth-1:0] slv_addr_t;
+  typedef logic [AxiMstPortAddrWidth-1:0] mst_addr_t;
+  typedef logic [AxiDataWidth       -1:0] data_t;
+  typedef logic [AxiIdWidth         -1:0] id_t;
+  typedef logic [AxiDataWidth/8     -1:0] strb_t;
+  typedef logic [AxiUserWidth       -1:0] user_t;
+  `AXI_TYPEDEF_AW_CHAN_T(slv_aw_t, slv_addr_t, id_t, user_t)
+  `AXI_TYPEDEF_AW_CHAN_T(mst_aw_t, mst_addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(w_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(b_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(slv_ar_t, slv_addr_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(mst_ar_t, mst_addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(r_t, data_t, id_t, user_t)
+  /// Translation lookup result.
+  typedef struct packed {
+    logic       hit;
+    mst_addr_t  addr;
+  } tlb_res_t;
+
+  // Fork input requests into L1 TLB.
+  logic aw_valid,             ar_valid,
+        aw_ready,             ar_ready,
+        l1_tlb_wr_req_valid,  l1_tlb_rd_req_valid,
+        l1_tlb_wr_req_ready,  l1_tlb_rd_req_ready;
+  stream_fork #(
+    .N_OUP  ( 2 )
+  ) i_aw_fork (
+    .clk_i,
+    .rst_ni,
+    .valid_i  ( slv_req_i.aw_valid              ),
+    .ready_o  ( slv_req_i.aw_ready              ),
+    .valid_o  ( {l1_tlb_wr_req_valid, aw_valid} ),
+    .ready_i  ( {l1_tlb_wr_req_ready, aw_ready} )
+  );
+  stream_fork #(
+    .N_OUP  ( 2 )
+  ) i_ar_fork (
+    .clk_i,
+    .rst_ni,
+    .valid_i  ( slv_req_i.ar_valid              ),
+    .ready_o  ( slv_req_i.ar_ready              ),
+    .valid_o  ( {l1_tlb_rd_req_valid, ar_valid} ),
+    .ready_i  ( {l1_tlb_rd_req_ready, ar_ready} )
+  );
+
+  // L1 TLB
+  tlb_res_t l1_tlb_wr_res,        l1_tlb_rd_res;
+  logic     l1_tlb_wr_res_valid,  l1_tlb_rd_res_valid,
+            l1_tlb_wr_res_ready,  l1_tlb_rd_res_ready;
+  axi_tlb_l1 #(
+    .InpAddrWidth     ( AxiSlvPortAddrWidth ),
+    .OupAddrWidth     ( AxiMstPortAddrWidth ),
+    .NumEntries       ( L1NumEntries        ),
+    .CfgAxiAddrWidth  ( CfgAxiAddrWidth     ),
+    .CfgAxiDataWidth  ( CfgAxiDataWidth     ),
+    .lite_req_t       ( lite_req_t          ),
+    .lite_resp_t      ( lite_resp_t         ),
+    .res_t            ( tlb_res_t           )
+  ) i_l1_tlb (
+    .clk_i,
+    .rst_ni,
+    .test_en_i,
+    .wr_req_addr_i  ( slv_req_i.aw.addr   ),
+    .wr_req_valid_i ( l1_tlb_wr_req_valid ),
+    .wr_req_ready_o ( l1_tlb_wr_req_ready ),
+    .wr_res_o       ( l1_tlb_wr_res       ),
+    .wr_res_valid_o ( l1_tlb_wr_res_valid ),
+    .wr_res_ready_i ( l1_tlb_wr_res_ready ),
+    .rd_req_addr_i  ( slv_req_i.ar.addr   ),
+    .rd_req_valid_i ( l1_tlb_rd_req_valid ),
+    .rd_req_ready_o ( l1_tlb_rd_req_ready ),
+    .rd_res_o       ( l1_tlb_rd_res       ),
+    .rd_res_valid_o ( l1_tlb_rd_res_valid ),
+    .rd_res_ready_i ( l1_tlb_rd_res_ready ),
+    .cfg_req_i,
+    .cfg_resp_o
+  );
+
+  // Join L1 TLB responses with Ax requests into demultiplexer.
+  slv_req_t demux_req;
+  resp_t    demux_resp;
+  stream_join #(
+    .N_INP  ( 2 )
+  ) i_aw_join (
+    .inp_valid_i  ( {l1_tlb_wr_res_valid, aw_valid} ),
+    .inp_ready_o  ( {l1_tlb_wr_res_ready, aw_ready} ),
+    .oup_valid_o  ( demux_req.aw_valid              ),
+    .oup_ready_i  ( demux_resp.aw_ready             )
+  );
+  assign demux_req.aw = slv_req_i.aw;
+  stream_join #(
+    .N_INP  ( 2 )
+  ) i_ar_join (
+    .inp_valid_i  ( {l1_tlb_rd_res_valid, ar_valid} ),
+    .inp_ready_o  ( {l1_tlb_rd_res_ready, ar_ready} ),
+    .oup_valid_o  ( demux_req.ar_valid              ),
+    .oup_ready_i  ( demux_resp.ar_ready             )
+  );
+  assign demux_req.ar = slv_req_i.ar;
+
+  // Connect W, B, and R channels directly between demultiplexer and slave port.
+  assign demux_req.w = slv_req_i.w;
+  assign demux_req.w_valid = slv_req_i.w_valid;
+  assign slv_resp_o.w_ready = demux_resp.w_ready;
+  assign slv_resp_o.b = demux_resp.b;
+  assign slv_resp_o.b_valid = demux_resp.b_valid;
+  assign demux_req.b_ready = slv_req_i.b_ready;
+  assign slv_resp_o.r = demux_resp.r;
+  assign slv_resp_o.r_valid = demux_resp.r_valid;
+  assign demux_req.r_ready = slv_req_i.r_ready;
+
+  // Demultiplex between address modifier for TLB hits and error slave for TLB misses.
+  slv_req_t mod_addr_req,   err_slv_req;
+  resp_t    mod_addr_resp,  err_slv_resp;
+  axi_demux #(
+    .AxiIdWidth   ( AxiIdWidth        ),
+    .aw_chan_t    ( slv_aw_t          ),
+    .w_chan_t     ( w_t               ),
+    .b_chan_t     ( b_t               ),
+    .ar_chan_t    ( slv_ar_t          ),
+    .r_chan_t     ( r_t               ),
+    .req_t        ( slv_req_t         ),
+    .resp_t       ( resp_t            ),
+    .NoMstPorts   ( 2                 ),
+    .MaxTrans     ( AxiSlvPortMaxTxns ),
+    .AxiLookBits  ( AxiIdWidth        ),
+    .FallThrough  ( 1'b0              ),
+    .SpillAw      ( L1CutAx           ),
+    .SpillW       ( 1'b0              ),
+    .SpillB       ( 1'b0              ),
+    .SpillAr      ( L1CutAx           ),
+    .SpillR       ( 1'b0              )
+  ) i_slv_demux (
+    .clk_i,
+    .rst_ni,
+    .test_i           ( test_en_i                       ),
+    .slv_req_i        ( demux_req                       ),
+    .slv_aw_select_i  ( l1_tlb_wr_res.hit               ),
+    .slv_ar_select_i  ( l1_tlb_rd_res.hit               ),
+    .slv_resp_o       ( demux_resp                      ),
+    .mst_reqs_o       ( {mod_addr_req,   err_slv_req}   ),
+    .mst_resps_i      ( {mod_addr_resp,  err_slv_resp}  )
+  );
+
+  // Pipeline translated address together with AW and AR.
+  mst_addr_t  l1_tlb_wr_res_addr_buf,
+              l1_tlb_rd_res_addr_buf;
+  if (L1CutAx) begin : gen_res_addr_buf
+    `FFARN(l1_tlb_wr_res_addr_buf, l1_tlb_wr_res.addr, '0, clk_i, rst_ni)
+    `FFARN(l1_tlb_rd_res_addr_buf, l1_tlb_rd_res.addr, '0, clk_i, rst_ni)
+  end else begin : gen_no_res_addr_buf
+    assign l1_tlb_wr_res_addr_buf = l1_tlb_wr_res.addr;
+    assign l1_tlb_rd_res_addr_buf = l1_tlb_rd_res.addr;
+  end
+
+  // Handle TLB hits: Replace address and forward to master port.
+  axi_modify_address #(
+    .slv_addr_t ( slv_addr_t  ),
+    .slv_req_t  ( slv_req_t   ),
+    .slv_resp_t ( resp_t      ),
+    .mst_addr_t ( mst_addr_t  ),
+    .mst_req_t  ( mst_req_t   ),
+    .mst_resp_t ( resp_t      )
+  ) i_mod_addr (
+    .slv_req_i      ( mod_addr_req            ),
+    .slv_resp_o     ( mod_addr_resp           ),
+    .slv_aw_addr_o  ( /* unused */            ),
+    .slv_ar_addr_o  ( /* unused */            ),
+    .mst_req_o,
+    .mst_resp_i,
+    .mst_aw_addr_i  ( l1_tlb_wr_res_addr_buf  ),
+    .mst_ar_addr_i  ( l1_tlb_rd_res_addr_buf  )
+  );
+
+  // Handle TLB misses: Absorb burst and respond with slave error.
+  axi_err_slv #(
+    .AxiIdWidth   ( AxiIdWidth            ),
+    .req_t        ( slv_req_t             ),
+    .resp_t       ( resp_t                ),
+    .Resp         ( axi_pkg::RESP_SLVERR  ),
+    .RespWidth    ( 32'd32                ),
+    .RespData     ( 32'hDEC0FFEE          ),
+    .ATOPs        ( 1'b1                  ),
+    .MaxTrans     ( 1                     )
+  ) i_err_slv (
+    .clk_i,
+    .rst_ni,
+    .test_i     ( test_en_i     ),
+    .slv_req_i  ( err_slv_req   ),
+    .slv_resp_o ( err_slv_resp  )
+  );
+
+  // TODO: many parameter and type assertions
+endmodule
+
+// TODO: interface variant `axi_tlb_intf`

--- a/src/axi_tlb.sv
+++ b/src/axi_tlb.sv
@@ -60,7 +60,7 @@ module axi_tlb #(
   /// Main master port request
   output mst_req_t    mst_req_o,
   /// Main master port response
-  output axi_resp_t   mst_resp_i,
+  input  axi_resp_t   mst_resp_i,
   /// Configuration port request
   input  lite_req_t   cfg_req_i,
   /// Configuration port response

--- a/src/axi_tlb.sv
+++ b/src/axi_tlb.sv
@@ -97,7 +97,7 @@ module axi_tlb #(
     .clk_i,
     .rst_ni,
     .valid_i  ( slv_req_i.aw_valid              ),
-    .ready_o  ( slv_req_i.aw_ready              ),
+    .ready_o  ( slv_resp_o.aw_ready             ),
     .valid_o  ( {l1_tlb_wr_req_valid, aw_valid} ),
     .ready_i  ( {l1_tlb_wr_req_ready, aw_ready} )
   );
@@ -107,7 +107,7 @@ module axi_tlb #(
     .clk_i,
     .rst_ni,
     .valid_i  ( slv_req_i.ar_valid              ),
-    .ready_o  ( slv_req_i.ar_ready              ),
+    .ready_o  ( slv_resp_o.ar_ready             ),
     .valid_o  ( {l1_tlb_rd_req_valid, ar_valid} ),
     .ready_i  ( {l1_tlb_rd_req_ready, ar_ready} )
   );

--- a/src/axi_tlb_l1.sv
+++ b/src/axi_tlb_l1.sv
@@ -80,17 +80,17 @@ module axi_tlb_l1 #(
   typedef logic [OupPageNumWidth-1:0] oup_page_t;
   /// Translation table entry with 4 KiB page granularity
   typedef struct packed {
-    /// Number of first page in input address segment
-    inp_page_t  first;
-    /// Number of last page (inclusive) in input address segment
-    inp_page_t  last;
+    /// Defines whether this entry can only be used for read accesses.
+    logic       read_only;
+    /// Defines whether this entry is valid.
+    logic       valid;
     /// Number of first page in output address segment; that is, the output address segment starts
     /// at this `base` page.
     oup_page_t  base;
-    /// Defines whether this entry is valid.
-    logic       valid;
-    /// Defines whether this entry can only be used for read accesses.
-    logic       read_only;
+    /// Number of last page (inclusive) in input address segment
+    inp_page_t  last;
+    /// Number of first page in input address segment
+    inp_page_t  first;
   } entry_t;
 
   entry_t [NumEntries-1:0]  entries;

--- a/src/axi_tlb_l1.sv
+++ b/src/axi_tlb_l1.sv
@@ -74,14 +74,22 @@ module axi_tlb_l1 #(
   localparam int unsigned InpPageNumWidth = InpAddrWidth - 12;
   localparam int unsigned OupPageNumWidth = OupAddrWidth - 12;
 
+  /// Page number in input address space
   typedef logic [InpPageNumWidth-1:0] inp_page_t;
+  /// Page number in output address space
   typedef logic [OupPageNumWidth-1:0] oup_page_t;
+  /// Translation table entry with 4 KiB page granularity
   typedef struct packed {
-    inp_addr_t  first;
+    /// Number of first page in input address segment
     inp_page_t  first;
+    /// Number of last page (inclusive) in input address segment
     inp_page_t  last;
+    /// Number of first page in output address segment; that is, the output address segment starts
+    /// at this `base` page.
     oup_page_t  base;
+    /// Defines whether this entry is valid.
     logic       valid;
+    /// Defines whether this entry can only be used for read accesses.
     logic       read_only;
   } entry_t;
 

--- a/src/axi_tlb_l1.sv
+++ b/src/axi_tlb_l1.sv
@@ -145,8 +145,19 @@ module axi_tlb_l1 #(
   localparam int unsigned EntryBytesAligned =
       2 * InpPageNumBytesAligned + OupPageNumBytesAligned + FlagBytesAligned;
   localparam int unsigned RegNumBytes = NumEntries * EntryBytesAligned;
-  // FIXME: generalize
-  localparam bit [RegNumBytes-1:0] AxiReadOnly = 64'b1110100010001000111010001000100011101000100010001110100010001000;
+  typedef struct packed {
+    bit [FlagBytesAligned-1:0]        flags;
+    bit [OupPageNumBytesAligned-1:0]  base;
+    bit [InpPageNumBytesAligned-1:0]  last;
+    bit [InpPageNumBytesAligned-1:0]  first;
+  } entry_bits_t;
+  localparam entry_bits_t [NumEntries-1:0] AxiReadOnly = '{NumEntries{'{
+    flags:              {{FlagBytesAligned-FlagBytes{1'b1}},       {FlagBytes{1'b0}}},
+    base:   {{OupPageNumBytesAligned-OupPageNumBytes{1'b1}}, {OupPageNumBytes{1'b0}}},
+    last:   {{InpPageNumBytesAligned-InpPageNumBytes{1'b1}}, {InpPageNumBytes{1'b0}}},
+    first:  {{InpPageNumBytesAligned-InpPageNumBytes{1'b1}}, {InpPageNumBytes{1'b0}}},
+    default: 1'b0 // this should not be needed, but in doubt better make the bytes writeable
+  }}};
   typedef logic [7:0] byte_t;
   byte_t [RegNumBytes-1:0] reg_q;
   axi_lite_regs #(

--- a/src/axi_tlb_l1.sv
+++ b/src/axi_tlb_l1.sv
@@ -223,10 +223,10 @@ module axi_tlb_l1_chan #(
   // Determine all entries matching a request.
   logic [NumEntries-1:0] entry_matches;
   for (genvar i = 0; i < NumEntries; i++) begin : gen_matches
-    assign entry_matches[i] = entries[i].valid & req_valid_i
-        & (req_page_i >= entries[i].first)
-        & (req_page_i <= entries[i].last)
-        & (~IsWriteChannel | ~entries[i].read_only);
+    assign entry_matches[i] = entries_i[i].valid & req_valid_i
+        & (req_page_i >= entries_i[i].first)
+        & (req_page_i <= entries_i[i].last)
+        & (~IsWriteChannel | ~entries_i[i].read_only);
   end
 
   // Determine entry with lowest index that matches the request.
@@ -249,14 +249,14 @@ module axi_tlb_l1_chan #(
     req_ready_o = 1'b0;
     res = '{default: '0};
     if (req_valid_i) begin
-      res_o.hit = ~no_match;
-      res_o.addr = (entries[match_idx].base + (req_page_i - entries[match_idx].first)) << 12;
+      res.hit = ~no_match;
+      res.addr = (entries_i[match_idx].base + (req_page_i - entries_i[match_idx].first)) << 12;
       res_valid = 1'b1;
       req_ready_o = res_ready;
     end
   end
   // Store translation in fall-through register.  This prevents changes in the translated address
-  // due to changes in `entries` while downstream handshake is outstanding.
+  // due to changes in `entries_i` while downstream handshake is outstanding.
   fall_through_register #(
     .T  ( res_t )
   ) i_res_ft_reg (

--- a/src/axi_tlb_l1.sv
+++ b/src/axi_tlb_l1.sv
@@ -1,0 +1,246 @@
+// Copyright (c) 2020 ETH Zurich, University of Bologna
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Andreas Kurth  <akurth@iis.ee.ethz.ch>
+
+/// Internal module of [`axi_tlb`](module.axi_tlb): L1 translation table.
+module axi_tlb_l1 #(
+  /// Width of addresses in input address space
+  parameter int unsigned InpAddrWidth = 0,
+  /// Width of addresses in output address space
+  parameter int unsigned OupAddrWidth = 0,
+  /// Number of entries in translation table
+  parameter int unsigned NumEntries = 0,
+  /// Address width of configuration AXI4-Lite port
+  parameter int unsigned CfgAxiAddrWidth = 0,
+  /// Data width of configuration AXI4-Lite port
+  parameter int unsigned CfgAxiDataWidth = 0,
+  /// Request type of configuration AXI4-Lite slave port
+  parameter type lite_req_t = logic,
+  /// Response type of configuration AXI4-Lite slave port
+  parameter type lite_resp_t = logic,
+  /// Type of translation result.  Must have a single-bit field `hit` and an `addr` field as wide as
+  /// the output address.
+  parameter type res_t = logic,
+  /// Derived (=do not override) type of input addresses
+  parameter type inp_addr_t = logic [InpAddrWidth-1:0],
+  /// Derived (=do not override) type of output addresses
+  parameter type oup_addr_t = logic [OupAddrWidth-1:0]
+) (
+  /// Rising-edge clock of all ports
+  input  logic        clk_i,
+  /// Asynchronous reset, active low
+  input  logic        rst_ni,
+  /// Test mode enable
+  input  logic        test_en_i,
+  /// Write request input address
+  input  inp_addr_t   wr_req_addr_i,
+  /// Write request valid
+  input  logic        wr_req_valid_i,
+  /// Write request ready
+  output logic        wr_req_ready_o,
+  /// Write translation result
+  output res_t        wr_res_o,
+  /// Write translation result valid
+  output logic        wr_res_valid_o,
+  /// Write translation result ready
+  input  logic        wr_res_ready_i,
+  /// Read request input address
+  input  inp_addr_t   rd_req_addr_i,
+  /// Read request valid
+  input  logic        rd_req_valid_i,
+  /// Read request ready
+  output logic        rd_req_ready_o,
+  /// Read translation result
+  output res_t        rd_res_o,
+  /// Read translation result valid
+  output logic        rd_res_valid_o,
+  /// Read translation result ready
+  input  logic        rd_res_ready_i,
+  /// Configuration port request
+  input  lite_req_t   cfg_req_i,
+  /// Configuration port response
+  output lite_resp_t  cfg_resp_o
+);
+
+  typedef struct packed {
+    inp_addr_t  first;
+    inp_addr_t  last;
+    oup_addr_t  base;
+    logic       valid;
+    logic       read_only;
+  } entry_t;
+
+  entry_t [NumEntries-1:0]  entries;
+
+  // Write channel
+  axi_tlb_l1_chan #(
+    .NumEntries     ( NumEntries  ),
+    .IsWriteChannel ( 1'b1        ),
+    .inp_addr_t     ( inp_addr_t  ),
+    .entry_t        ( entry_t     ),
+    .res_t          ( res_t       )
+  ) i_wr_chan (
+    .clk_i,
+    .rst_ni,
+    .test_en_i,
+    .entries_i    ( entries         ),
+    .req_addr_i   ( wr_req_addr_i   ),
+    .req_valid_i  ( wr_req_valid_i  ),
+    .req_ready_o  ( wr_req_ready_o  ),
+    .res_o        ( wr_res_o        ),
+    .res_valid_o  ( wr_res_valid_o  ),
+    .res_ready_i  ( wr_res_ready_i  )
+  );
+
+  // Read channel
+  axi_tlb_l1_chan #(
+    .NumEntries     ( NumEntries  ),
+    .IsWriteChannel ( 1'b0        ),
+    .inp_addr_t     ( inp_addr_t  ),
+    .entry_t        ( entry_t     ),
+    .res_t          ( res_t       )
+  ) i_rd_chan (
+    .clk_i,
+    .rst_ni,
+    .test_en_i,
+    .entries_i    ( entries         ),
+    .req_addr_i   ( rd_req_addr_i   ),
+    .req_valid_i  ( rd_req_valid_i  ),
+    .req_ready_o  ( rd_req_ready_o  ),
+    .res_o        ( rd_res_o        ),
+    .res_valid_o  ( rd_res_valid_o  ),
+    .res_ready_i  ( rd_res_ready_i  )
+  );
+
+  // Table entries from AXI4-Lite registers
+  localparam NumAxiRegs = 13; // TODO
+  localparam RegDataWidth = 42; // TODO
+  axi_lite_regs #(
+    .NumAxiRegs     ( NumAxiRegs      ),
+    .AxiAddrWidth   ( CfgAxiAddrWidth ),
+    .AxiDataWidth   ( CfgAxiDataWidth ),
+    .PrivProtOnly   ( 1'b0            ),
+    .SecuProtOnly   ( 1'b0            ),
+    .RegDataWidth   ( RegDataWidth    ),
+    .AxiReadOnly    ( 1'b0            ),
+    .req_lite_t     ( lite_req_t      ),
+    .resp_lite_t    ( lite_resp_t     )
+  ) i_regs (
+    .clk_i,
+    .rst_ni,
+    .axi_req_i        ( cfg_req_i                             ),
+    .axi_resp_o       ( cfg_resp_o                            ),
+    .axi_base_addr_i  ( /* TODO */                            ),
+    .axi_wr_idx_o     ( /* unused */                          ),
+    .axi_wr_active_o  ( /* unused */                          ),
+    .axi_rd_idx_o     ( /* unused */                          ),
+    .axi_rd_active_o  ( /* unused */                          ),
+    .reg_d_i          ( '{NumAxiRegs{'{RegDataWidth{1'b0}}}}  ),
+    .reg_load_i       ( '{NumAxiRegs{1'b0}}                   ),
+    .reg_q_o          ( /* TODO */                            )
+  );
+
+endmodule
+
+
+/// Internal module of [`axi_tlb_l1`](module.axi_tlb_l1): Channel handler.
+module axi_tlb_l1_chan #(
+  /// Number of entries in translation table
+  parameter int unsigned NumEntries = 0,
+  /// Is this channel is used for writes?
+  parameter logic IsWriteChannel = 1'b0,
+  /// Type of input address
+  parameter type inp_addr_t = logic,
+  /// Type of a translation table entry
+  parameter type entry_t = logic,
+  /// Type of translation result
+  parameter type res_t = logic
+) (
+  /// Rising-edge clock
+  input  logic                    clk_i,
+  /// Asynchronous reset, active low
+  input  logic                    rst_ni,
+  /// Test mode enable
+  input  logic                    test_en_i,
+  /// Translation table entries
+  input  entry_t [NumEntries-1:0] entries_i,
+  /// Request input address
+  input  inp_addr_t               req_addr_i,
+  /// Request valid
+  input  logic                    req_valid_i,
+  /// Request ready
+  output logic                    req_ready_o,
+  /// Translation result
+  output res_t                    res_o,
+  /// Translation result valid
+  output logic                    res_valid_o,
+  /// Translation result ready
+  input  logic                    res_ready_i
+);
+
+  localparam int unsigned EntryIdxWidth = NumEntries > 1 ? $clog2(NumEntries) : 1;
+
+  typedef logic [EntryIdxWidth-1:0] entry_idx_t;
+
+  // Determine all entries matching a request.
+  logic [NumEntries-1:0] entry_matches;
+  for (genvar i = 0; i < NumEntries; i++) begin : gen_matches
+    assign entry_matches[i] = entries[i].valid & req_valid_i
+        & (req_addr_i >= entries[i].first)
+        & (req_addr_i <= entries[i].last)
+        & (~IsWriteChannel | ~entries[i].read_only);
+  end
+
+  // Determine entry with lowest index that matches the request.
+  entry_idx_t match_idx;
+  logic       no_match;
+  lzc #(
+    .WIDTH  ( NumEntries  ),
+    .MODE   ( 1'b0        )   // trailing zeros -> lowest match
+  ) i_lzc (
+    .in_i     ( entry_matches ),
+    .cnt_o    ( match_idx     ),
+    .empty_o  ( no_match      )
+  );
+
+  // Handle request and translate address.
+  logic res_valid, res_ready;
+  res_t res;
+  always_comb begin
+    res_valid = 1'b0;
+    req_ready_o = 1'b0;
+    res = '{default: '0};
+    if (req_valid_i) begin
+      res_o.hit = ~no_match;
+      res_o.addr = entries[match_idx].base + (req_addr_i - entries[match_idx].first);
+      res_valid = 1'b1;
+      req_ready_o = res_ready;
+    end
+  end
+  // Store translation in fall-through register.  This prevents changes in the translated address
+  // due to changes in `entries` while downstream handshake is outstanding.
+  fall_through_register #(
+    .T  ( res_t )
+  ) i_res_ft_reg (
+    .clk_i,
+    .rst_ni,
+    .clr_i      ( 1'b0        ),
+    .testmode_i ( test_en_i   ),
+    .valid_i    ( res_valid   ),
+    .ready_o    ( res_ready   ),
+    .data_i     ( res         ),
+    .valid_o    ( res_valid_o ),
+    .ready_i    ( res_ready_i ),
+    .data_o     ( res_o       )
+  );
+
+endmodule

--- a/src_files.yml
+++ b/src_files.yml
@@ -39,9 +39,11 @@ axi:
     - src/axi_err_slv.sv
     - src/axi_dw_converter.sv
     - src/axi_multicut.sv
+    - src/axi_tlb_l1.sv
     - src/axi_to_axi_lite.sv
     # Level 4
     - src/axi_lite_xbar.sv
+    - src/axi_tlb.sv
     - src/axi_xbar.sv
 
 axi_sim:

--- a/test/tb_axi_tlb.sv
+++ b/test/tb_axi_tlb.sv
@@ -1,0 +1,375 @@
+// Copyright (c) 2020 ETH Zurich, University of Bologna
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Andreas Kurth  <akurth@iis.ee.ethz.ch>
+
+`include "axi/assign.svh"
+`include "axi/typedef.svh"
+
+/// Testbench for [`axi_tlb`](module.axi_tlb)
+module tb_axi_tlb #(
+  // DUT Parameters
+  parameter int unsigned AxiSlvPortAddrWidth = 32,
+  parameter int unsigned AxiMstPortAddrWidth = 64,
+  parameter int unsigned AxiDataWidth = 32,
+  parameter int unsigned AxiIdWidth = 4,
+  parameter int unsigned AxiUserWidth = 4,
+  parameter int unsigned AxiSlvPortMaxTxns = 4,
+  parameter int unsigned CfgAxiAddrWidth = 32,
+  parameter int unsigned CfgAxiDataWidth = 32,
+  parameter int unsigned L1NumEntries = 4,
+  parameter bit L1CutAx = 1'b1,
+  // TB Parameters
+  parameter int unsigned NumReads = 1000,
+  parameter int unsigned NumWrites = 1000,
+  parameter time CyclTime = 10ns,
+  parameter time ApplTime = 2ns,
+  parameter time TestTime = 8ns
+);
+
+  // Clock and reset
+  logic clk,  rst_n;
+  clk_rst_gen #(
+    .CLK_PERIOD     ( CyclTime  ),
+    .RST_CLK_CYCLES ( 5         )
+  ) i_clk_rst_gen (
+    .clk_o  ( clk   ),
+    .rst_no ( rst_n )
+  );
+
+  // Interfaces
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH ( AxiSlvPortAddrWidth ),
+    .AXI_DATA_WIDTH ( AxiDataWidth        ),
+    .AXI_ID_WIDTH   ( AxiIdWidth          ),
+    .AXI_USER_WIDTH ( AxiUserWidth        )
+  ) upstream_dv (clk);
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH ( AxiSlvPortAddrWidth ),
+    .AXI_DATA_WIDTH ( AxiDataWidth        ),
+    .AXI_ID_WIDTH   ( AxiIdWidth          ),
+    .AXI_USER_WIDTH ( AxiUserWidth        )
+  ) upstream ();
+  `AXI_ASSIGN(upstream, upstream_dv)
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH ( AxiMstPortAddrWidth ),
+    .AXI_DATA_WIDTH ( AxiDataWidth        ),
+    .AXI_ID_WIDTH   ( AxiIdWidth          ),
+    .AXI_USER_WIDTH ( AxiUserWidth        )
+  ) downstream ();
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH ( AxiMstPortAddrWidth ),
+    .AXI_DATA_WIDTH ( AxiDataWidth        ),
+    .AXI_ID_WIDTH   ( AxiIdWidth          ),
+    .AXI_USER_WIDTH ( AxiUserWidth        )
+  ) downstream_dv (clk);
+  `AXI_ASSIGN(downstream_dv, downstream)
+  AXI_LITE_DV #(
+    .AXI_ADDR_WIDTH ( CfgAxiAddrWidth ),
+    .AXI_DATA_WIDTH ( CfgAxiDataWidth )
+  ) cfg_dv (clk);
+  AXI_LITE #(
+    .AXI_ADDR_WIDTH ( CfgAxiAddrWidth ),
+    .AXI_DATA_WIDTH ( CfgAxiDataWidth )
+  ) cfg ();
+  `AXI_LITE_ASSIGN(cfg, cfg_dv)
+
+  // DUT
+  axi_tlb_intf #(
+    .AXI_SLV_PORT_ADDR_WIDTH  ( AxiSlvPortAddrWidth ),
+    .AXI_MST_PORT_ADDR_WIDTH  ( AxiMstPortAddrWidth ),
+    .AXI_DATA_WIDTH           ( AxiDataWidth        ),
+    .AXI_ID_WIDTH             ( AxiIdWidth          ),
+    .AXI_USER_WIDTH           ( AxiUserWidth        ),
+    .AXI_SLV_PORT_MAX_TXNS    ( AxiSlvPortMaxTxns   ),
+    .CFG_AXI_ADDR_WIDTH       ( CfgAxiAddrWidth     ),
+    .CFG_AXI_DATA_WIDTH       ( CfgAxiDataWidth     ),
+    .L1_NUM_ENTRIES           ( L1NumEntries        ),
+    .L1_CUT_AX                ( L1CutAx             )
+  ) i_dut (
+    .clk_i      ( clk         ),
+    .rst_ni     ( rst_n       ),
+    .test_en_i  ( 1'b0        ),
+    .slv        ( upstream    ),
+    .mst        ( downstream  ),
+    .cfg        ( cfg         )
+  );
+
+  // Configuration port driver
+  axi_test::axi_lite_driver #(
+    .AW ( CfgAxiAddrWidth ),
+    .DW ( CfgAxiDataWidth ),
+    .TA ( ApplTime        ),
+    .TT ( TestTime        )
+  ) cfg_driver = new(cfg_dv);
+  typedef logic [CfgAxiAddrWidth-1:0] cfg_addr_t;
+  typedef logic [CfgAxiDataWidth-1:0] cfg_data_t;
+  task automatic write_cfg(cfg_addr_t addr, cfg_data_t data);
+    axi_pkg::resp_t resp;
+    fork
+      cfg_driver.send_aw(addr, '0);
+      cfg_driver.send_w(data, 4'b1111);
+    join
+    cfg_driver.recv_b(resp);
+    assert(resp == axi_pkg::RESP_OKAY);
+  endtask
+  typedef logic [31:0] pfn_t;
+  localparam pfn_t first_pfn = 32'h1;      // first PFN (page frame number) of input range
+  localparam pfn_t last_pfn = 32'h7_FFFF;  // last PFN of input range
+  localparam pfn_t base_pfn = 32'h1_0000;  // map to output range starting with this address
+  initial begin
+    cfg_driver.reset_master();
+    wait (rst_n);
+    write_cfg(32'h0000_0000, first_pfn);
+    write_cfg(32'h0000_0004, last_pfn);
+    write_cfg(32'h0000_0008, base_pfn);
+    // make valid and read-writable
+    if (AxiMstPortAddrWidth <= 32) begin
+      write_cfg(32'h0000_000C, 32'h0000_0001);
+    end else begin
+      write_cfg(32'h0000_0010, 32'h0000_0001);
+    end
+  end
+
+  // Capture transactions into upstream and downstream queues.
+  localparam AxiStrbWidth = AxiDataWidth / 8;
+  typedef logic [AxiSlvPortAddrWidth-1:0] slv_addr_t;
+  typedef logic [AxiMstPortAddrWidth-1:0] mst_addr_t;
+  typedef logic [AxiDataWidth-1:0]        data_t;
+  typedef logic [AxiIdWidth-1:0]          id_t;
+  typedef logic [AxiStrbWidth-1:0]        strb_t;
+  typedef logic [AxiUserWidth-1:0]        user_t;
+  `AXI_TYPEDEF_AW_CHAN_T(slv_aw_t, slv_addr_t, id_t, user_t)
+  `AXI_TYPEDEF_AW_CHAN_T(mst_aw_t, mst_addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(w_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(b_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(slv_ar_t, slv_addr_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(mst_ar_t, mst_addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(r_t, data_t, id_t, user_t)
+  localparam int unsigned AxiNumIds = 2**AxiIdWidth;
+  mst_aw_t  downstream_aw,
+            downstream_exp_aw_queue[$];
+  w_t       upstream_w,
+            downstream_w,
+            downstream_exp_w_queue[$];
+  b_t       upstream_b,
+            downstream_b_queue[AxiNumIds-1:0][$],
+            downstream_b;
+  mst_ar_t  downstream_ar,
+            downstream_exp_ar_queue[$];
+  r_t       upstream_r,
+            downstream_r_queue[AxiNumIds-1:0][$],
+            downstream_r;
+  `AXI_ASSIGN_TO_W(upstream_w, upstream)
+  `AXI_ASSIGN_TO_B(upstream_b, upstream)
+  `AXI_ASSIGN_TO_R(upstream_r, upstream)
+  `AXI_ASSIGN_TO_AW(downstream_aw, downstream)
+  `AXI_ASSIGN_TO_W(downstream_w, downstream)
+  `AXI_ASSIGN_TO_B(downstream_b, downstream)
+  `AXI_ASSIGN_TO_AR(downstream_ar, downstream)
+  `AXI_ASSIGN_TO_R(downstream_r, downstream)
+  function bit addr_in_pfn_range(slv_addr_t addr, pfn_t first_pfn, pfn_t last_pfn);
+    automatic pfn_t pfn = addr >> 12;
+    return (pfn >= first_pfn) && (pfn <= last_pfn);
+  endfunction
+  function bit addr_is_mapped(slv_addr_t addr);
+    return addr_in_pfn_range(addr, first_pfn, last_pfn);
+  endfunction
+  function mst_addr_t addr_maps_to(slv_addr_t addr);
+    automatic pfn_t maps_to_pfn = (addr >> 12) + base_pfn - first_pfn;
+    return (maps_to_pfn << 12) | (addr & 12'hFFF);
+  endfunction
+
+  typedef struct {
+    bit goes_through;
+    id_t id;
+    axi_pkg::len_t len;
+  } dcsn_t;
+  dcsn_t w_dcsn_queue[$], b_dcsn_queue[AxiNumIds-1:0][$], r_dcsn_queue[AxiNumIds-1:0][$];
+
+  initial begin
+    wait (rst_n);
+    forever begin
+      @(posedge clk);
+      #TestTime;
+      // AW
+      if (upstream.aw_valid && upstream.aw_ready) begin
+        automatic dcsn_t w_dcsn;
+        w_dcsn.id = upstream.aw_id;
+        if (addr_is_mapped(upstream.aw_addr)) begin
+          automatic mst_aw_t exp_aw;
+          `AXI_SET_TO_AW(exp_aw, upstream)
+          exp_aw.addr = addr_maps_to(upstream.aw_addr);
+          downstream_exp_aw_queue.push_back(exp_aw);
+          w_dcsn.goes_through = 1'b1;
+        end else begin
+          w_dcsn.goes_through = 1'b0;
+        end
+        w_dcsn.len = upstream.aw_len;
+        w_dcsn_queue.push_back(w_dcsn);
+      end
+      if (downstream.aw_valid && downstream.aw_ready) begin
+        automatic mst_aw_t exp_aw;
+        assert (downstream_exp_aw_queue.size() != 0)
+          else $fatal(1, "Unexpected AW at master port!");
+        exp_aw = downstream_exp_aw_queue.pop_front();
+        assert (downstream_aw == exp_aw)
+          else $error("AW at master port does not match: %p != %p!", downstream_aw, exp_aw);
+      end
+      // W
+      if (upstream.w_valid && upstream.w_ready) begin
+        automatic dcsn_t w_dcsn;
+        assert (w_dcsn_queue.size() != 0)
+          else $fatal(1, "W beat that TB cannot handle at slave port!");
+        w_dcsn = w_dcsn_queue[0];
+        if (w_dcsn.goes_through) begin
+          downstream_exp_w_queue.push_back(upstream_w);
+        end
+        if (upstream_w.last) begin
+          b_dcsn_queue[w_dcsn.id].push_back(w_dcsn);
+          void'(w_dcsn_queue.pop_front());
+        end
+      end
+      if (downstream.w_valid && downstream.w_ready) begin
+        automatic w_t exp_w;
+        assert (downstream_exp_w_queue.size() != 0)
+          else $fatal(1, "Unexpected W at master port!");
+        exp_w = downstream_exp_w_queue.pop_front();
+        assert (downstream_w == exp_w)
+          else $error("W at master port does not match: %p != %p!", downstream_w, exp_w);
+      end
+      // B
+      if (downstream.b_valid && downstream.b_ready) begin
+        downstream_b_queue[downstream.b_id].push_back(downstream_b);
+      end
+      if (upstream.b_valid && upstream.b_ready) begin
+        automatic b_t exp_b;
+        automatic dcsn_t b_dcsn;
+        assert (b_dcsn_queue[upstream.b_id].size() != 0)
+          else $fatal(1, "Unexpected B with ID %0d at slave port!", upstream.b_id);
+        b_dcsn = b_dcsn_queue[upstream.b_id].pop_front();
+        if (b_dcsn.goes_through) begin
+          assert (downstream_b_queue[upstream.b_id].size() != 0)
+            else $fatal(1, "Unexpected B with ID %0d at slave port!", upstream.b_id);
+          exp_b = downstream_b_queue[upstream.b_id].pop_front();
+        end else begin
+          exp_b = '{
+            id: b_dcsn.id,
+            resp: axi_pkg::RESP_SLVERR,
+            user: 'x
+          };
+        end
+        assert (upstream_b ==? exp_b)
+          else $error("B at slave port does not match: %p != %p!", upstream_b, exp_b);
+      end
+      // AR
+      if (upstream.ar_valid && upstream.ar_ready) begin
+        automatic dcsn_t r_dcsn;
+        r_dcsn.id = upstream.ar_id;
+        if (addr_is_mapped(upstream.ar_addr)) begin
+          automatic mst_ar_t exp_ar;
+          `AXI_SET_TO_AR(exp_ar, upstream)
+          exp_ar.addr = addr_maps_to(upstream.ar_addr);
+          downstream_exp_ar_queue.push_back(exp_ar);
+          r_dcsn.goes_through = 1'b1;
+        end else begin
+          r_dcsn.goes_through = 1'b0;
+        end
+        r_dcsn.len = upstream.ar_len;
+        r_dcsn_queue[r_dcsn.id].push_back(r_dcsn);
+      end
+      if (downstream.ar_valid && downstream.ar_ready) begin
+        automatic mst_ar_t exp_ar;
+        assert (downstream_exp_ar_queue.size() != 0)
+          else $fatal(1, "Unexpected AR at master port!");
+        exp_ar = downstream_exp_ar_queue.pop_front();
+        assert (downstream_ar == exp_ar)
+          else $error("AR at master port does not match: %p != %p!", downstream_ar, exp_ar);
+      end
+      // R
+      if (downstream.r_valid && downstream.r_ready) begin
+        downstream_r_queue[downstream.r_id].push_back(downstream_r);
+      end
+      if (upstream.r_valid && upstream.r_ready) begin
+        automatic r_t exp_r;
+        automatic dcsn_t r_dcsn;
+        assert (r_dcsn_queue[upstream.r_id].size() != 0)
+          else $fatal(1, "Unexpected R with ID %0d at slave port!", upstream.r_id);
+        r_dcsn = r_dcsn_queue[upstream.r_id][0];
+        if (r_dcsn.goes_through) begin
+          assert (downstream_r_queue[upstream.r_id].size() != 0)
+            else $fatal(1, "Unexpected R with ID %0d at slave port!", upstream.r_id);
+          exp_r = downstream_r_queue[upstream.r_id].pop_front();
+        end else begin
+          exp_r = '{
+            data: 'x,
+            id: r_dcsn.id,
+            last: (r_dcsn.len == '0),
+            resp: axi_pkg::RESP_SLVERR,
+            user: 'x
+          };
+        end
+        assert (upstream_r ==? exp_r)
+          else $error("R at slave port does not match: %p != %p!", upstream_r, exp_r);
+        if (r_dcsn.len == '0) begin
+          assert (exp_r.last) else $error("Expected last R beat!");
+          void'(r_dcsn_queue[exp_r.id].pop_front());
+        end else begin
+          r_dcsn_queue[exp_r.id][0].len -= 1;
+        end
+      end
+    end
+  end
+
+  // Upstream driver
+  logic end_of_sim;
+  axi_test::axi_rand_master #(
+    .AW               ( AxiSlvPortAddrWidth ),
+    .DW               ( AxiDataWidth        ),
+    .IW               ( AxiIdWidth          ),
+    .UW               ( AxiUserWidth        ),
+    .TA               ( ApplTime            ),
+    .TT               ( TestTime            ),
+    .MAX_READ_TXNS    ( 20                  ),
+    .MAX_WRITE_TXNS   ( 20                  ),
+    .AXI_EXCLS        ( 1'b1                ),
+    .AXI_ATOPS        ( 1'b1                ),
+    .AXI_BURST_FIXED  ( 1'b1                ),
+    .AXI_BURST_INCR   ( 1'b1                ),
+    .AXI_BURST_WRAP   ( 1'b1                )
+  ) upstream_driver = new(upstream_dv);
+  initial begin
+    end_of_sim = 1'b0;
+    // TODO: add two memory regions: one that is mapped in the TLB and one that is not
+    //upstream_driver.add_memory_region(32'h0000_0000, 32'h1000_0000, axi_pkg::DEVICE_NONBUFFERABLE);
+    //upstream_driver.add_memory_region(/* ... */);
+    upstream_driver.reset();
+    wait (rst_n);
+    upstream_driver.run(NumReads, NumWrites);
+    end_of_sim = 1'b1;
+  end
+
+  // Downstream driver
+  axi_test::axi_rand_slave #(
+    .AW ( AxiMstPortAddrWidth ),
+    .DW ( AxiDataWidth        ),
+    .IW ( AxiIdWidth          ),
+    .UW ( AxiUserWidth        ),
+    .TA ( ApplTime            ),
+    .TT ( TestTime            )
+  ) downstream_driver = new(downstream_dv);
+  initial begin
+    downstream_driver.reset();
+    wait (rst_n);
+    downstream_driver.run();
+  end
+
+endmodule

--- a/test/tb_axi_tlb.wave.do
+++ b/test/tb_axi_tlb.wave.do
@@ -1,0 +1,52 @@
+add wave -noupdate /tb_axi_tlb/i_dut/clk_i
+add wave -noupdate /tb_axi_tlb/i_dut/rst_ni
+add wave -noupdate -expand -group dut /tb_axi_tlb/i_dut/test_en_i
+add wave -noupdate -expand -group dut -group {Slv Port AW} /tb_axi_tlb/i_dut/slv_req.aw
+add wave -noupdate -expand -group dut -group {Slv Port AW} /tb_axi_tlb/i_dut/slv_req.aw_valid
+add wave -noupdate -expand -group dut -group {Slv Port AW} /tb_axi_tlb/i_dut/slv_resp.aw_ready
+add wave -noupdate -expand -group dut -group {Mst Port AW} /tb_axi_tlb/i_dut/mst_req.aw
+add wave -noupdate -expand -group dut -group {Mst Port AW} /tb_axi_tlb/i_dut/mst_req.aw_valid
+add wave -noupdate -expand -group dut -group {Mst Port AW} /tb_axi_tlb/i_dut/mst_resp.aw_ready
+add wave -noupdate -expand -group dut -group {Slv Port W} /tb_axi_tlb/i_dut/slv_req.w
+add wave -noupdate -expand -group dut -group {Slv Port W} /tb_axi_tlb/i_dut/slv_req.w_valid
+add wave -noupdate -expand -group dut -group {Slv Port W} /tb_axi_tlb/i_dut/slv_resp.w_ready
+add wave -noupdate -expand -group dut -group {Mst Port W} /tb_axi_tlb/i_dut/mst_req.w
+add wave -noupdate -expand -group dut -group {Mst Port W} /tb_axi_tlb/i_dut/mst_req.w_valid
+add wave -noupdate -expand -group dut -group {Mst Port W} /tb_axi_tlb/i_dut/mst_resp.w_ready
+add wave -noupdate -expand -group dut -group {Mst Port B} /tb_axi_tlb/i_dut/mst_resp.b
+add wave -noupdate -expand -group dut -group {Mst Port B} /tb_axi_tlb/i_dut/mst_resp.b.id
+add wave -noupdate -expand -group dut -group {Mst Port B} /tb_axi_tlb/i_dut/mst_resp.b.resp
+add wave -noupdate -expand -group dut -group {Mst Port B} /tb_axi_tlb/i_dut/mst_resp.b.user
+add wave -noupdate -expand -group dut -group {Mst Port B} /tb_axi_tlb/i_dut/mst_resp.b_valid
+add wave -noupdate -expand -group dut -group {Mst Port B} /tb_axi_tlb/i_dut/mst_req.b_ready
+add wave -noupdate -expand -group dut -group {Slv Port B} /tb_axi_tlb/i_dut/slv_resp.b
+add wave -noupdate -expand -group dut -group {Slv Port B} /tb_axi_tlb/i_dut/slv_resp.b_valid
+add wave -noupdate -expand -group dut -group {Slv Port B} /tb_axi_tlb/i_dut/slv_req.b_ready
+add wave -noupdate -expand -group dut -group {Slv Port AR} /tb_axi_tlb/i_dut/slv_req.ar
+add wave -noupdate -expand -group dut -group {Slv Port AR} /tb_axi_tlb/i_dut/slv_req.ar_valid
+add wave -noupdate -expand -group dut -group {Slv Port AR} /tb_axi_tlb/i_dut/slv_resp.ar_ready
+add wave -noupdate -expand -group dut -group {Mst Port AR} /tb_axi_tlb/i_dut/mst_req.ar
+add wave -noupdate -expand -group dut -group {Mst Port AR} /tb_axi_tlb/i_dut/mst_req.ar_valid
+add wave -noupdate -expand -group dut -group {Mst Port AR} /tb_axi_tlb/i_dut/mst_resp.ar_ready
+add wave -noupdate -expand -group dut -group {Mst Port R} /tb_axi_tlb/i_dut/mst_resp.r
+add wave -noupdate -expand -group dut -group {Mst Port R} /tb_axi_tlb/i_dut/mst_resp.r_valid
+add wave -noupdate -expand -group dut -group {Mst Port R} /tb_axi_tlb/i_dut/mst_req.r_ready
+add wave -noupdate -expand -group dut -group {Slv Port R} /tb_axi_tlb/i_dut/slv_resp.r
+add wave -noupdate -expand -group dut -group {Slv Port R} /tb_axi_tlb/i_dut/slv_resp.r_valid
+add wave -noupdate -expand -group dut -group {Slv Port R} /tb_axi_tlb/i_dut/slv_req.r_ready
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_req.aw
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_req.aw_valid
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_resp.aw_ready
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_req.w
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_req.w_valid
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_resp.w_ready
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_resp.b
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_resp.b_valid
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_req.b_ready
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_req.ar
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_req.ar_valid
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_resp.ar_ready
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_resp.r
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_resp.r_valid
+add wave -noupdate -expand -group dut -group {Cfg Port} /tb_axi_tlb/i_dut/cfg_req.r_ready
+add wave -noupdate -group l1_tlb /tb_axi_tlb/i_dut/i_axi_tlb/i_l1_tlb/*


### PR DESCRIPTION
Here is a first draft of an AXI TLB. I would highly appreciate initial architectural feedback.

The concept is similar to that of the RAB (no need to reinvent the wheel), but in a fully stream-based, modular implementation (using the `common_cells` stream infrastructure) and leveraging core `axi` modules such as `axi_demux` to handle the protocol.

## TODOs
- [ ] Integrate `axi_lite_regs` from #79.
- [ ] Testbench
- [ ] Documentation