### PR TITLE
Add support for FIXED transactions in the DWCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `axi_pkg`: Add `bufferable` and `modifiable` helper functions.
+- `axi_dw_converter`: Add support for single-beat *fixed* bursts in the downsizer and for *fixed*
+  bursts of any length in the upsizer.
 
 ### Changed
+- `axi_dw_downsizer` (part of `axi_dw_converter`): Downsize regardless of the *modifiable* bit of
+  incoming transactions.  Previously, non-*modifiable* transactions whose attributes would have to
+  be modified for downsizing were rejected with a slave error.  As of this change, transactions are
+  downsized and their attributes modified even if their *modifiable* bit is not set.  This is
+  permitted by a note in the AXI specification (page A4-65 of IHI0022H).
 
 ### Fixed
+- `axi_dw_downsizer` (part of `axi_dw_converter`): Fix condition for keeping transactions that have
+  a smaller `size` than the master/downstream port unmodified.
 
 
 ## 0.21.0 - 2020-04-27

--- a/src/axi_dw_converter.sv
+++ b/src/axi_dw_converter.sv
@@ -10,8 +10,9 @@
 
 // Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 
-// NOTE: The upsizer/downsizer do not support WRAP and FIXED bursts, and
-// will answer with SLVERR upon receiving a burst of such types.
+// NOTE: The upsizer does not support WRAP bursts, and will answer with SLVERR
+// upon receiving a burst of such type. In addition to that, the downsizer also
+// does not support FIXED bursts with incoming axlen != 0.
 
 module axi_dw_converter #(
     parameter int unsigned AxiMaxReads         = 1    , // Number of outstanding reads

--- a/src/axi_dw_downsizer.sv
+++ b/src/axi_dw_downsizer.sv
@@ -737,7 +737,7 @@ module axi_dw_downsizer #(
             w_req_d.aw_throw_error = 1'b1         ;
 
             // ... but might if this is a narrow single-beat transaction
-            if (slv_req_i.aw.size <= AxiSlvPortMaxSize && slv_req_i.aw.len == '0)
+            if (slv_req_i.aw.size <= AxiMstPortMaxSize && slv_req_i.aw.len == '0)
               w_req_d.aw_throw_error = 1'b0;
           end
 
@@ -747,7 +747,7 @@ module axi_dw_downsizer #(
             w_req_d.aw_throw_error = 1'b1         ;
 
             // ... but might if this is a narrow single-beat transaction
-            if (slv_req_i.aw.size <= AxiSlvPortMaxSize && slv_req_i.aw.len == '0)
+            if (slv_req_i.aw.size <= AxiMstPortMaxSize && slv_req_i.aw.len == '0)
               w_req_d.aw_throw_error = 1'b0;
           end
         endcase

--- a/src/axi_dw_downsizer.sv
+++ b/src/axi_dw_downsizer.sv
@@ -15,8 +15,9 @@
 // Connects a wide master to a narrower slave.
 
 // NOTE: The downsizer does not support WRAP bursts, and will answer with SLVERR
-// upon receiving a burst of such type. The downsizer also does not support
-
+// upon receiving a burst of such type.  The downsizer does support FIXED
+// bursts, but only if they consist of a single beat; it will answer with SLVERR
+// on multi-beat FIXED bursts.
 module axi_dw_downsizer #(
     parameter int unsigned AxiMaxReads         = 1    , // Number of outstanding reads
     parameter int unsigned AxiSlvPortDataWidth = 8    , // Data width of the slv port

--- a/src/axi_dw_downsizer.sv
+++ b/src/axi_dw_downsizer.sv
@@ -14,8 +14,8 @@
 // Data width downsize conversion.
 // Connects a wide master to a narrower slave.
 
-// NOTE: The downsizer does not support WRAP and FIXED bursts, and
-// will answer with SLVERR upon receiving a burst of such types.
+// NOTE: The downsizer does not support WRAP bursts, and will answer with SLVERR
+// upon receiving a burst of such type. The downsizer also does not support
 
 module axi_dw_downsizer #(
     parameter int unsigned AxiMaxReads         = 1    , // Number of outstanding reads
@@ -416,17 +416,40 @@ module axi_dw_downsizer #(
                 end
               end
 
-              axi_pkg::BURST_WRAP: begin
-                // The DW converter does not support this kind of burst ...
-                r_state_d              = R_PASSTHROUGH;
-                r_req_d.ar_throw_error = 1'b1         ;
+              axi_pkg::BURST_FIXED: begin
+                // Modifiable transaction
+                if (modifiable(r_req_d.ar.cache)) begin
+                  // Single transaction
+                  if (r_req_d.ar.len == '0) begin
+                    // Evaluate downsize ratio
+                    automatic addr_t size_mask  = (1 << r_req_d.ar.size) - 1                                              ;
+                    automatic addr_t conv_ratio = ((1 << r_req_d.ar.size) + AxiMstPortStrbWidth - 1) / AxiMstPortStrbWidth;
 
-                // ... but might if this is a narrow single-beat transaction
-                if (r_req_d.ar.len == '0 && r_req_d.ar.size <= AxiMstPortMaxSize)
-                  r_req_d.ar_throw_error = 1'b0;
+                    // Evaluate output burst length
+                    automatic addr_t align_adj = (r_req_d.ar.addr & size_mask & ~MstPortByteMask) / AxiMstPortStrbWidth;
+                    r_req_d.burst_len          = conv_ratio - align_adj - 1                                            ;
+
+                    if (conv_ratio != 1) begin
+                      r_state_d        = R_INCR_DOWNSIZE    ;
+                      r_req_d.ar.len   = r_req_d.burst_len  ;
+                      r_req_d.ar.size  = AxiMstPortMaxSize  ;
+                      r_req_d.ar.burst = axi_pkg::BURST_INCR;
+                    end
+                  end else begin
+                    // The downsizer does not support fixed burts
+                    r_req_d.ar_throw_error = 1'b1;
+                  end
+                // Non-modifiable transaction
+                end else begin
+                  // Incoming transaction is wider than the master bus
+                  if (r_req_d.ar.size > AxiMstPortMaxSize) begin
+                    r_req_d.ar_throw_error = 1'b1         ;
+                    r_state_d              = R_PASSTHROUGH;
+                  end
+                end
               end
 
-              axi_pkg::BURST_FIXED: begin
+              axi_pkg::BURST_WRAP: begin
                 // The DW converter does not support this kind of burst ...
                 r_state_d              = R_PASSTHROUGH;
                 r_req_d.ar_throw_error = 1'b1         ;
@@ -466,13 +489,21 @@ module axi_dw_downsizer #(
                       r_req_d.r.data[8*b +: 8] = mst_resp.r.data[8*(b + mst_port_offset - slv_port_offset) +: 8];
                     end
 
-                  r_req_d.burst_len = r_req_q.burst_len - 1                                                  ;
-                  r_req_d.ar.len    = r_req_q.ar.len - 1                                                     ;
-                  r_req_d.ar.addr   = aligned_addr(r_req_q.ar.addr, r_req_q.ar.size) + (1 << r_req_q.ar.size);
-                  r_req_d.r.last    = (r_req_q.burst_len == 0)                                               ;
-                  r_req_d.r.id      = mst_resp.r.id                                                          ;
-                  r_req_d.r.resp    = mst_resp.r.resp                                                        ;
-                  r_req_d.r.user    = mst_resp.r.user                                                        ;
+                  r_req_d.burst_len = r_req_q.burst_len - 1   ;
+                  r_req_d.ar.len    = r_req_q.ar.len - 1      ;
+                  r_req_d.r.last    = (r_req_q.burst_len == 0);
+                  r_req_d.r.id      = mst_resp.r.id           ;
+                  r_req_d.r.resp    = mst_resp.r.resp         ;
+                  r_req_d.r.user    = mst_resp.r.user         ;
+
+                  case (r_req_d.ar.burst)
+                    axi_pkg::BURST_INCR: begin
+                      r_req_d.ar.addr = aligned_addr(r_req_q.ar.addr, r_req_q.ar.size) + (1 << r_req_q.ar.size);
+                    end
+                    axi_pkg::BURST_FIXED: begin
+                      r_req_d.ar.addr = r_req_q.ar.addr;
+                    end
+                  endcase
 
                   if (r_req_q.burst_len == 0)
                     idqueue_pop[t] = 1'b1;
@@ -638,9 +669,17 @@ module axi_dw_downsizer #(
 
         // Acknowledgment
         if (mst_resp.w_ready && mst_req.w_valid) begin
-          w_req_d.burst_len = w_req_q.burst_len - 1                                                  ;
-          w_req_d.aw.len    = w_req_q.aw.len - 1                                                     ;
-          w_req_d.aw.addr   = aligned_addr(w_req_q.aw.addr, w_req_q.aw.size) + (1 << w_req_q.aw.size);
+          w_req_d.burst_len = w_req_q.burst_len - 1;
+          w_req_d.aw.len    = w_req_q.aw.len - 1   ;
+
+          case (w_req_d.aw.burst)
+            axi_pkg::BURST_INCR: begin
+              w_req_d.aw.addr = aligned_addr(w_req_q.aw.addr, w_req_q.aw.size) + (1 << w_req_q.aw.size);
+            end
+            axi_pkg::BURST_FIXED: begin
+              w_req_d.aw.addr = w_req_q.aw.addr;
+            end
+          endcase
 
           case (w_state_q)
             W_PASSTHROUGH:
@@ -731,17 +770,40 @@ module axi_dw_downsizer #(
             end
           end
 
-          axi_pkg::BURST_WRAP: begin
-            // The DW converter does not support this kind of burst ...
-            w_state_d              = W_PASSTHROUGH;
-            w_req_d.aw_throw_error = 1'b1         ;
+          axi_pkg::BURST_FIXED: begin
+            // Modifiable transaction
+            if (modifiable(slv_req_i.aw.cache)) begin
+              // Single transaction
+              if (slv_req_i.aw.len == '0) begin
+                // Evaluate downsize ratio
+                automatic addr_t size_mask  = (1 << slv_req_i.aw.size) - 1                                              ;
+                automatic addr_t conv_ratio = ((1 << slv_req_i.aw.size) + AxiMstPortStrbWidth - 1) / AxiMstPortStrbWidth;
 
-            // ... but might if this is a narrow single-beat transaction
-            if (slv_req_i.aw.size <= AxiMstPortMaxSize && slv_req_i.aw.len == '0)
-              w_req_d.aw_throw_error = 1'b0;
+                // Evaluate output burst length
+                automatic addr_t align_adj = (slv_req_i.aw.addr & size_mask & ~MstPortByteMask) / AxiMstPortStrbWidth;
+                w_req_d.burst_len          = conv_ratio - align_adj - 1                                              ;
+
+                if (conv_ratio != 1) begin
+                  w_state_d        = W_INCR_DOWNSIZE    ;
+                  w_req_d.aw.len   = w_req_d.burst_len  ;
+                  w_req_d.aw.size  = AxiMstPortMaxSize  ;
+                  w_req_d.aw.burst = axi_pkg::BURST_INCR;
+                end
+              end else begin
+                // The downsizer does not support fixed burts
+                w_req_d.aw_throw_error = 1'b1;
+              end
+            // Non-modifiable transaction
+            end else begin
+              // Incoming transaction is wider than the master bus
+              if (w_req_d.aw.size > AxiMstPortMaxSize) begin
+                w_req_d.aw_throw_error = 1'b1         ;
+                w_state_d              = W_PASSTHROUGH;
+              end
+            end
           end
 
-          axi_pkg::BURST_FIXED: begin
+          axi_pkg::BURST_WRAP: begin
             // The DW converter does not support this kind of burst ...
             w_state_d              = W_PASSTHROUGH;
             w_req_d.aw_throw_error = 1'b1         ;

--- a/src/axi_dw_upsizer.sv
+++ b/src/axi_dw_upsizer.sv
@@ -14,8 +14,8 @@
 // Data width upsize conversion.
 // Connects a narrow master to a wider slave.
 
-// NOTE: The upsizer does not support WRAP bursts, and
-// will answer with SLVERR upon receiving a burst of such types.
+// NOTE: The upsizer does not support WRAP bursts, and will answer with SLVERR
+// upon receiving a burst of such type.
 
 module axi_dw_upsizer #(
     parameter int unsigned AxiMaxReads         = 1    , // Number of outstanding reads


### PR DESCRIPTION
This PR adds support for `FIXED` transactions in the DWCs. 

It is trivial to upsize `FIXED` transactions, and the upsized AXI transaction is identical to the original. 
Downsizing them, however, is more complex:
-  If the incoming `FIXED` transactions have an `axsize` not wider than the outcoming port, the DWC can forward the transaction without any changes.
- Otherwise, each data beat of the incoming `FIXED`  transaction must be transformed into an `INCR` burst.

The downsizer currently does not support `FIXED` bursts. It would be possible to support them by converting them into a sequence of `INCR` bursts. But I wonder whether this is a common enough use case to require the support of the downsizer. If such bursts are needed, an alternative would be to use an `axi_burst_splitter` in front of the downsizer.  