### PR TITLE
axi_pkg: Add modifiable and bufferable helper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+- `axi_pkg`: Add `bufferable` and `modifiable` helper functions.
 
 ### Changed
 

--- a/src/axi_burst_splitter.sv
+++ b/src/axi_burst_splitter.sv
@@ -105,7 +105,7 @@ module axi_burst_splitter #(
     // ATOPs are not supported.
     if (atop != '0) return 1'b0;
     // The AXI Spec (A3.4.1) only allows splitting non-modifiable transactions ..
-    if (!(|(cache & axi_pkg::CACHE_MODIFIABLE))) begin
+    if (!axi_pkg::modifiable(cache)) begin
       // .. if they are INCR bursts and longer than 16 beats.
       return (burst == axi_pkg::BURST_INCR) & (len > 16);
     end

--- a/src/axi_dw_downsizer.sv
+++ b/src/axi_dw_downsizer.sv
@@ -49,6 +49,7 @@ module axi_dw_downsizer #(
    *  DEFINITIONS  *
    *****************/
   import axi_pkg::aligned_addr;
+  import axi_pkg::modifiable  ;
 
   // Type used to index which adapter is handling each outstanding transaction.
   localparam TranIdWidth = AxiMaxReads > 1 ? $clog2(AxiMaxReads) : 1;
@@ -385,7 +386,7 @@ module axi_dw_downsizer #(
             case (r_req_d.ar.burst)
               axi_pkg::BURST_INCR : begin
                 // Modifiable transaction
-                if (|(r_req_d.ar.cache & axi_pkg::CACHE_MODIFIABLE)) begin
+                if (modifiable(r_req_d.ar.cache)) begin
                   // Evaluate downsize ratio
                   automatic addr_t size_mask  = (1 << r_req_d.ar.size) - 1                                              ;
                   automatic addr_t conv_ratio = ((1 << r_req_d.ar.size) + AxiMstPortStrbWidth - 1) / AxiMstPortStrbWidth;
@@ -700,7 +701,7 @@ module axi_dw_downsizer #(
         case (slv_req_i.aw.burst)
           axi_pkg::BURST_INCR: begin
             // Modifiable transaction
-            if (|(slv_req_i.aw.cache & axi_pkg::CACHE_MODIFIABLE)) begin
+            if (modifiable(slv_req_i.aw.cache)) begin
               // Evaluate downsize ratio
               automatic addr_t size_mask  = (1 << slv_req_i.aw.size) - 1                                              ;
               automatic addr_t conv_ratio = ((1 << slv_req_i.aw.size) + AxiMstPortStrbWidth - 1) / AxiMstPortStrbWidth;

--- a/src/axi_dw_upsizer.sv
+++ b/src/axi_dw_upsizer.sv
@@ -50,6 +50,7 @@ module axi_dw_upsizer #(
    *****************/
   import axi_pkg::aligned_addr;
   import axi_pkg::beat_addr   ;
+  import axi_pkg::modifiable  ;
 
   // Type used to index which adapter is handling each outstanding transaction.
   localparam TranIdWidth = AxiMaxReads > 1 ? $clog2(AxiMaxReads) : 1;
@@ -368,7 +369,7 @@ module axi_dw_upsizer #(
             case (r_req_d.ar.burst)
               axi_pkg::BURST_INCR : begin
                 // Modifiable transaction
-                if (|(r_req_d.ar.cache & axi_pkg::CACHE_MODIFIABLE)) begin
+                if (modifiable(r_req_d.ar.cache)) begin
                   // No need to upsize single-beat transactions.
                   if (r_req_d.ar.len != '0) begin
                     // Evaluate output burst length
@@ -596,7 +597,7 @@ module axi_dw_upsizer #(
         case (slv_req_i.aw.burst)
           axi_pkg::BURST_INCR: begin
             // Modifiable transaction
-            if (|(slv_req_i.aw.cache & axi_pkg::CACHE_MODIFIABLE))
+            if (modifiable(slv_req_i.aw.cache))
               // No need to upsize single-beat transactions.
               if (slv_req_i.aw.len != '0) begin
                 // Evaluate output burst length

--- a/src/axi_pkg.sv
+++ b/src/axi_pkg.sv
@@ -185,6 +185,16 @@ package axi_pkg;
     end
   endfunction
 
+  /// Is the bufferable bit set?
+  function automatic logic bufferable(cache_t cache);
+    return |(cache & CACHE_BUFFERABLE);
+  endfunction
+
+  /// Is the modifiable bit set?
+  function automatic logic modifiable(cache_t cache);
+    return |(cache & CACHE_MODIFIABLE);
+  endfunction
+
   /// Memory Type.
   typedef enum logic [3:0] {
     DEVICE_NONBUFFERABLE,


### PR DESCRIPTION
This adds a function to `axi_pkg`, that returns whether the AXI transactions are modifiable/bufferable based on the value of their `axcache`. This replaces a common pattern such as
```sv
// The AXI Spec (A3.4.1) only allows splitting non-modifiable transactions ..
if (!(|(cache & axi_pkg::CACHE_MODIFIABLE)))
```
by
```sv
// The AXI Spec (A3.4.1) only allows splitting non-modifiable transactions ..
if (!axi_pkg::modifiable(cache))  
```