### PR TITLE
Add golden models for the DW Converters

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -67,6 +67,7 @@ sources:
       - test/tb_axi_addr_test.sv
       - test/tb_axi_cdc.sv
       - test/tb_axi_delayer.sv
+      - test/tb_axi_dw_pkg.sv
       - test/tb_axi_dw_downsizer.sv
       - test/tb_axi_dw_upsizer.sv
       - test/tb_axi_isolate.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+- `axi_pkg`: Add function that defines response precedence.
 
 ### Changed
+- `axi_dw_downsizer` and `axi_dw_upsizer`: Pipeline injection of atomic AWs into the AR channel to
+  shorten the critical path.
 
 ### Fixed
+- `axi_dw_downsizer` and `axi_dw_upsizer`: Improve portability of bit slice assignment constructs.
+- `axi_dw_downsizer`:
+  - Forward worst response among split transactions.
+  - Fix overflow of B forward FIFO.
+- `axi_test`: Remove minimal length constraint from `rand_atop_burst`.
 
 
 ## 0.23.2 - 2020-09-14

--- a/scripts/run_vsim.sh
+++ b/scripts/run_vsim.sh
@@ -36,14 +36,14 @@ exec_test() {
             ;;
         axi_dw_downsizer)
             for AxiSlvPortDataWidth in 8 16 32 64 128 256 512 1024; do
-                for (( AxiMstPortDataWidth = 8; AxiMstPortDataWidth <= $AxiSlvPortDataWidth; AxiMstPortDataWidth *= 2 )); do
+                for (( AxiMstPortDataWidth = 8; AxiMstPortDataWidth < $AxiSlvPortDataWidth; AxiMstPortDataWidth *= 2 )); do
                     call_vsim tb_axi_dw_downsizer -GAxiSlvPortDataWidth=$AxiSlvPortDataWidth -GAxiMstPortDataWidth=$AxiMstPortDataWidth -t 1ps -c
                 done
             done
             ;;
         axi_dw_upsizer)
             for AxiSlvPortDataWidth in 8 16 32 64 128 256 512 1024; do
-                for (( AxiMstPortDataWidth = $AxiSlvPortDataWidth; AxiMstPortDataWidth <= 1024; AxiMstPortDataWidth *= 2 )); do
+                for (( AxiMstPortDataWidth = $AxiSlvPortDataWidth*2; AxiMstPortDataWidth <= 1024; AxiMstPortDataWidth *= 2 )); do
                     call_vsim tb_axi_dw_upsizer -GAxiSlvPortDataWidth=$AxiSlvPortDataWidth -GAxiMstPortDataWidth=$AxiMstPortDataWidth -t 1ps -c
                 done
             done

--- a/scripts/run_vsim.sh
+++ b/scripts/run_vsim.sh
@@ -35,16 +35,16 @@ exec_test() {
             done
             ;;
         axi_dw_downsizer)
-            for DW in 8 16 32 64 128 256 512 1024; do
-                for (( MULT = 2; MULT <= `echo 1024/$DW`; MULT *= 2 )); do
-                    call_vsim tb_axi_dw_downsizer -GDW=$DW -GMULT=$MULT -t 1ps -c
+            for AxiSlvPortDataWidth in 8 16 32 64 128 256 512 1024; do
+                for (( AxiMstPortDataWidth = 8; AxiMstPortDataWidth <= $AxiSlvPortDataWidth; AxiMstPortDataWidth *= 2 )); do
+                    call_vsim tb_axi_dw_downsizer -GAxiSlvPortDataWidth=$AxiSlvPortDataWidth -GAxiMstPortDataWidth=$AxiMstPortDataWidth -t 1ps -c
                 done
             done
             ;;
         axi_dw_upsizer)
-            for DW in 8 16 32 64 128 256 512 1024; do
-                for (( MULT = `echo 1024/$DW | bc`; MULT > 1; MULT /= 2 )); do
-                    call_vsim tb_axi_dw_upsizer -GDW=$DW -GMULT=$MULT -t 1ps -c
+            for AxiSlvPortDataWidth in 8 16 32 64 128 256 512 1024; do
+                for (( AxiMstPortDataWidth = $AxiSlvPortDataWidth; AxiMstPortDataWidth <= 1024; AxiMstPortDataWidth *= 2 )); do
+                    call_vsim tb_axi_dw_upsizer -GAxiSlvPortDataWidth=$AxiSlvPortDataWidth -GAxiMstPortDataWidth=$AxiMstPortDataWidth -t 1ps -c
                 done
             done
             ;;

--- a/src/axi_dw_downsizer.sv
+++ b/src/axi_dw_downsizer.sv
@@ -678,7 +678,6 @@ module axi_dw_downsizer #(
     mst_req.w_valid    = '0;
     slv_resp_o.w_ready = '0;
 
-
     // B Channel (No latency)
     if (mst_resp.b_valid) begin
       // Merge response of this burst with prior one according to precedence rules.

--- a/src/axi_dw_downsizer.sv
+++ b/src/axi_dw_downsizer.sv
@@ -68,6 +68,10 @@ module axi_dw_downsizer #(
   localparam SlvPortByteMask = AxiSlvPortStrbWidth - 1;
   localparam MstPortByteMask = AxiMstPortStrbWidth - 1;
 
+  // Byte-grouped data words
+  typedef logic [AxiMstPortStrbWidth-1:0][7:0] mst_data_t;
+  typedef logic [AxiSlvPortStrbWidth-1:0][7:0] slv_data_t;
+
   // Address width
   typedef logic [AxiAddrWidth-1:0] addr_t;
 
@@ -528,16 +532,19 @@ module axi_dw_downsizer #(
                   automatic addr_t mst_port_offset = AxiMstPortStrbWidth == 1 ? '0 : r_req_q.ar.addr[idx_width(AxiMstPortStrbWidth)-1:0];
                   automatic addr_t slv_port_offset = AxiSlvPortStrbWidth == 1 ? '0 : r_req_q.ar.addr[idx_width(AxiSlvPortStrbWidth)-1:0];
 
+                  automatic slv_data_t r_data = r_req_d.r.data;
+
                   // Serialization
                   for (int b = 0; b < AxiSlvPortStrbWidth; b++)
                     if ((b >= slv_port_offset) &&
                         (b - slv_port_offset < (1 << r_req_q.orig_ar_size)) &&
                         (b + mst_port_offset - slv_port_offset < AxiMstPortStrbWidth)) begin
-                      r_req_d.r.data[8*b +: 8] = mst_resp.r.data[8*(b + mst_port_offset - slv_port_offset) +: 8];
+                      r_data[b] = mst_resp.r.data[8*(b + mst_port_offset - slv_port_offset) +: 8];
                     end
 
                   r_req_d.burst_len = r_req_q.burst_len - 1   ;
                   r_req_d.ar.len    = r_req_q.ar.len - 1      ;
+                  r_req_d.r.data    = r_data                  ;
                   r_req_d.r.last    = (r_req_q.burst_len == 0);
                   r_req_d.r.id      = mst_resp.r.id           ;
                   r_req_d.r.resp    = mst_resp.r.resp         ;
@@ -701,6 +708,8 @@ module axi_dw_downsizer #(
             automatic addr_t mst_port_offset = AxiMstPortStrbWidth == 1 ? '0 : w_req_q.aw.addr[idx_width(AxiMstPortStrbWidth)-1:0];
             automatic addr_t slv_port_offset = AxiSlvPortStrbWidth == 1 ? '0 : w_req_q.aw.addr[idx_width(AxiSlvPortStrbWidth)-1:0];
 
+            automatic mst_data_t w_data = mst_req.w.data;
+
             // Valid output
             mst_req.w_valid = 1'b1               ;
             mst_req.w.last  = w_req_q.aw.len == 0;
@@ -711,9 +720,10 @@ module axi_dw_downsizer #(
               if ((b >= slv_port_offset) &&
                   (b - slv_port_offset < (1 << w_req_q.orig_aw_size)) &&
                   (b + mst_port_offset - slv_port_offset < AxiMstPortStrbWidth)) begin
-                mst_req.w.data[8*(b + mst_port_offset - slv_port_offset) +: 8] = slv_req_i.w.data[8*b +: 8];
-                mst_req.w.strb[b + mst_port_offset - slv_port_offset]          = slv_req_i.w.strb[b]       ;
+                w_data[b + mst_port_offset - slv_port_offset]         = slv_req_i.w.data[8*b +: 8];
+                mst_req.w.strb[b + mst_port_offset - slv_port_offset] = slv_req_i.w.strb[b]       ;
               end
+            mst_req.w.data = w_data;
           end
 
         // Acknowledgment
@@ -781,11 +791,11 @@ module axi_dw_downsizer #(
         w_state_d = W_PASSTHROUGH;
 
         // Save beat
-        w_req_d.aw            = slv_req_i.aw     ;
-        w_req_d.aw_valid      = 1'b1             ;
-        w_req_d.burst_len     = slv_req_i.aw.len ;
-        w_req_d.orig_aw_len   = slv_req_i.aw.len ;
-        w_req_d.orig_aw_size  = slv_req_i.aw.size;
+        w_req_d.aw            = slv_req_i.aw      ;
+        w_req_d.aw_valid      = 1'b1              ;
+        w_req_d.burst_len     = slv_req_i.aw.len  ;
+        w_req_d.orig_aw_len   = slv_req_i.aw.len  ;
+        w_req_d.orig_aw_size  = slv_req_i.aw.size ;
         w_req_d.orig_aw_burst = slv_req_i.aw.burst;
 
         case (slv_req_i.aw.burst)

--- a/src/axi_dw_upsizer.sv
+++ b/src/axi_dw_upsizer.sv
@@ -65,6 +65,10 @@ module axi_dw_upsizer #(
   localparam AxiSlvPortMaxSize = $clog2(AxiSlvPortStrbWidth);
   localparam AxiMstPortMaxSize = $clog2(AxiMstPortStrbWidth);
 
+  // Byte-grouped data words
+  typedef logic [AxiMstPortStrbWidth-1:0][7:0] mst_data_t;
+  typedef logic [AxiSlvPortStrbWidth-1:0][7:0] slv_data_t;
+
   // Address width
   typedef logic [AxiAddrWidth-1:0] addr_t;
 
@@ -457,6 +461,8 @@ module axi_dw_upsizer #(
               automatic addr_t mst_port_offset = AxiMstPortStrbWidth == 1 ? '0 : r_req_q.ar.addr[idx_width(AxiMstPortStrbWidth)-1:0];
               automatic addr_t slv_port_offset = AxiSlvPortStrbWidth == 1 ? '0 : r_req_q.ar.addr[idx_width(AxiSlvPortStrbWidth)-1:0];
 
+              automatic slv_data_t r_data = slv_r_tran[t].data;
+
               // Valid output
               slv_r_valid_tran[t] = 1'b1                                       ;
               slv_r_tran[t].last  = mst_resp.r.last && (r_req_q.burst_len == 0);
@@ -466,9 +472,10 @@ module axi_dw_upsizer #(
                 if ((b >= mst_port_offset) &&
                     (b - mst_port_offset < (1 << r_req_q.orig_ar_size)) &&
                     (b + slv_port_offset - mst_port_offset < AxiSlvPortStrbWidth)) begin
-                  slv_r_tran[t].data[8*(b + slv_port_offset - mst_port_offset) +: 8] = mst_resp.r.data[8*b +: 8];
+                  r_data[b + slv_port_offset - mst_port_offset] = mst_resp.r.data[8*b +: 8];
                 end
               end
+              slv_r_tran[t].data = r_data;
 
               // Acknowledgment
               if (slv_r_ready_tran[t]) begin
@@ -582,18 +589,21 @@ module axi_dw_upsizer #(
             automatic addr_t mst_port_offset = AxiMstPortStrbWidth == 1 ? '0 : w_req_q.aw.addr[idx_width(AxiMstPortStrbWidth)-1:0];
             automatic addr_t slv_port_offset = AxiSlvPortStrbWidth == 1 ? '0 : w_req_q.aw.addr[idx_width(AxiSlvPortStrbWidth)-1:0];
 
+            automatic mst_data_t w_data = w_req_d.w.data;
+
             // Serialization
             for (int b = 0; b < AxiMstPortStrbWidth; b++)
               if ((b >= mst_port_offset) &&
                   (b - mst_port_offset < (1 << w_req_q.orig_aw_size)) &&
                   (b + slv_port_offset - mst_port_offset < AxiSlvPortStrbWidth)) begin
-                w_req_d.w.data[8*b +: 8] = slv_req_i.w.data[8*(b + slv_port_offset - mst_port_offset) +: 8];
-                w_req_d.w.strb[b]        = slv_req_i.w.strb[b + slv_port_offset - mst_port_offset]         ;
+                w_data[b]         = slv_req_i.w.data[8*(b + slv_port_offset - mst_port_offset) +: 8];
+                w_req_d.w.strb[b] = slv_req_i.w.strb[b + slv_port_offset - mst_port_offset]         ;
               end
 
-            w_req_d.burst_len = w_req_q.burst_len - 1    ;
-            w_req_d.w.last    = (w_req_q.burst_len == 0) ;
-            w_req_d.w.user    = slv_req_i.w.user         ;
+            w_req_d.burst_len = w_req_q.burst_len - 1   ;
+            w_req_d.w.data    = w_data                  ;
+            w_req_d.w.last    = (w_req_q.burst_len == 0);
+            w_req_d.w.user    = slv_req_i.w.user        ;
 
             case (w_req_q.aw.burst)
               axi_pkg::BURST_INCR: begin

--- a/src/axi_dw_upsizer.sv
+++ b/src/axi_dw_upsizer.sv
@@ -52,6 +52,8 @@ module axi_dw_upsizer #(
   import axi_pkg::beat_addr   ;
   import axi_pkg::modifiable  ;
 
+  import cf_math_pkg::idx_width;
+
   // Type used to index which adapter is handling each outstanding transaction.
   localparam TranIdWidth = AxiMaxReads > 1 ? $clog2(AxiMaxReads) : 1;
   typedef logic [TranIdWidth-1:0] tran_id_t;
@@ -229,6 +231,7 @@ module axi_dw_upsizer #(
 
   typedef enum logic [1:0] {
     R_IDLE       ,
+    R_INJECT_AW  ,
     R_PASSTHROUGH,
     R_INCR_UPSIZE
   } r_state_e;
@@ -299,7 +302,7 @@ module axi_dw_upsizer #(
     r_req_t r_req_d    , r_req_q  ;
 
     // Are we idle?
-    assign idle_read_upsizer[t] = (r_state_q == R_IDLE);
+    assign idle_read_upsizer[t] = (r_state_q == R_IDLE) || (r_state_q == R_INJECT_AW);
 
     always_comb begin
       // Maintain state
@@ -341,73 +344,118 @@ module axi_dw_upsizer #(
           if (arb_slv_ar_req && (idx_ar_upsizer == t)) begin
             arb_slv_ar_gnt_tran[t] = 1'b1;
 
-            // Default state
-            r_state_d = R_PASSTHROUGH;
-
-            // Save beat
-            r_req_d.ar           = slv_req_i.ar     ;
-            r_req_d.ar_valid     = 1'b1             ;
-            r_req_d.burst_len    = slv_req_i.ar.len ;
-            r_req_d.orig_ar_size = slv_req_i.ar.size;
+            // Must inject an AW request into this upsizer
             if (inject_aw_into_ar) begin
-              r_req_d.ar.id        = slv_req_i.aw.id    ;
-              r_req_d.ar.addr      = slv_req_i.aw.addr  ;
-              r_req_d.ar.size      = slv_req_i.aw.size  ;
-              r_req_d.ar.burst     = slv_req_i.aw.burst ;
-              r_req_d.ar.len       = slv_req_i.aw.len   ;
-              r_req_d.ar.lock      = slv_req_i.aw.lock  ;
-              r_req_d.ar.cache     = slv_req_i.aw.cache ;
-              r_req_d.ar.prot      = slv_req_i.aw.prot  ;
-              r_req_d.ar.qos       = slv_req_i.aw.qos   ;
-              r_req_d.ar.region    = slv_req_i.aw.region;
-              r_req_d.ar.user      = slv_req_i.aw.user  ;
-              r_req_d.ar_valid     = 1'b0               ; // Injected "AR"s from AW are not valid.
-              r_req_d.burst_len    = slv_req_i.aw.len   ;
-              r_req_d.orig_ar_size = slv_req_i.aw.size  ;
-            end
+              r_state_d = R_INJECT_AW;
+            end else begin
+              // Default state
+              r_state_d = R_PASSTHROUGH;
 
-            case (r_req_d.ar.burst)
-              axi_pkg::BURST_INCR: begin
-                // Modifiable transaction
-                if (modifiable(r_req_d.ar.cache)) begin
-                  // No need to upsize single-beat transactions.
-                  if (r_req_d.ar.len != '0) begin
-                    // Evaluate output burst length
-                    automatic addr_t start_addr = aligned_addr(r_req_d.ar.addr, AxiMstPortMaxSize);
-                    automatic addr_t end_addr   = aligned_addr(beat_addr(r_req_d.ar.addr,
-                        r_req_d.orig_ar_size, r_req_d.burst_len, r_req_d.ar.burst,
-                        r_req_d.burst_len), AxiMstPortMaxSize);
-                    r_req_d.ar.len  = (end_addr - start_addr) >> AxiMstPortMaxSize;
-                    r_req_d.ar.size = AxiMstPortMaxSize                           ;
-                    r_state_d       = R_INCR_UPSIZE                               ;
+              // Save beat
+              r_req_d.ar           = slv_req_i.ar     ;
+              r_req_d.ar_valid     = 1'b1             ;
+              r_req_d.burst_len    = slv_req_i.ar.len ;
+              r_req_d.orig_ar_size = slv_req_i.ar.size;
+
+              case (r_req_d.ar.burst)
+                axi_pkg::BURST_INCR: begin
+                  // Modifiable transaction
+                  if (modifiable(r_req_d.ar.cache)) begin
+                    // No need to upsize single-beat transactions.
+                    if (r_req_d.ar.len != '0) begin
+                      // Evaluate output burst length
+                      automatic addr_t start_addr = aligned_addr(r_req_d.ar.addr, AxiMstPortMaxSize);
+                      automatic addr_t end_addr   = aligned_addr(beat_addr(r_req_d.ar.addr,
+                          r_req_d.orig_ar_size, r_req_d.burst_len, r_req_d.ar.burst,
+                          r_req_d.burst_len), AxiMstPortMaxSize);
+                      r_req_d.ar.len  = (end_addr - start_addr) >> AxiMstPortMaxSize;
+                      r_req_d.ar.size = AxiMstPortMaxSize                           ;
+                      r_state_d       = R_INCR_UPSIZE                               ;
+                    end
                   end
                 end
-              end
 
-              axi_pkg::BURST_FIXED: begin
-                // Passes through the upsizer without any changes
-                r_state_d = R_PASSTHROUGH;
-              end
+                axi_pkg::BURST_FIXED: begin
+                  // Passes through the upsizer without any changes
+                  r_state_d = R_PASSTHROUGH;
+                end
 
-              axi_pkg::BURST_WRAP: begin
-                // The DW converter does not support this kind of burst ...
-                r_state_d              = R_PASSTHROUGH;
-                r_req_d.ar_throw_error = 1'b1         ;
+                axi_pkg::BURST_WRAP: begin
+                  // The DW converter does not support this kind of burst ...
+                  r_state_d              = R_PASSTHROUGH;
+                  r_req_d.ar_throw_error = 1'b1         ;
 
-                // ... but might if this is a single-beat transaction
-                if (r_req_d.ar.len == '0)
-                  r_req_d.ar_throw_error = 1'b0;
-              end
-            endcase
+                  // ... but might if this is a single-beat transaction
+                  if (r_req_d.ar.len == '0)
+                    r_req_d.ar_throw_error = 1'b0;
+                end
+              endcase
+            end
           end
+        end
+
+        R_INJECT_AW : begin
+          // Save beat
+          // During this cycle, w_req_q stores the original AW request
+          r_req_d.ar.id        = w_req_q.aw.id       ;
+          r_req_d.ar.addr      = w_req_q.aw.addr     ;
+          r_req_d.ar.size      = w_req_q.orig_aw_size;
+          r_req_d.ar.burst     = w_req_q.aw.burst    ;
+          r_req_d.ar.len       = w_req_q.burst_len   ;
+          r_req_d.ar.lock      = w_req_q.aw.lock     ;
+          r_req_d.ar.cache     = w_req_q.aw.cache    ;
+          r_req_d.ar.prot      = w_req_q.aw.prot     ;
+          r_req_d.ar.qos       = w_req_q.aw.qos      ;
+          r_req_d.ar.region    = w_req_q.aw.region   ;
+          r_req_d.ar.user      = w_req_q.aw.user     ;
+          r_req_d.ar_valid     = 1'b0                ; // Injected "AR"s from AW are not valid.
+          r_req_d.burst_len    = w_req_q.burst_len   ;
+          r_req_d.orig_ar_size = w_req_q.orig_aw_size;
+
+          // Default state
+          r_state_d = R_PASSTHROUGH;
+
+          case (r_req_d.ar.burst)
+            axi_pkg::BURST_INCR: begin
+              // Modifiable transaction
+              if (modifiable(r_req_d.ar.cache)) begin
+                // No need to upsize single-beat transactions.
+                if (r_req_d.ar.len != '0) begin
+                  // Evaluate output burst length
+                  automatic addr_t start_addr = aligned_addr(r_req_d.ar.addr, AxiMstPortMaxSize);
+                  automatic addr_t end_addr   = aligned_addr(beat_addr(r_req_d.ar.addr,
+                      r_req_d.orig_ar_size, r_req_d.burst_len, r_req_d.ar.burst,
+                      r_req_d.burst_len), AxiMstPortMaxSize);
+                  r_req_d.ar.len  = (end_addr - start_addr) >> AxiMstPortMaxSize;
+                  r_req_d.ar.size = AxiMstPortMaxSize                           ;
+                  r_state_d       = R_INCR_UPSIZE                               ;
+                end
+              end
+            end
+
+            axi_pkg::BURST_FIXED: begin
+              // Passes through the upsizer without any changes
+              r_state_d = R_PASSTHROUGH;
+            end
+
+            axi_pkg::BURST_WRAP: begin
+              // The DW converter does not support this kind of burst ...
+              r_state_d              = R_PASSTHROUGH;
+              r_req_d.ar_throw_error = 1'b1         ;
+
+              // ... but might if this is a single-beat transaction
+              if (r_req_d.ar.len == '0)
+                r_req_d.ar_throw_error = 1'b0;
+            end
+          endcase
         end
 
         R_PASSTHROUGH, R_INCR_UPSIZE: begin
           // Request was accepted
           if (!r_req_q.ar_valid)
             if (mst_resp.r_valid && (idx_r_upsizer == t) && r_upsizer_valid) begin
-              automatic addr_t mst_port_offset = r_req_q.ar.addr[(AxiMstPortStrbWidth == 1 ? 1 : $clog2(AxiMstPortStrbWidth)) - 1:0];
-              automatic addr_t slv_port_offset = r_req_q.ar.addr[(AxiSlvPortStrbWidth == 1 ? 1 : $clog2(AxiSlvPortStrbWidth)) - 1:0];
+              automatic addr_t mst_port_offset = AxiMstPortStrbWidth == 1 ? '0 : r_req_q.ar.addr[idx_width(AxiMstPortStrbWidth)-1:0];
+              automatic addr_t slv_port_offset = AxiSlvPortStrbWidth == 1 ? '0 : r_req_q.ar.addr[idx_width(AxiSlvPortStrbWidth)-1:0];
 
               // Valid output
               slv_r_valid_tran[t] = 1'b1                                       ;
@@ -531,8 +579,8 @@ module axi_dw_upsizer #(
           slv_resp_o.w_ready = ~mst_req.w_valid || mst_resp.w_ready;
 
           if (slv_req_i.w_valid && slv_resp_o.w_ready) begin
-            automatic addr_t mst_port_offset = w_req_q.aw.addr[(AxiMstPortStrbWidth == 1 ? 1 : $clog2(AxiMstPortStrbWidth)) - 1:0];
-            automatic addr_t slv_port_offset = w_req_q.aw.addr[(AxiSlvPortStrbWidth == 1 ? 1 : $clog2(AxiSlvPortStrbWidth)) - 1:0];
+            automatic addr_t mst_port_offset = AxiMstPortStrbWidth == 1 ? '0 : w_req_q.aw.addr[idx_width(AxiMstPortStrbWidth)-1:0];
+            automatic addr_t slv_port_offset = AxiSlvPortStrbWidth == 1 ? '0 : w_req_q.aw.addr[idx_width(AxiSlvPortStrbWidth)-1:0];
 
             // Serialization
             for (int b = 0; b < AxiMstPortStrbWidth; b++)

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -865,7 +865,7 @@ package axi_test;
             // Total data transferred in burst can be 2, 4, 8, 16, or 32 B.
             automatic int unsigned log_bytes;
             rand_success = std::randomize(log_bytes) with {
-              log_bytes > 0; 2**log_bytes >= AXI_STRB_WIDTH; 2**log_bytes <= 32;
+              log_bytes > 0; 2**log_bytes <= 32;
             }; assert(rand_success);
             bytes = 2**log_bytes;
           end else begin

--- a/test/tb_axi_dw_downsizer.do
+++ b/test/tb_axi_dw_downsizer.do
@@ -1,4 +1,4 @@
 add wave -position insertpoint  \
-  sim:/tb_axi_dw_downsizer/i_dw_converter/gen_dw_downsize/i_axi_dw_downsizer/AxiMstDataWidth \
-  sim:/tb_axi_dw_downsizer/i_dw_converter/gen_dw_downsize/i_axi_dw_downsizer/AxiSlvDataWidth \
-  sim:/tb_axi_dw_downsizer/i_dw_converter/gen_dw_downsize/i_axi_dw_downsizer/*
+  sim:/tb_axi_dw_downsizer/i_dw_converter/i_axi_dw_converter/gen_dw_downsize/i_axi_dw_downsizer/AxiSlvPortDataWidth \
+  sim:/tb_axi_dw_downsizer/i_dw_converter/i_axi_dw_converter/gen_dw_downsize/i_axi_dw_downsizer/AxiMstPortDataWidth \
+  sim:/tb_axi_dw_downsizer/i_dw_converter/i_axi_dw_converter/gen_dw_downsize/i_axi_dw_downsizer/*

--- a/test/tb_axi_dw_downsizer.sv
+++ b/test/tb_axi_dw_downsizer.sv
@@ -85,6 +85,8 @@ module tb_axi_dw_downsizer #(
     .UW             (AxiUserWidth       ),
     .TA             (ApplTime           ),
     .TT             (TestTime           ),
+    .MAX_READ_TXNS  (8                  ),
+    .MAX_WRITE_TXNS (8                  ),
     .AXI_BURST_FIXED(1'b0               )
   ) master_drv = new (master_dv);
 

--- a/test/tb_axi_dw_downsizer.sv
+++ b/test/tb_axi_dw_downsizer.sv
@@ -87,7 +87,8 @@ module tb_axi_dw_downsizer #(
     .TT             (TestTime           ),
     .MAX_READ_TXNS  (8                  ),
     .MAX_WRITE_TXNS (8                  ),
-    .AXI_BURST_FIXED(1'b0               )
+    .AXI_BURST_FIXED(1'b0               ),
+    .AXI_ATOPS      (1'b1               )
   ) master_drv = new (master_dv);
 
   // Slave port

--- a/test/tb_axi_dw_downsizer.sv
+++ b/test/tb_axi_dw_downsizer.sv
@@ -27,8 +27,8 @@ module tb_axi_dw_downsizer #(
     parameter int unsigned AxiUserWidth        = 8   ,
     // TB Parameters
     parameter time CyclTime                    = 10ns,
-    parameter time ApplTime                    = 0ns ,
-    parameter time TestTime                    = 5ns
+    parameter time ApplTime                    = 2ns ,
+    parameter time TestTime                    = 8ns
   );
 
   /****************
@@ -147,6 +147,9 @@ module tb_axi_dw_downsizer #(
     master_drv.reset()                                                                                 ;
     master_drv.add_memory_region({AxiAddrWidth{1'b0}}, {AxiAddrWidth{1'b1}}, axi_pkg::WTHRU_NOALLOCATE);
 
+    // Wait for the reset before sending requests
+    @(posedge rst_n);
+
     fork
       // Act as a sink
       slave_drv.run()         ;
@@ -154,7 +157,7 @@ module tb_axi_dw_downsizer #(
     join_any
 
     // Done
-    #(10*CyclTime);
+    repeat (10) @(posedge clk);
     eos = 1'b1;
   end
 

--- a/test/tb_axi_dw_downsizer.sv
+++ b/test/tb_axi_dw_downsizer.sv
@@ -18,152 +18,147 @@
 `include "axi/assign.svh"
 `include "axi/typedef.svh"
 
-module tb_axi_dw_downsizer;
-
-  timeunit      1ns;
-  timeprecision 10ps;
-
-  parameter AW   = 64;
-  parameter IW   = 4;
-  parameter DW   = 32;
-  parameter UW   = 8;
-  parameter MULT = 8;
-
-  // Clock
-
-  localparam tCK = 1ns;
-
-  logic clk  = 0;
-  logic rst  = 1;
-  logic done = 0;
-
-  initial begin
-    #tCK;
-    rst <= 0;
-    #tCK;
-    rst <= 1;
-    #tCK;
-    while (!done) begin
-      clk <= 1;
-      #(tCK/2);
-      clk <= 0;
-      #(tCK/2);
-    end
-  end
-
-  // AXI Buses
-
-  AXI_BUS_DV #(
-    .AXI_ADDR_WIDTH(AW     ),
-    .AXI_DATA_WIDTH(MULT*DW),
-    .AXI_ID_WIDTH  (IW     ),
-    .AXI_USER_WIDTH(UW     )
-  ) axi_master_dv (clk);
-
-  axi_test::rand_axi_master #(
-    .AW            (AW     ),
-    .DW            (MULT*DW),
-    .IW            (IW     ),
-    .UW            (UW     ),
-    .MAX_READ_TXNS (8      ),
-    .MAX_WRITE_TXNS(8      ),
-    .TA            (200ps  ),
-    .TT            (700ps  )
-  ) axi_master_drv = new (axi_master_dv);
-
-  AXI_BUS_DV #(
-    .AXI_ADDR_WIDTH(AW),
-    .AXI_DATA_WIDTH(DW),
-    .AXI_ID_WIDTH  (IW),
-    .AXI_USER_WIDTH(UW)
-  ) axi_slave_dv (clk);
-
-  axi_test::rand_axi_slave #(
-    .AW(AW   ),
-    .DW(DW   ),
-    .IW(IW   ),
-    .UW(UW   ),
-    .TA(200ps),
-    .TT(700ps)
-  ) axi_slave_drv = new ( axi_slave_dv );
-
-  // AXI channel types
-  typedef logic [AW-1:0] addr_t           ;
-  typedef logic [IW-1:0] id_t             ;
-  typedef logic [UW-1:0] user_t           ;
-  typedef logic [MULT*DW-1:0] mst_data_t  ;
-  typedef logic [MULT*DW/8-1:0] mst_strb_t;
-  typedef logic [DW-1:0] slv_data_t       ;
-  typedef logic [DW/8-1:0] slv_strb_t     ;
-
-  `AXI_TYPEDEF_AW_CHAN_T(aw_chan_t, addr_t, id_t, user_t)            ;
-  `AXI_TYPEDEF_W_CHAN_T(mst_w_chan_t, mst_data_t, mst_strb_t, user_t);
-  `AXI_TYPEDEF_W_CHAN_T(slv_w_chan_t, slv_data_t, slv_strb_t, user_t);
-  `AXI_TYPEDEF_B_CHAN_T(b_chan_t, id_t, user_t)                      ;
-  `AXI_TYPEDEF_AR_CHAN_T(ar_chan_t, addr_t, id_t, user_t)            ;
-  `AXI_TYPEDEF_R_CHAN_T(mst_r_chan_t, mst_data_t, id_t, user_t)      ;
-  `AXI_TYPEDEF_R_CHAN_T(slv_r_chan_t, slv_data_t, id_t, user_t)      ;
-
-  `AXI_TYPEDEF_REQ_T(mst_req_t, aw_chan_t, mst_w_chan_t, ar_chan_t);
-  `AXI_TYPEDEF_RESP_T(mst_resp_t, b_chan_t, mst_r_chan_t)          ;
-  `AXI_TYPEDEF_REQ_T(slv_req_t, aw_chan_t, slv_w_chan_t, ar_chan_t);
-  `AXI_TYPEDEF_RESP_T(slv_resp_t, b_chan_t, slv_r_chan_t)          ;
-
-  mst_req_t  axi_mst_req;
-  mst_resp_t axi_mst_resp;
-  `AXI_ASSIGN_TO_REQ(axi_mst_req, axi_master_dv)    ;
-  `AXI_ASSIGN_FROM_RESP(axi_master_dv, axi_mst_resp);
-
-  slv_req_t  axi_slv_req;
-  slv_resp_t axi_slv_resp;
-  `AXI_ASSIGN_FROM_REQ(axi_slave_dv, axi_slv_req);
-  `AXI_ASSIGN_TO_RESP(axi_slv_resp, axi_slave_dv);
-
-  // DUT
-
-  axi_dw_converter #(
-    .AxiMaxReads        (4           ),
-    .AxiSlvPortDataWidth(MULT * DW   ),
-    .AxiMstPortDataWidth(DW          ),
-    .AxiAddrWidth       (AW          ),
-    .AxiIdWidth         (IW          ),
-    .aw_chan_t          (aw_chan_t   ),
-    .mst_w_chan_t       (slv_w_chan_t),
-    .slv_w_chan_t       (mst_w_chan_t),
-    .b_chan_t           (b_chan_t    ),
-    .ar_chan_t          (ar_chan_t   ),
-    .mst_r_chan_t       (slv_r_chan_t),
-    .slv_r_chan_t       (mst_r_chan_t),
-    .axi_mst_req_t      (slv_req_t   ),
-    .axi_mst_resp_t     (slv_resp_t  ),
-    .axi_slv_req_t      (mst_req_t   ),
-    .axi_slv_resp_t     (mst_resp_t  )
-  ) i_dw_converter (
-    .clk_i     (clk         ),
-    .rst_ni    (rst         ),
-    .slv_req_i (axi_mst_req ),
-    .slv_resp_o(axi_mst_resp),
-    .mst_req_o (axi_slv_req ),
-    .mst_resp_i(axi_slv_resp)
+module tb_axi_dw_downsizer #(
+    // AXI Parameters
+    parameter int unsigned AxiAddrWidth        = 64  ,
+    parameter int unsigned AxiIdWidth          = 4   ,
+    parameter int unsigned AxiSlvPortDataWidth = 64  ,
+    parameter int unsigned AxiMstPortDataWidth = 32  ,
+    parameter int unsigned AxiUserWidth        = 8   ,
+    // TB Parameters
+    parameter time CyclTime                    = 10ns,
+    parameter time ApplTime                    = 2ns ,
+    parameter time TestTime                    = 8ns
   );
 
-  initial begin
-    axi_master_drv.reset()                                                             ;
-    axi_master_drv.add_memory_region({AW{1'b0}}, {AW{1'b1}}, axi_pkg::WTHRU_NOALLOCATE);
-    axi_master_drv.run(50, 50)                                                         ;
-    done = 1;
-  end
+  /****************
+   *  PARAMETERS  *
+   ****************/
+
+  `include "axi/assign.svh"
+  `include "axi/typedef.svh"
+
+  localparam AxiSlvPortStrbWidth = AxiSlvPortDataWidth / 8;
+  localparam AxiMstPortStrbWidth = AxiMstPortDataWidth / 8;
+
+  localparam AxiSlvPortMaxSize = $clog2(AxiSlvPortStrbWidth);
+  localparam AxiMstPortMaxSize = $clog2(AxiMstPortStrbWidth);
+
+  /*********************
+   *  CLOCK GENERATOR  *
+   *********************/
+
+  logic clk;
+  logic rst_n;
+
+  clk_rst_gen #(
+    .CLK_PERIOD    (CyclTime),
+    .RST_CLK_CYCLES(5       )
+  ) i_clk_rst_gen (
+    .clk_o (clk  ),
+    .rst_no(rst_n)
+  );
+
+
+  /*********
+   *  AXI  *
+   *********/
+
+  // Master port
+
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH(AxiAddrWidth       ),
+    .AXI_DATA_WIDTH(AxiSlvPortDataWidth),
+    .AXI_ID_WIDTH  (AxiIdWidth         ),
+    .AXI_USER_WIDTH(AxiUserWidth       )
+  ) master_dv (
+    .clk_i(clk)
+  );
+
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH(AxiAddrWidth       ),
+    .AXI_DATA_WIDTH(AxiSlvPortDataWidth),
+    .AXI_ID_WIDTH  (AxiIdWidth         ),
+    .AXI_USER_WIDTH(AxiUserWidth       )
+  ) master ();
+
+  `AXI_ASSIGN(master, master_dv)
+
+  axi_test::rand_axi_master #(
+    .AW(AxiAddrWidth       ),
+    .DW(AxiSlvPortDataWidth),
+    .IW(AxiIdWidth         ),
+    .UW(AxiUserWidth       ),
+    .TA(ApplTime           ),
+    .TT(TestTime           )
+  ) master_drv = new (master_dv);
+
+  // Slave port
+
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH(AxiAddrWidth       ),
+    .AXI_DATA_WIDTH(AxiMstPortDataWidth),
+    .AXI_ID_WIDTH  (AxiIdWidth         ),
+    .AXI_USER_WIDTH(AxiUserWidth       )
+  ) slave_dv (
+    .clk_i(clk)
+  );
+
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH(AxiAddrWidth       ),
+    .AXI_DATA_WIDTH(AxiMstPortDataWidth),
+    .AXI_ID_WIDTH  (AxiIdWidth         ),
+    .AXI_USER_WIDTH(AxiUserWidth       )
+  ) slave ();
+
+  axi_test::rand_axi_slave #(
+    .AW(AxiAddrWidth       ),
+    .DW(AxiMstPortDataWidth),
+    .IW(AxiIdWidth         ),
+    .UW(AxiUserWidth       ),
+    .TA(ApplTime           ),
+    .TT(TestTime           )
+  ) slave_drv = new (slave_dv);
+
+  `AXI_ASSIGN(slave_dv, slave)
+
+  /*********
+   *  DUT  *
+   *********/
+
+  axi_dw_converter_intf #(
+    .AXI_MAX_READS          (4                  ),
+    .AXI_ADDR_WIDTH         (AxiAddrWidth       ),
+    .AXI_ID_WIDTH           (AxiIdWidth         ),
+    .AXI_SLV_PORT_DATA_WIDTH(AxiSlvPortDataWidth),
+    .AXI_MST_PORT_DATA_WIDTH(AxiMstPortDataWidth),
+    .AXI_USER_WIDTH         (AxiUserWidth       )
+  ) i_dw_converter (
+    .clk_i (clk   ),
+    .rst_ni(rst_n ),
+    .slv   (master),
+    .mst   (slave )
+  );
+
+  /********
+   *  TB  *
+   ********/
 
   initial begin
-    axi_slave_drv.reset();
-    axi_slave_drv.run()  ;
-  end
+    // Configuration
+    slave_drv.reset()                                                                                  ;
+    master_drv.reset()                                                                                 ;
+    master_drv.add_memory_region({AxiAddrWidth{1'b0}}, {AxiAddrWidth{1'b1}}, axi_pkg::WTHRU_NOALLOCATE);
 
-  // Terminate simulation after all transactions have completed.
-  initial begin
-    wait (done);
-    #(10*tCK)  ;
-    $finish(0) ;
+    fork
+      // Act as a sink
+      slave_drv.run()       ;
+      master_drv.run(50, 50);
+    join_any
+
+    // Done
+    #(10*CyclTime);
+    $finish(0)    ;
   end
 
 // vsim -voptargs=+acc work.tb_axi_dw_downsizer

--- a/test/tb_axi_dw_pkg.sv
+++ b/test/tb_axi_dw_pkg.sv
@@ -314,36 +314,32 @@ package tb_axi_dw_pkg;
     // For the tasks every clock cycle all processes that only push something in the fifo's and
     // Queues get run. When they are finished the processes that pop something get run.
     task run();
-      Continous: fork
-        begin
-          do begin
-            // At every cycle, spawn some monitoring processes.
-            cycle_start();
+      forever begin
+        // At every cycle, spawn some monitoring processes.
+        cycle_start();
 
-            // Execute all processes that push something into the queues
-            PushMon: fork
-              proc_mst_aw: monitor_mst_aw();
-              proc_mst_ar: monitor_mst_ar();
-            join: PushMon
+        // Execute all processes that push something into the queues
+        PushMon: fork
+          proc_mst_aw: monitor_mst_aw();
+          proc_mst_ar: monitor_mst_ar();
+        join: PushMon
 
-            // These pop and push something
-            proc_slv_aw: monitor_slv_aw();
-            proc_slv_w : monitor_slv_w() ;
+        // These pop and push something
+        proc_slv_aw: monitor_slv_aw();
+        proc_slv_w : monitor_slv_w() ;
 
-            // These only pop something from the queues
-            PopMon: fork
-              proc_mst_b : monitor_mst_b() ;
-              proc_slv_ar: monitor_slv_ar();
-              proc_mst_r : monitor_mst_r() ;
-            join : PopMon
+        // These only pop something from the queues
+        PopMon: fork
+          proc_mst_b : monitor_mst_b() ;
+          proc_slv_ar: monitor_slv_ar();
+          proc_mst_r : monitor_mst_r() ;
+        join : PopMon
 
-            // Check the slave W FIFOs last
-            proc_check_slv_w: check_slv_w();
+        // Check the slave W FIFOs last
+        proc_check_slv_w: check_slv_w();
 
-            cycle_end();
-          end while (1'b1);
-        end
-      join: Continous
+        cycle_end();
+      end
     endtask : run
 
     task print_result()                                    ;
@@ -465,7 +461,7 @@ package tb_axi_dw_pkg;
         $display("        Expect B response.")        ;
 
         // Inject expected R beats on this id, if it is an atop
-        if(master_axi.aw_atop[5]) begin
+        if(master_axi.aw_atop[axi_pkg::ATOP_R_RESP]) begin
           // Push the required R beats into the right fifo (reuse the exp_b variable)
           $display("        Expect R response, len: %0d.", master_axi.aw_len);
           for (int unsigned j = 0; j <= master_axi.aw_len; j++) begin
@@ -709,7 +705,7 @@ package tb_axi_dw_pkg;
         $display("        Expect B response.")        ;
 
         // Inject expected R beats on this id, if it is an atop
-        if(master_axi.aw_atop[5]) begin
+        if(master_axi.aw_atop[axi_pkg::ATOP_R_RESP]) begin
           // Push the required R beats into the right fifo (reuse the exp_b variable)
           $display("        Expect R response, len: %0d.", master_axi.aw_len);
           for (int unsigned j = 0; j <= master_axi.aw_len; j++) begin

--- a/test/tb_axi_dw_pkg.sv
+++ b/test/tb_axi_dw_pkg.sv
@@ -1,0 +1,477 @@
+// Copyright (c) 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+
+// `axi_dw_upsizer_monitor` implements an AXI bus monitor that is tuned
+// for the AXI Data Width Upsizer. It snoops on the slave and master port
+// of the upsizer and populates FIFOs and ID queues to validate that no
+// AXI beats get lost.
+
+package tb_axi_dw_pkg;
+  /*************
+   *  UPSIZER  *
+   *************/
+
+  class axi_dw_upsizer_monitor #(
+      parameter int unsigned AxiAddrWidth       ,
+      parameter int unsigned AxiSlvPortDataWidth,
+      parameter int unsigned AxiMstPortDataWidth,
+      parameter int unsigned AxiIdWidth         ,
+      parameter int unsigned AxiUserWidth       ,
+      // Stimuli application and test time
+      parameter time TimeTest
+    );
+
+    localparam AxiSlvPortStrbWidth = AxiSlvPortDataWidth / 8;
+    localparam AxiMstPortStrbWidth = AxiMstPortDataWidth / 8;
+
+    localparam AxiSlvPortMaxSize = $clog2(AxiSlvPortStrbWidth);
+    localparam AxiMstPortMaxSize = $clog2(AxiMstPortStrbWidth);
+
+    typedef logic [AxiIdWidth-1:0] axi_id_t    ;
+    typedef logic [AxiAddrWidth-1:0] axi_addr_t;
+    typedef axi_pkg::len_t axi_len_t           ;
+
+    typedef struct packed {
+      axi_id_t axi_id;
+      logic last     ;
+    } exp_t;
+    typedef struct packed {
+      axi_id_t slv_axi_id    ;
+      axi_addr_t slv_axi_addr;
+      axi_len_t slv_axi_len  ;
+    } exp_ax_t;
+
+    typedef rand_id_queue_pkg::rand_id_queue #(
+      .data_t  (exp_t     ),
+      .ID_WIDTH(AxiIdWidth)
+    ) exp_queue_t;
+    typedef rand_id_queue_pkg::rand_id_queue #(
+      .data_t  (exp_ax_t  ),
+      .ID_WIDTH(AxiIdWidth)
+    ) ax_queue_t;
+
+    /************************
+     *  Virtual Interfaces  *
+     ************************/
+
+    virtual AXI_BUS_DV #(
+      .AXI_ADDR_WIDTH(AxiAddrWidth       ),
+      .AXI_DATA_WIDTH(AxiSlvPortDataWidth),
+      .AXI_ID_WIDTH  (AxiIdWidth         ),
+      .AXI_USER_WIDTH(AxiUserWidth       )
+    ) master_axi;
+    virtual AXI_BUS_DV #(
+      .AXI_ADDR_WIDTH(AxiAddrWidth       ),
+      .AXI_DATA_WIDTH(AxiMstPortDataWidth),
+      .AXI_ID_WIDTH  (AxiIdWidth         ),
+      .AXI_USER_WIDTH(AxiUserWidth       )
+    ) slave_axi;
+
+    /*****************
+     *  Bookkeeping  *
+     *****************/
+
+    longint unsigned tests_expected;
+    longint unsigned tests_conducted;
+    longint unsigned tests_failed;
+    semaphore        cnt_sem;
+
+    // Queues and FIFOs to hold the expected AXIDs
+
+    // Write transactions
+    ax_queue_t  exp_aw_queue;
+    exp_t       exp_w_fifo [$];
+    exp_t       act_w_fifo [$];
+    exp_queue_t exp_b_queue;
+
+    // Read transactions
+    ax_queue_t  exp_ar_queue;
+    exp_queue_t exp_r_queue;
+
+    /*****************
+     *  Constructor  *
+     *****************/
+
+    function new (
+        virtual AXI_BUS_DV #(
+          .AXI_ADDR_WIDTH(AxiAddrWidth       ),
+          .AXI_DATA_WIDTH(AxiSlvPortDataWidth),
+          .AXI_ID_WIDTH  (AxiIdWidth         ),
+          .AXI_USER_WIDTH(AxiUserWidth       )
+        ) axi_master_vif,
+        virtual AXI_BUS_DV #(
+          .AXI_ADDR_WIDTH(AxiAddrWidth       ),
+          .AXI_DATA_WIDTH(AxiMstPortDataWidth),
+          .AXI_ID_WIDTH  (AxiIdWidth         ),
+          .AXI_USER_WIDTH(AxiUserWidth       )
+        ) axi_slave_vif
+      );
+      begin
+        this.master_axi      = axi_master_vif;
+        this.slave_axi       = axi_slave_vif ;
+        this.tests_expected  = 0             ;
+        this.tests_conducted = 0             ;
+        this.tests_failed    = 0             ;
+        this.exp_b_queue     = new           ;
+        this.exp_r_queue     = new           ;
+        this.exp_aw_queue    = new           ;
+        this.exp_ar_queue    = new           ;
+        this.cnt_sem         = new(1)        ;
+      end
+    endfunction
+
+    task cycle_start;
+      #TimeTest;
+    endtask: cycle_start
+
+    task cycle_end;
+      @(posedge master_axi.clk_i);
+    endtask: cycle_end
+
+    /**************
+     *  Monitors  *
+     **************/
+
+    // This task monitors a slave port of the upsizer. Every time an AW beat is seen, it populates
+    //
+    // it populates an id queue at the right master port (if there is no expected decode error),
+    // populates the expected b response in its own id_queue and in case when the atomic bit [5]
+    // is set it also injects an expected response in the R channel.
+    task automatic monitor_mst_aw ();
+      exp_ax_t exp_aw;
+      exp_t    exp_b;
+
+      logic exp_slverr;
+
+      if (master_axi.aw_valid && master_axi.aw_ready) begin
+        // Non-modifiable transaction
+        if (!axi_pkg::modifiable(master_axi.aw_cache)) begin
+          // We expect that the transaction will not be modified
+          exp_aw = '{
+            slv_axi_id  : master_axi.aw_id  ,
+            slv_axi_addr: master_axi.aw_addr,
+            slv_axi_len : master_axi.aw_len
+          } ;
+        end
+        // Modifiable transaction
+        else begin
+          case (master_axi.aw_burst)
+            // Passthrough upsize
+            axi_pkg::BURST_FIXED: begin
+              exp_aw = '{
+                slv_axi_id  : master_axi.aw_id  ,
+                slv_axi_addr: master_axi.aw_addr,
+                slv_axi_len : master_axi.aw_len
+              } ;
+            end
+            // INCR upsize
+            axi_pkg::BURST_INCR: begin
+              automatic axi_addr_t aligned_start = axi_pkg::aligned_addr(master_axi.aw_addr, AxiMstPortMaxSize)                                                                                       ;
+              automatic axi_addr_t aligned_end   = axi_pkg::aligned_addr(axi_pkg::aligned_addr(master_axi.aw_addr, master_axi.aw_size) + (master_axi.aw_len << master_axi.aw_size), AxiMstPortMaxSize);
+
+              exp_aw = '{
+                slv_axi_id  : master_axi.aw_id  ,
+                slv_axi_addr: master_axi.aw_addr,
+                slv_axi_len : (aligned_end - aligned_start) >> AxiMstPortMaxSize
+              } ;
+            end
+          endcase
+          this.exp_aw_queue.push(master_axi.aw_id, exp_aw);
+          incr_expected_tests(3)                          ;
+          $display("%0tns > Master: AW to Slave: Axi ID: %b",
+            $time, master_axi.aw_id);
+        end
+
+        // Populate the expected B queue
+        exp_b = '{axi_id: master_axi.aw_id, last: 1'b1};
+        this.exp_b_queue.push(master_axi.aw_id, exp_b);
+        incr_expected_tests(1)                        ;
+        $display("        Expect B response.")        ;
+
+        // Inject expected R beats on this id, if it is an atop
+        if(master_axi.aw_atop[5]) begin
+          // Push the required R beats into the right fifo (reuse the exp_b variable)
+          $display("        Expect R response, len: %0d.", master_axi.aw_len);
+          for (int unsigned j = 0; j <= master_axi.aw_len; j++) begin
+            exp_b.axi_id = master_axi.aw_id;
+            exp_b.last   = (j == master_axi.aw_len) ? 1'b1 : 1'b0;
+            this.exp_r_queue.push(master_axi.aw_id, exp_b);
+            incr_expected_tests(1)                        ;
+          end
+        end
+      end
+    endtask : monitor_mst_aw
+
+    // This task monitors the slave port of the crossbar. Every time there is an AW vector it
+    // gets checked for its contents and if it was expected. The task then pushes an expected
+    // amount of W beats in the respective fifo. Emphasis of the last flag.
+    task automatic monitor_slv_aw ();
+      exp_ax_t exp_aw;
+      exp_t    exp_slv_w;
+      if (slave_axi.aw_valid && slave_axi.aw_ready) begin
+        // Test if the AW beat was expected
+        exp_aw = this.exp_aw_queue.pop_id(slave_axi.aw_id);
+        if (exp_aw.slv_axi_id != slave_axi.aw_id) begin
+          incr_failed_tests(1)                                         ;
+          $warning("Slave: Unexpected AW with ID: %b", slave_axi.aw_id);
+        end
+        if (exp_aw.slv_axi_addr != slave_axi.aw_addr) begin
+          incr_failed_tests(1);
+          $warning("Slave : Unexpected AW with ID: %b and ADDR: %h, exp: %h",
+            slave_axi.aw_id, slave_axi.aw_addr, exp_aw.slv_axi_addr);
+        end
+        if (exp_aw.slv_axi_len != slave_axi.aw_len) begin
+          incr_failed_tests(1);
+          $warning("Slave: Unexpected AW with ID: %b and LEN: %h, exp: %h",
+            slave_axi.aw_id, slave_axi.aw_len, exp_aw.slv_axi_len);
+        end
+        incr_conducted_tests(3);
+
+        // Push the required W beats into the right fifo
+        incr_expected_tests(slave_axi.aw_len + 1);
+        for (int unsigned j = 0; j <= slave_axi.aw_len; j++) begin
+          exp_slv_w.axi_id = slave_axi.aw_id;
+          exp_slv_w.last   = (j == slave_axi.aw_len) ? 1'b1 : 1'b0;
+          this.exp_w_fifo.push_back(exp_slv_w) ;
+        end
+      end
+    endtask : monitor_slv_aw
+
+    // This task just pushes every W beat that gets sent on a master port in its respective fifo.
+    task automatic monitor_slv_w ();
+      exp_t act_slv_w;
+      if (slave_axi.w_valid && slave_axi.w_ready) begin
+        act_slv_w.last   = slave_axi.w_last ;
+        act_slv_w.axi_id = 'x               ;
+        this.act_w_fifo.push_back(act_slv_w);
+      end
+    endtask : monitor_slv_w
+
+    // This task compares the expected and actual W beats on a master port. The reason that
+    // this is not done in `monitor_slv_w` is that there can be per protocol W beats on the
+    // channel, before AW is sent to the slave.
+    task automatic check_slv_w ();
+      exp_t exp_w, act_w;
+      while (this.exp_w_fifo.size() != 0 && this.act_w_fifo.size() != 0) begin
+
+        exp_w = this.exp_w_fifo.pop_front();
+        act_w = this.act_w_fifo.pop_front();
+        // do the check
+        incr_conducted_tests(1);
+        if(exp_w.last != act_w.last) begin
+          incr_failed_tests(1);
+          $warning("Slave: unexpected W beat last flag %b, expected: %b.",
+            act_w.last, exp_w.last);
+        end
+      end
+    endtask : check_slv_w
+
+    // This task checks if a B response is allowed on a slave port of the upsizer.
+    task automatic monitor_mst_b ();
+      exp_t    exp_b;
+      axi_id_t axi_b_id;
+      if (master_axi.b_valid && master_axi.b_ready) begin
+        incr_conducted_tests(1);
+        axi_b_id = master_axi.b_id;
+        $display("%0tns > Master: Got last B with id: %b",
+          $time, axi_b_id);
+        if (this.exp_b_queue.empty()) begin
+          incr_failed_tests(1)                                                 ;
+          $warning("Master: unexpected B beat with ID: %b detected!", axi_b_id);
+        end else begin
+          exp_b = this.exp_b_queue.pop_id(axi_b_id);
+          if (axi_b_id != exp_b.axi_id) begin
+            incr_failed_tests(1)                                      ;
+            $warning("Master: got unexpected B with ID: %b", axi_b_id);
+          end
+        end
+      end
+    endtask : monitor_mst_b
+
+    // This task monitors the AR channel of a slave port of the crossbar. For each AR it populates
+    // the corresponding ID queue with the number of r beats indicated on the `ar_len` field.
+    // Emphasis on the last flag. We will detect reordering, if the last flags do not match,
+    // as each `random` burst tend to have a different length.
+    task automatic monitor_mst_ar ();
+      exp_ax_t exp_slv_ar;
+      exp_t    exp_mst_r;
+
+      if (master_axi.ar_valid && master_axi.ar_ready) begin
+        // Non-modifiable transaction
+        if (!axi_pkg::modifiable(master_axi.ar_cache)) begin
+          // We expect that the transaction will not be modified
+          exp_slv_ar = '{
+            slv_axi_id  : master_axi.ar_id  ,
+            slv_axi_addr: master_axi.ar_addr,
+            slv_axi_len : master_axi.ar_len
+          } ;
+        end
+        // Modifiable transaction
+        else begin
+          case (master_axi.ar_burst)
+            // Passthrough upsize
+            axi_pkg::BURST_FIXED: begin
+              exp_slv_ar.slv_axi_id   = master_axi.ar_id  ;
+              exp_slv_ar.slv_axi_addr = master_axi.ar_addr;
+              exp_slv_ar.slv_axi_len  = master_axi.ar_len ;
+            end
+            // INCR upsize
+            axi_pkg::BURST_INCR: begin
+              automatic axi_addr_t aligned_start = axi_pkg::aligned_addr(master_axi.ar_addr, AxiMstPortMaxSize)                                                                                       ;
+              automatic axi_addr_t aligned_end   = axi_pkg::aligned_addr(axi_pkg::aligned_addr(master_axi.ar_addr, master_axi.ar_size) + (master_axi.ar_len << master_axi.ar_size), AxiMstPortMaxSize);
+
+              exp_slv_ar = '{
+                slv_axi_id  : master_axi.ar_id  ,
+                slv_axi_addr: master_axi.ar_addr,
+                slv_axi_len : (aligned_end - aligned_start) >> AxiMstPortMaxSize
+              } ;
+            end
+          endcase
+          this.exp_ar_queue.push(master_axi.ar_id, exp_slv_ar);
+          incr_expected_tests(1)                              ;
+          $display("%0tns > Master: AR to Slave: Axi ID: %b",
+            $time, master_axi.ar_id);
+        end
+
+        // Push the required R beats into the right fifo
+        $display("        Expect R response, len: %0d.", master_axi.ar_len);
+        for (int unsigned j = 0; j <= master_axi.ar_len; j++) begin
+          exp_mst_r.axi_id = master_axi.ar_id;
+          exp_mst_r.last   = (j == master_axi.ar_len) ? 1'b1 : 1'b0;
+          this.exp_r_queue.push(master_axi.ar_id, exp_mst_r);
+          incr_expected_tests(1)                            ;
+        end
+      end
+    endtask : monitor_mst_ar
+
+    // This task monitors a master port of the upsizer and checks if a transmitted AR beat was
+    // expected.
+    task automatic monitor_slv_ar ();
+      exp_ax_t exp_slv_ar;
+      axi_id_t slv_axi_id;
+      if (slave_axi.ar_valid && slave_axi.ar_ready) begin
+        incr_conducted_tests(1);
+        slv_axi_id = slave_axi.ar_id;
+        if (this.exp_ar_queue.empty()) begin
+          incr_failed_tests(1);
+        end else begin
+          // check that the ids are the same
+          exp_slv_ar = this.exp_ar_queue.pop_id(slv_axi_id);
+          $display("%0tns > Slave: AR Axi ID: %b", $time, slv_axi_id);
+          if (exp_slv_ar.slv_axi_id != slv_axi_id) begin
+            incr_failed_tests(1)                                    ;
+            $warning("Slave: Unexpected AR with ID: %b", slv_axi_id);
+          end
+        end
+      end
+    endtask : monitor_slv_ar
+
+    // This task does the R channel monitoring on a slave port. It compares the last flags,
+    // which are determined by the sequence of previously sent AR vectors.
+    task automatic monitor_mst_r ();
+      exp_t    exp_mst_r;
+      axi_id_t mst_axi_r_id;
+      logic    mst_axi_r_last;
+      if (master_axi.r_valid && master_axi.r_ready) begin
+        incr_conducted_tests(1);
+        mst_axi_r_id   = master_axi.r_id  ;
+        mst_axi_r_last = master_axi.r_last;
+        if (mst_axi_r_last) begin
+          $display("%0tns > Master: Got last R with id: %b",
+            $time, mst_axi_r_id);
+        end
+        if (this.exp_r_queue.empty()) begin
+          incr_failed_tests(1)                                                     ;
+          $warning("Master: unexpected R beat with ID: %b detected!", mst_axi_r_id);
+        end else begin
+          exp_mst_r = this.exp_r_queue.pop_id(mst_axi_r_id);
+          if (mst_axi_r_id != exp_mst_r.axi_id) begin
+            incr_failed_tests(1)                                          ;
+            $warning("Master: got unexpected R with ID: %b", mst_axi_r_id);
+          end
+          if (mst_axi_r_last != exp_mst_r.last) begin
+            incr_failed_tests(1);
+            $warning("Master: got unexpected R with ID: %b and last flag: %b",
+              mst_axi_r_id, mst_axi_r_last);
+          end
+        end
+      end
+    endtask : monitor_mst_r
+
+    // Some tasks to manage bookkeeping of the tests conducted.
+    task incr_expected_tests(input int unsigned times);
+      cnt_sem.get()               ;
+      this.tests_expected += times;
+      cnt_sem.put()               ;
+    endtask : incr_expected_tests
+
+    task incr_conducted_tests(input int unsigned times);
+      cnt_sem.get()                ;
+      this.tests_conducted += times;
+      cnt_sem.put()                ;
+    endtask : incr_conducted_tests
+
+    task incr_failed_tests(input int unsigned times);
+      cnt_sem.get()             ;
+      this.tests_failed += times;
+      cnt_sem.put()             ;
+    endtask : incr_failed_tests
+
+    // This task invokes the various monitoring tasks. It first forks in two, spitting
+    // the tasks that should continuously run and the ones that get invoked every clock cycle.
+    // For the tasks every clock cycle all processes that only push something in the fifo's and
+    // Queues get run. When they are finished the processes that pop something get run.
+    task run();
+      Continous: fork
+        begin
+          do begin
+            cycle_start();
+            // At every cycle, spawn some monitoring processes.
+
+            // Execute all processes that push something into the queues
+            PushMon: fork
+              proc_mst_aw: monitor_mst_aw();
+              proc_mst_ar: monitor_mst_ar();
+            join: PushMon
+
+            // These pop and push something
+            proc_slv_aw: monitor_slv_aw();
+            proc_slv_w : monitor_slv_w() ;
+
+            // These only pop something from the queues
+            PopMon: fork
+              proc_mst_b : monitor_mst_b() ;
+              proc_slv_ar: monitor_slv_ar();
+              proc_mst_r : monitor_mst_r() ;
+            join : PopMon
+
+            // Check the slave W FIFOs last
+            proc_check_slv_w: check_slv_w();
+
+            cycle_end();
+          end while (1'b1);
+        end
+      join: Continous
+    endtask : run
+
+    task print_result()                                    ;
+      $info("Simulation has ended!")                       ;
+      $display("Tests Expected:  %d", this.tests_expected) ;
+      $display("Tests Conducted: %d", this.tests_conducted);
+      $display("Tests Failed:    %d", this.tests_failed)   ;
+      if(tests_failed > 0) begin
+        $error("Simulation encountered unexpected transactions!!!!!!");
+      end
+    endtask : print_result
+
+  endclass : axi_dw_upsizer_monitor
+endpackage: tb_axi_dw_pkg

--- a/test/tb_axi_dw_pkg.sv
+++ b/test/tb_axi_dw_pkg.sv
@@ -677,11 +677,14 @@ package tb_axi_dw_pkg;
             end
             // Split into master_axi.aw_len + 1 INCR bursts
             else begin
+              automatic axi_addr_t size_mask          = (1'b1 << master_axi.aw_size) - 1                                            ;
+              automatic axi_addr_t aligned_adjustment = (master_axi.aw_addr & size_mask & ~AxiMstPortByteMask) / AxiMstPortStrbWidth;
+
               for (int unsigned j = 0; j <= master_axi.aw_len; j++) begin
                 exp_aw = '{
                   slv_axi_id  : master_axi.aw_id  ,
                   slv_axi_addr: master_axi.aw_addr,
-                  slv_axi_len : master_axi.aw_len
+                  slv_axi_len : (downsize_ratio >= aligned_adjustment + 1) ? (downsize_ratio - aligned_adjustment - 1) : 0
                 };
 
                 this.exp_aw_queue.push(master_axi.aw_id, exp_aw);
@@ -809,11 +812,14 @@ package tb_axi_dw_pkg;
             end
             // Split into master_axi.ar_len + 1 INCR bursts
             else begin
+              automatic axi_addr_t size_mask          = (1'b1 << master_axi.ar_size) - 1                                            ;
+              automatic axi_addr_t aligned_adjustment = (master_axi.ar_addr & size_mask & ~AxiMstPortByteMask) / AxiMstPortStrbWidth;
+
               for (int unsigned j = 0; j <= master_axi.ar_len; j++) begin
                 exp_slv_ar = '{
                   slv_axi_id  : master_axi.ar_id  ,
                   slv_axi_addr: master_axi.ar_addr,
-                  slv_axi_len : master_axi.ar_len
+                  slv_axi_len : (downsize_ratio >= aligned_adjustment + 1) ? (downsize_ratio - aligned_adjustment - 1) : 0
                 };
 
                 this.exp_ar_queue.push(master_axi.ar_id, exp_slv_ar);

--- a/test/tb_axi_dw_pkg.sv
+++ b/test/tb_axi_dw_pkg.sv
@@ -11,8 +11,8 @@
 // Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 
 // `axi_dw_upsizer_monitor` implements an AXI bus monitor that is tuned
-// for the AXI Data Width Upsizer. It snoops on the slave and master port
-// of the upsizer and populates FIFOs and ID queues to validate that no
+// for the AXI Data Width Converters. It snoops on the slave and master port
+// of the DWCs and populates FIFOs and ID queues to validate that no
 // AXI beats get lost.
 
 package tb_axi_dw_pkg;
@@ -36,9 +36,6 @@ package tb_axi_dw_pkg;
     localparam AxiSlvPortMaxSize = $clog2(AxiSlvPortStrbWidth);
     localparam AxiMstPortMaxSize = $clog2(AxiMstPortStrbWidth);
 
-    localparam AxiSlvPortByteMask = AxiSlvPortStrbWidth - 1;
-    localparam AxiMstPortByteMask = AxiMstPortStrbWidth - 1;
-
     typedef logic [AxiIdWidth-1:0] axi_id_t    ;
     typedef logic [AxiAddrWidth-1:0] axi_addr_t;
     typedef axi_pkg::len_t axi_len_t           ;
@@ -48,9 +45,9 @@ package tb_axi_dw_pkg;
       logic last     ;
     } exp_t;
     typedef struct packed {
-      axi_id_t slv_axi_id    ;
-      axi_addr_t slv_axi_addr;
-      axi_len_t slv_axi_len  ;
+      axi_id_t axi_id    ;
+      axi_addr_t axi_addr;
+      axi_len_t axi_len  ;
     } exp_ax_t;
 
     typedef rand_id_queue_pkg::rand_id_queue #(
@@ -62,6 +59,15 @@ package tb_axi_dw_pkg;
       .ID_WIDTH(AxiIdWidth)
     ) ax_queue_t;
 
+    /**********************
+     *  Helper functions  *
+     **********************/
+
+    // Returns a byte mask corresponding to the size of the AXI transaction
+    function automatic axi_addr_t size_mask(axi_pkg::size_t size);
+      return (axi_addr_t'(1) << size) - 1;
+    endfunction
+
     /************************
      *  Virtual Interfaces  *
      ************************/
@@ -71,13 +77,13 @@ package tb_axi_dw_pkg;
       .AXI_DATA_WIDTH(AxiSlvPortDataWidth),
       .AXI_ID_WIDTH  (AxiIdWidth         ),
       .AXI_USER_WIDTH(AxiUserWidth       )
-    ) master_axi;
+    ) slv_port_axi;
     virtual AXI_BUS_DV #(
       .AXI_ADDR_WIDTH(AxiAddrWidth       ),
       .AXI_DATA_WIDTH(AxiMstPortDataWidth),
       .AXI_ID_WIDTH  (AxiIdWidth         ),
       .AXI_USER_WIDTH(AxiUserWidth       )
-    ) slave_axi;
+    ) mst_port_axi;
 
     /*****************
      *  Bookkeeping  *
@@ -110,25 +116,25 @@ package tb_axi_dw_pkg;
           .AXI_DATA_WIDTH(AxiSlvPortDataWidth),
           .AXI_ID_WIDTH  (AxiIdWidth         ),
           .AXI_USER_WIDTH(AxiUserWidth       )
-        ) axi_master_vif,
+        ) slv_port_vif,
         virtual AXI_BUS_DV #(
           .AXI_ADDR_WIDTH(AxiAddrWidth       ),
           .AXI_DATA_WIDTH(AxiMstPortDataWidth),
           .AXI_ID_WIDTH  (AxiIdWidth         ),
           .AXI_USER_WIDTH(AxiUserWidth       )
-        ) axi_slave_vif
+        ) mst_port_vif
       );
       begin
-        this.master_axi      = axi_master_vif;
-        this.slave_axi       = axi_slave_vif ;
-        this.tests_expected  = 0             ;
-        this.tests_conducted = 0             ;
-        this.tests_failed    = 0             ;
-        this.exp_b_queue     = new           ;
-        this.exp_r_queue     = new           ;
-        this.exp_aw_queue    = new           ;
-        this.exp_ar_queue    = new           ;
-        this.cnt_sem         = new(1)        ;
+        this.slv_port_axi    = slv_port_vif;
+        this.mst_port_axi    = mst_port_vif;
+        this.tests_expected  = 0           ;
+        this.tests_conducted = 0           ;
+        this.tests_failed    = 0           ;
+        this.exp_b_queue     = new         ;
+        this.exp_r_queue     = new         ;
+        this.exp_aw_queue    = new         ;
+        this.exp_ar_queue    = new         ;
+        this.cnt_sem         = new(1)      ;
       end
     endfunction
 
@@ -137,68 +143,86 @@ package tb_axi_dw_pkg;
     endtask: cycle_start
 
     task cycle_end;
-      @(posedge master_axi.clk_i);
+      @(posedge slv_port_axi.clk_i);
     endtask: cycle_end
 
     /**************
      *  Monitors  *
      **************/
 
-    virtual task automatic monitor_mst_aw ();
-    endtask
+    /*
+     * You need to override this task. Use it to push the expected beats on the
+     * master B and R channels to the respective queues, together with the expected
+     * AW requests on the slave side.
+     */
+    virtual task automatic mon_slv_port_aw ()    ;
+      $error("This task needs to be overridden.");
+    endtask : mon_slv_port_aw
 
-    virtual task automatic monitor_mst_ar ();
-    endtask
+    /*
+     * You need to override this task. Use it to push the expected beats on the
+     * master R channels to the respective queues, together with the expected
+     * AR requests on the slave side.
+     */
+    virtual task automatic mon_slv_port_ar ()    ;
+      $error("This task needs to be overridden.");
+    endtask : mon_slv_port_ar
 
-    // This task monitors the slave port of the DW converter. Every time there is an AW vector it
-    // gets checked for its contents and if it was expected. The task then pushes an expected
-    // amount of W beats in the respective fifo. Emphasis of the last flag.
-    task automatic monitor_slv_aw ();
+    /*
+     * This task monitors the master port of the DW converter. Every time it gets an AW transaction,
+     * it gets checked for its contents against the expected beat on the `exp_aw_queue`. The task then
+     * pushes an expected amount of W beats in the respective fifo. Emphasis of the last flag.
+     */
+    task automatic mon_mst_port_aw ();
       exp_ax_t exp_aw;
-      exp_t    exp_slv_w;
-      if (slave_axi.aw_valid && slave_axi.aw_ready) begin
+      exp_t    exp_mst_port_w;
+      if (mst_port_axi.aw_valid && mst_port_axi.aw_ready) begin
         // Test if the AW beat was expected
-        exp_aw = this.exp_aw_queue.pop_id(slave_axi.aw_id);
-        if (exp_aw.slv_axi_id != slave_axi.aw_id) begin
-          incr_failed_tests(1)                                         ;
-          $warning("Slave: Unexpected AW with ID: %b", slave_axi.aw_id);
+        exp_aw = this.exp_aw_queue.pop_id(mst_port_axi.aw_id);
+        if (exp_aw.axi_id != mst_port_axi.aw_id) begin
+          incr_failed_tests(1)                                            ;
+          $warning("Slave: Unexpected AW with ID: %b", mst_port_axi.aw_id);
         end
-        if (exp_aw.slv_axi_addr != slave_axi.aw_addr) begin
+        if (exp_aw.axi_addr != mst_port_axi.aw_addr) begin
           incr_failed_tests(1);
-          $warning("Slave : Unexpected AW with ID: %b and ADDR: %h, exp: %h",
-            slave_axi.aw_id, slave_axi.aw_addr, exp_aw.slv_axi_addr);
+          $warning("Slave: Unexpected AW with ID: %b and ADDR: %h, exp: %h",
+            mst_port_axi.aw_id, mst_port_axi.aw_addr, exp_aw.axi_addr);
         end
-        if (exp_aw.slv_axi_len != slave_axi.aw_len) begin
+        if (exp_aw.axi_len != mst_port_axi.aw_len) begin
           incr_failed_tests(1);
           $warning("Slave: Unexpected AW with ID: %b and LEN: %h, exp: %h",
-            slave_axi.aw_id, slave_axi.aw_len, exp_aw.slv_axi_len);
+            mst_port_axi.aw_id, mst_port_axi.aw_len, exp_aw.axi_len);
         end
         incr_conducted_tests(3);
 
-        // Push the required W beats into the right fifo
-        for (int unsigned j = 0; j <= slave_axi.aw_len; j++) begin
-          exp_slv_w.axi_id = slave_axi.aw_id;
-          exp_slv_w.last   = (j == slave_axi.aw_len) ? 1'b1 : 1'b0;
-          this.exp_w_fifo.push_back(exp_slv_w);
-          incr_expected_tests(1)              ;
+        // Push the required W beats into `exp_w_fifo`
+        for (int unsigned j = 0; j <= mst_port_axi.aw_len; j++) begin
+          exp_mst_port_w.axi_id = mst_port_axi.aw_id;
+          exp_mst_port_w.last   = (j == mst_port_axi.aw_len) ? 1'b1 : 1'b0;
+          this.exp_w_fifo.push_back(exp_mst_port_w);
+          incr_expected_tests(1)                   ;
         end
       end
-    endtask : monitor_slv_aw
+    endtask : mon_mst_port_aw
 
-    // This task just pushes every W beat that gets sent on a master port in its respective fifo.
-    task automatic monitor_slv_w ();
-      exp_t act_slv_w;
-      if (slave_axi.w_valid && slave_axi.w_ready) begin
-        act_slv_w.last   = slave_axi.w_last ;
-        act_slv_w.axi_id = 'x               ;
-        this.act_w_fifo.push_back(act_slv_w);
+    /*
+     * This task pushes every W beat that gets received on the master port in the respective FIFO.
+     */
+    task automatic mon_mst_port_w ();
+      exp_t act_mst_port_w;
+      if (mst_port_axi.w_valid && mst_port_axi.w_ready) begin
+        act_mst_port_w.last   = mst_port_axi.w_last ;
+        act_mst_port_w.axi_id = 'x                  ;
+        this.act_w_fifo.push_back(act_mst_port_w);
       end
-    endtask : monitor_slv_w
+    endtask : mon_mst_port_w
 
-    // This task compares the expected and actual W beats on a master port. The reason that
-    // this is not done in `monitor_slv_w` is that there can be per protocol W beats on the
-    // channel, before AW is sent to the slave.
-    task automatic check_slv_w ();
+    /*
+     * This task compares the expected and actual W beats on the master port. The reason that
+     * this is not done in mon_mst_port_w` is that there can be per protocol W beats on the
+     * channel, before AW is sent to the slave.
+     */
+    task automatic check_mst_port_w ();
       exp_t exp_w, act_w;
       while (this.exp_w_fifo.size() != 0 && this.act_w_fifo.size() != 0) begin
 
@@ -212,15 +236,17 @@ package tb_axi_dw_pkg;
             act_w.last, exp_w.last);
         end
       end
-    endtask : check_slv_w
+    endtask : check_mst_port_w
 
-    // This task checks if a B response is allowed on a slave port of the upsizer.
-    task automatic monitor_mst_b ();
+    /*
+     * This task checks if a B response is allowed on a slave port of the DW converter.
+     */
+    task automatic mon_slv_port_b ();
       exp_t    exp_b;
       axi_id_t axi_b_id;
-      if (master_axi.b_valid && master_axi.b_ready) begin
+      if (slv_port_axi.b_valid && slv_port_axi.b_ready) begin
         incr_conducted_tests(1);
-        axi_b_id = master_axi.b_id;
+        axi_b_id = slv_port_axi.b_id;
         $display("%0tns > Master: Got last B with ID: %b",
           $time, axi_b_id);
         if (this.exp_b_queue.empty()) begin
@@ -234,61 +260,63 @@ package tb_axi_dw_pkg;
           end
         end
       end
-    endtask : monitor_mst_b
+    endtask : mon_slv_port_b
 
-    // This task monitors a master port of the DW converter and checks if a transmitted
-    // AR beat was expected.
-    task automatic monitor_slv_ar ();
-      exp_ax_t exp_slv_ar;
-      axi_id_t slv_axi_id;
-      if (slave_axi.ar_valid && slave_axi.ar_ready) begin
+    /*
+     * This task monitors a the master port of the DW converter and checks
+     * if the AR beats were all expected.
+     */
+    task automatic mon_mst_port_ar ();
+      exp_ax_t exp_mst_port_ar;
+      if (mst_port_axi.ar_valid && mst_port_axi.ar_ready) begin
         incr_conducted_tests(1);
-        slv_axi_id = slave_axi.ar_id;
         if (this.exp_ar_queue.empty()) begin
           incr_failed_tests(1);
         end else begin
-          // check that the ids are the same
-          exp_slv_ar = this.exp_ar_queue.pop_id(slv_axi_id);
-          $display("%0tns > Slave: AR with ID: %b", $time, slv_axi_id);
-          if (exp_slv_ar.slv_axi_id != slv_axi_id) begin
-            incr_failed_tests(1)                                    ;
-            $warning("Slave: Unexpected AR with ID: %b", slv_axi_id);
+          // Check whether the IDs are all the same
+          exp_mst_port_ar = this.exp_ar_queue.pop_id(mst_port_axi.ar_id);
+          $display("%0tns > Slave: AR with ID: %b", $time, mst_port_axi.ar_id);
+          if (exp_mst_port_ar.axi_id != mst_port_axi.ar_id) begin
+            incr_failed_tests(1)                                            ;
+            $warning("Slave: Unexpected AR with ID: %b", mst_port_axi.ar_id);
           end
         end
       end
-    endtask : monitor_slv_ar
+    endtask : mon_mst_port_ar
 
-    // This task does the R channel monitoring on a slave port. It compares the last flags,
-    // which are determined by the sequence of previously sent AR vectors.
-    task automatic monitor_mst_r ();
-      exp_t    exp_mst_r;
-      axi_id_t mst_axi_r_id;
-      logic    mst_axi_r_last;
-      if (master_axi.r_valid && master_axi.r_ready) begin
+    /*
+     * This task does the R channel monitoring on a slave port. It compares the last flags,
+     * which are determined by the sequence of previously sent AR vectors.
+     */
+    task automatic mon_slv_port_r ();
+      exp_t    exp_slv_port_r;
+      axi_id_t slv_port_r_id;
+      logic    slv_port_r_last;
+      if (slv_port_axi.r_valid && slv_port_axi.r_ready) begin
         incr_conducted_tests(1);
-        mst_axi_r_id   = master_axi.r_id  ;
-        mst_axi_r_last = master_axi.r_last;
-        if (mst_axi_r_last) begin
+        slv_port_r_id   = slv_port_axi.r_id  ;
+        slv_port_r_last = slv_port_axi.r_last;
+        if (slv_port_r_last) begin
           $display("%0tns > Master: Got last R with ID: %b",
-            $time, mst_axi_r_id);
+            $time, slv_port_r_id);
         end
         if (this.exp_r_queue.empty()) begin
-          incr_failed_tests(1)                                                     ;
-          $warning("Master: unexpected R beat with ID: %b detected!", mst_axi_r_id);
+          incr_failed_tests(1)                                                      ;
+          $warning("Master: unexpected R beat with ID: %b detected!", slv_port_r_id);
         end else begin
-          exp_mst_r = this.exp_r_queue.pop_id(mst_axi_r_id);
-          if (mst_axi_r_id != exp_mst_r.axi_id) begin
-            incr_failed_tests(1)                                          ;
-            $warning("Master: got unexpected R with ID: %b", mst_axi_r_id);
+          exp_slv_port_r = this.exp_r_queue.pop_id(slv_port_r_id);
+          if (slv_port_r_id != exp_slv_port_r.axi_id) begin
+            incr_failed_tests(1)                                           ;
+            $warning("Master: got unexpected R with ID: %b", slv_port_r_id);
           end
-          if (mst_axi_r_last != exp_mst_r.last) begin
+          if (slv_port_r_last != exp_slv_port_r.last) begin
             incr_failed_tests(1);
             $warning("Master: got unexpected R with ID: %b and last flag: %b",
-              mst_axi_r_id, mst_axi_r_last);
+              slv_port_r_id, slv_port_r_last);
           end
         end
       end
-    endtask : monitor_mst_r
+    endtask : mon_slv_port_r
 
     // Some tasks to manage bookkeeping of the tests conducted.
     task incr_expected_tests(input int unsigned times);
@@ -309,10 +337,11 @@ package tb_axi_dw_pkg;
       cnt_sem.put()             ;
     endtask : incr_failed_tests
 
-    // This task invokes the various monitoring tasks. It first forks in two, splitting
-    // the tasks that should continuously run and the ones that get invoked every clock cycle.
-    // For the tasks every clock cycle all processes that only push something in the fifo's and
-    // Queues get run. When they are finished the processes that pop something get run.
+    /*
+     * This task invokes the various monitoring tasks. First, all processes that only
+     * push something in the FIFOs are invoked. After they are finished, the processes
+     * that pop something from them are invoked.
+     */
     task run();
       forever begin
         // At every cycle, spawn some monitoring processes.
@@ -320,23 +349,23 @@ package tb_axi_dw_pkg;
 
         // Execute all processes that push something into the queues
         PushMon: fork
-          proc_mst_aw: monitor_mst_aw();
-          proc_mst_ar: monitor_mst_ar();
+          proc_mst_aw: mon_slv_port_aw();
+          proc_mst_ar: mon_slv_port_ar();
         join: PushMon
 
         // These pop and push something
-        proc_slv_aw: monitor_slv_aw();
-        proc_slv_w : monitor_slv_w() ;
+        proc_slv_aw: mon_mst_port_aw();
+        proc_slv_w : mon_mst_port_w() ;
 
         // These only pop something from the queues
         PopMon: fork
-          proc_mst_b : monitor_mst_b() ;
-          proc_slv_ar: monitor_slv_ar();
-          proc_mst_r : monitor_mst_r() ;
+          proc_mst_b : mon_slv_port_b() ;
+          proc_slv_ar: mon_mst_port_ar();
+          proc_mst_r : mon_slv_port_r() ;
         join : PopMon
 
         // Check the slave W FIFOs last
-        proc_check_slv_w: check_slv_w();
+        proc_check_slv_w: check_mst_port_w();
 
         cycle_end();
       end
@@ -348,12 +377,11 @@ package tb_axi_dw_pkg;
       $display("Tests Conducted: %d", this.tests_conducted);
       $display("Tests Failed:    %d", this.tests_failed)   ;
       if(tests_failed > 0) begin
-        $error("Simulation encountered unexpected transactions!!!!!!");
+        $error("Simulation encountered unexpected transactions!");
       end
     endtask : print_result
 
   endclass : axi_dw_monitor
-
 
   /*************
    *  UPSIZER  *
@@ -386,16 +414,16 @@ package tb_axi_dw_pkg;
           .AXI_DATA_WIDTH(AxiSlvPortDataWidth),
           .AXI_ID_WIDTH  (AxiIdWidth         ),
           .AXI_USER_WIDTH(AxiUserWidth       )
-        ) axi_master_vif,
+        ) slv_port_vif,
         virtual AXI_BUS_DV #(
           .AXI_ADDR_WIDTH(AxiAddrWidth       ),
           .AXI_DATA_WIDTH(AxiMstPortDataWidth),
           .AXI_ID_WIDTH  (AxiIdWidth         ),
           .AXI_USER_WIDTH(AxiUserWidth       )
-        ) axi_slave_vif
+        ) mst_port_vif
       );
       begin
-        super.new(axi_master_vif, axi_slave_vif);
+        super.new(slv_port_vif, mst_port_vif);
       end
     endfunction
 
@@ -403,43 +431,45 @@ package tb_axi_dw_pkg;
      *  Monitors  *
      **************/
 
-    // This task monitors a slave port of the upsizer. Every time an AW beat is seen, it populates
-    // the id queue of the right master port, populates the expected b response in its own id_queue
-    // and in case when the atomic bit [5] is set it also injects an expected response in the R channel.
-    task automatic monitor_mst_aw ();
+    /*
+     * This task monitors the slave AW channel of the upsizer. Every time an AW beat is seen, it
+     * populates the ID queue of master port, populates the expected B response in its own id_queue,
+     * and if a response in the R channel is expected (axi_pkg::ATOP_R_RESP), populates the R queue.
+     */
+    task automatic mon_slv_port_aw ();
       exp_ax_t exp_aw;
       exp_t    exp_b;
 
-      if (master_axi.aw_valid && master_axi.aw_ready) begin
+      if (slv_port_axi.aw_valid && slv_port_axi.aw_ready) begin
         // Non-modifiable transaction
-        if (!axi_pkg::modifiable(master_axi.aw_cache)) begin
+        if (!axi_pkg::modifiable(slv_port_axi.aw_cache)) begin
           // We expect that the transaction will not be modified
           exp_aw = '{
-            slv_axi_id  : master_axi.aw_id  ,
-            slv_axi_addr: master_axi.aw_addr,
-            slv_axi_len : master_axi.aw_len
+            axi_id  : slv_port_axi.aw_id  ,
+            axi_addr: slv_port_axi.aw_addr,
+            axi_len : slv_port_axi.aw_len
           } ;
         end
         // Modifiable transaction
         else begin
-          case (master_axi.aw_burst)
+          case (slv_port_axi.aw_burst)
             // Passthrough upsize
             axi_pkg::BURST_FIXED: begin
               exp_aw = '{
-                slv_axi_id  : master_axi.aw_id  ,
-                slv_axi_addr: master_axi.aw_addr,
-                slv_axi_len : master_axi.aw_len
+                axi_id  : slv_port_axi.aw_id  ,
+                axi_addr: slv_port_axi.aw_addr,
+                axi_len : slv_port_axi.aw_len
               };
             end
             // INCR upsize
             axi_pkg::BURST_INCR: begin
-              automatic axi_addr_t aligned_start = axi_pkg::aligned_addr(master_axi.aw_addr, AxiMstPortMaxSize)                                                                                                  ;
-              automatic axi_addr_t aligned_end   = axi_pkg::aligned_addr(axi_pkg::aligned_addr(master_axi.aw_addr, master_axi.aw_size) + (unsigned'(master_axi.aw_len) << master_axi.aw_size), AxiMstPortMaxSize);
+              automatic axi_addr_t aligned_start = axi_pkg::aligned_addr(slv_port_axi.aw_addr, AxiMstPortMaxSize)                                                                                                        ;
+              automatic axi_addr_t aligned_end   = axi_pkg::aligned_addr(axi_pkg::aligned_addr(slv_port_axi.aw_addr, slv_port_axi.aw_size) + (unsigned'(slv_port_axi.aw_len) << slv_port_axi.aw_size), AxiMstPortMaxSize);
 
               exp_aw = '{
-                slv_axi_id  : master_axi.aw_id  ,
-                slv_axi_addr: master_axi.aw_addr,
-                slv_axi_len : (aligned_end - aligned_start) >> AxiMstPortMaxSize
+                axi_id  : slv_port_axi.aw_id  ,
+                axi_addr: slv_port_axi.aw_addr,
+                axi_len : (aligned_end - aligned_start) >> AxiMstPortMaxSize
               };
             end
             // WRAP upsize
@@ -448,67 +478,69 @@ package tb_axi_dw_pkg;
               $warning("WRAP bursts are not supported.");
             end
           endcase
-          this.exp_aw_queue.push(master_axi.aw_id, exp_aw);
-          incr_expected_tests(3)                          ;
-          $display("%0tns > Master: AW to Slave: Axi ID: %b",
-            $time, master_axi.aw_id);
+          this.exp_aw_queue.push(slv_port_axi.aw_id, exp_aw);
+          incr_expected_tests(3)                            ;
+          $display("%0tns > Master: AW with ID: %b",
+            $time, slv_port_axi.aw_id);
         end
 
         // Populate the expected B queue
-        exp_b = '{axi_id: master_axi.aw_id, last: 1'b1};
-        this.exp_b_queue.push(master_axi.aw_id, exp_b);
-        incr_expected_tests(1)                        ;
-        $display("        Expect B response.")        ;
+        exp_b = '{axi_id: slv_port_axi.aw_id, last: 1'b1};
+        this.exp_b_queue.push(slv_port_axi.aw_id, exp_b);
+        incr_expected_tests(1)                          ;
+        $display("        Expect B response.")          ;
 
         // Inject expected R beats on this id, if it is an atop
-        if(master_axi.aw_atop[axi_pkg::ATOP_R_RESP]) begin
-          // Push the required R beats into the right fifo (reuse the exp_b variable)
-          $display("        Expect R response, len: %0d.", master_axi.aw_len);
-          for (int unsigned j = 0; j <= master_axi.aw_len; j++) begin
-            exp_b.axi_id = master_axi.aw_id;
-            exp_b.last   = (j == master_axi.aw_len) ? 1'b1 : 1'b0;
-            this.exp_r_queue.push(master_axi.aw_id, exp_b);
-            incr_expected_tests(1)                        ;
+        if(slv_port_axi.aw_atop[axi_pkg::ATOP_R_RESP]) begin
+          // Push the required R beats into their FIFO (reuse the exp_b variable)
+          $display("        Expect R response, len: %0d.", slv_port_axi.aw_len);
+          for (int unsigned j = 0; j <= slv_port_axi.aw_len; j++) begin
+            exp_b.axi_id = slv_port_axi.aw_id;
+            exp_b.last   = (j == slv_port_axi.aw_len) ? 1'b1 : 1'b0;
+            this.exp_r_queue.push(slv_port_axi.aw_id, exp_b);
+            incr_expected_tests(1)                          ;
           end
         end
       end
-    endtask : monitor_mst_aw
+    endtask : mon_slv_port_aw
 
-    // This task monitors the AR channel of a slave port of the upsizer. For each AR it populates
-    // the corresponding ID queue with the number of R beats indicated on the `ar_len` field.
-    // Emphasis on the last flag.
-    task automatic monitor_mst_ar ();
+    /*
+     * This task monitors the slave AR channel of the upsizer. Every time an AR beat is seen, it
+     * populates the corresponding ID queue with the number of R beats indicated on the `ar_len` field.
+     * Emphasis on the last flag.
+     */
+    task automatic mon_slv_port_ar ();
       exp_ax_t exp_slv_ar;
       exp_t    exp_mst_r;
 
-      if (master_axi.ar_valid && master_axi.ar_ready) begin
+      if (slv_port_axi.ar_valid && slv_port_axi.ar_ready) begin
         // Non-modifiable transaction
-        if (!axi_pkg::modifiable(master_axi.ar_cache)) begin
+        if (!axi_pkg::modifiable(slv_port_axi.ar_cache)) begin
           // We expect that the transaction will not be modified
           exp_slv_ar = '{
-            slv_axi_id  : master_axi.ar_id  ,
-            slv_axi_addr: master_axi.ar_addr,
-            slv_axi_len : master_axi.ar_len
+            axi_id  : slv_port_axi.ar_id  ,
+            axi_addr: slv_port_axi.ar_addr,
+            axi_len : slv_port_axi.ar_len
           } ;
         end
         // Modifiable transaction
         else begin
-          case (master_axi.ar_burst)
+          case (slv_port_axi.ar_burst)
             // Passthrough upsize
             axi_pkg::BURST_FIXED: begin
-              exp_slv_ar.slv_axi_id   = master_axi.ar_id  ;
-              exp_slv_ar.slv_axi_addr = master_axi.ar_addr;
-              exp_slv_ar.slv_axi_len  = master_axi.ar_len ;
+              exp_slv_ar.axi_id   = slv_port_axi.ar_id  ;
+              exp_slv_ar.axi_addr = slv_port_axi.ar_addr;
+              exp_slv_ar.axi_len  = slv_port_axi.ar_len ;
             end
             // INCR upsize
             axi_pkg::BURST_INCR: begin
-              automatic axi_addr_t aligned_start = axi_pkg::aligned_addr(master_axi.ar_addr, AxiMstPortMaxSize)                                                                                                  ;
-              automatic axi_addr_t aligned_end   = axi_pkg::aligned_addr(axi_pkg::aligned_addr(master_axi.ar_addr, master_axi.ar_size) + (unsigned'(master_axi.ar_len) << master_axi.ar_size), AxiMstPortMaxSize);
+              automatic axi_addr_t aligned_start = axi_pkg::aligned_addr(slv_port_axi.ar_addr, AxiMstPortMaxSize)                                                                                                        ;
+              automatic axi_addr_t aligned_end   = axi_pkg::aligned_addr(axi_pkg::aligned_addr(slv_port_axi.ar_addr, slv_port_axi.ar_size) + (unsigned'(slv_port_axi.ar_len) << slv_port_axi.ar_size), AxiMstPortMaxSize);
 
               exp_slv_ar = '{
-                slv_axi_id  : master_axi.ar_id  ,
-                slv_axi_addr: master_axi.ar_addr,
-                slv_axi_len : (aligned_end - aligned_start) >> AxiMstPortMaxSize
+                axi_id  : slv_port_axi.ar_id  ,
+                axi_addr: slv_port_axi.ar_addr,
+                axi_len : (aligned_end - aligned_start) >> AxiMstPortMaxSize
               };
             end
             // WRAP upsize
@@ -517,22 +549,22 @@ package tb_axi_dw_pkg;
               $warning("WRAP bursts are not supported.");
             end
           endcase
-          this.exp_ar_queue.push(master_axi.ar_id, exp_slv_ar);
-          incr_expected_tests(1)                              ;
-          $display("%0tns > Master: AR to Slave: Axi ID: %b",
-            $time, master_axi.ar_id);
+          this.exp_ar_queue.push(slv_port_axi.ar_id, exp_slv_ar);
+          incr_expected_tests(1)                                ;
+          $display("%0tns > Master: AR with ID: %b",
+            $time, slv_port_axi.ar_id);
         end
 
         // Push the required R beats into the right fifo
-        $display("        Expect R response, len: %0d.", master_axi.ar_len);
-        for (int unsigned j = 0; j <= master_axi.ar_len; j++) begin
-          exp_mst_r.axi_id = master_axi.ar_id;
-          exp_mst_r.last   = (j == master_axi.ar_len) ? 1'b1 : 1'b0;
-          this.exp_r_queue.push(master_axi.ar_id, exp_mst_r);
-          incr_expected_tests(1)                            ;
+        $display("        Expect R response, len: %0d.", slv_port_axi.ar_len);
+        for (int unsigned j = 0; j <= slv_port_axi.ar_len; j++) begin
+          exp_mst_r.axi_id = slv_port_axi.ar_id;
+          exp_mst_r.last   = (j == slv_port_axi.ar_len) ? 1'b1 : 1'b0;
+          this.exp_r_queue.push(slv_port_axi.ar_id, exp_mst_r);
+          incr_expected_tests(1)                              ;
         end
       end
-    endtask : monitor_mst_ar
+    endtask : mon_slv_port_ar
   endclass : axi_dw_upsizer_monitor
 
   /***************
@@ -556,6 +588,27 @@ package tb_axi_dw_pkg;
       .TimeTest           (TimeTest           )
     );
 
+    /**********************
+     *  Helper functions  *
+     **********************/
+
+    /**
+     * Returns the downsize ratio between the incoming AXI transaction and the outcoming
+     * transaction of axsize AxiMstPortMaxSize.
+     * @return ceil(num_bytes(size)/num_bytes(AxiMstPortMaxSize))
+     */
+    function automatic int unsigned downsize_ratio(axi_pkg::size_t size)                                                 ;
+      return (axi_pkg::num_bytes(size) + axi_pkg::num_bytes(AxiMstPortMaxSize) - 1)/axi_pkg::num_bytes(AxiMstPortMaxSize);
+    endfunction: downsize_ratio
+
+    /*
+     * Returns how many beats of the incoming AXI transaction will be dropped after downsizing
+     * due to an unaligned memory address.
+     */
+    function automatic axi_len_t aligned_adjustment(axi_addr_t addr, axi_pkg::size_t size)                 ;
+      return (addr & size_mask(size) & ~size_mask(AxiMstPortMaxSize))/axi_pkg::num_bytes(AxiMstPortMaxSize);
+    endfunction: aligned_adjustment
+
     /*****************
      *  Constructor  *
      *****************/
@@ -566,16 +619,16 @@ package tb_axi_dw_pkg;
           .AXI_DATA_WIDTH(AxiSlvPortDataWidth),
           .AXI_ID_WIDTH  (AxiIdWidth         ),
           .AXI_USER_WIDTH(AxiUserWidth       )
-        ) axi_master_vif,
+        ) slv_port_vif,
         virtual AXI_BUS_DV #(
           .AXI_ADDR_WIDTH(AxiAddrWidth       ),
           .AXI_DATA_WIDTH(AxiMstPortDataWidth),
           .AXI_ID_WIDTH  (AxiIdWidth         ),
           .AXI_USER_WIDTH(AxiUserWidth       )
-        ) axi_slave_vif
+        ) mst_port_vif
       );
       begin
-        super.new(axi_master_vif, axi_slave_vif);
+        super.new(slv_port_vif, mst_port_vif);
       end
     endfunction
 
@@ -583,44 +636,42 @@ package tb_axi_dw_pkg;
      *  Monitors  *
      **************/
 
-    // This task monitors a slave port of the downsizer. Every time an AW beat is seen, it populates
-    // the id queue at the master port, populates the expected B response in its own id_queue and in
-    // case when the atomic bit [5] is set it also injects an expected response in the R channel.
-    task automatic monitor_mst_aw ();
+    /*
+     * This task monitors the slave AW channel of the downsizer. Every time an AW beat is seen, it
+     * populates the ID queue of master port, populates the expected B response in its own id_queue,
+     * and if a response in the R channel is expected (axi_pkg::ATOP_R_RESP), populates the R queue.
+     */
+    task automatic mon_slv_port_aw ();
       exp_ax_t exp_aw;
       exp_t    exp_b;
 
-      if (master_axi.aw_valid && master_axi.aw_ready) begin
-        case (master_axi.aw_burst)
+      if (slv_port_axi.aw_valid && slv_port_axi.aw_ready) begin
+        case (slv_port_axi.aw_burst)
           axi_pkg::BURST_INCR: begin
-            automatic int unsigned downsize_ratio = ((1'b1 << master_axi.aw_size) + AxiMstPortStrbWidth - 1) / AxiMstPortStrbWidth ;
-
             // Transaction unchanged
-            if (downsize_ratio == 1) begin
+            if (downsize_ratio(slv_port_axi.aw_size) == 1) begin
               exp_aw = '{
-                slv_axi_id  : master_axi.aw_id  ,
-                slv_axi_addr: master_axi.aw_addr,
-                slv_axi_len : master_axi.aw_len
+                axi_id  : slv_port_axi.aw_id  ,
+                axi_addr: slv_port_axi.aw_addr,
+                axi_len : slv_port_axi.aw_len
               };
 
-              this.exp_aw_queue.push(master_axi.aw_id, exp_aw);
-              incr_expected_tests(3)                          ;
+              this.exp_aw_queue.push(slv_port_axi.aw_id, exp_aw);
+              incr_expected_tests(3)                            ;
             end
             // INCR downsize
             else begin
-              automatic axi_addr_t size_mask          = (1'b1 << master_axi.aw_size) - 1                                            ;
-              automatic axi_addr_t aligned_adjustment = (master_axi.aw_addr & size_mask & ~AxiMstPortByteMask) / AxiMstPortStrbWidth;
-              automatic int unsigned num_beats        = (master_axi.aw_len + 1) * downsize_ratio - aligned_adjustment               ;
+              automatic int unsigned num_beats = (slv_port_axi.aw_len + 1) * downsize_ratio(slv_port_axi.aw_size) - aligned_adjustment(slv_port_axi.aw_addr, slv_port_axi.aw_size);
               // One burst
               if (num_beats <= 256) begin
                 exp_aw = '{
-                  slv_axi_id  : master_axi.aw_id  ,
-                  slv_axi_addr: master_axi.aw_addr,
-                  slv_axi_len : num_beats - 1
+                  axi_id  : slv_port_axi.aw_id  ,
+                  axi_addr: slv_port_axi.aw_addr,
+                  axi_len : num_beats - 1
                 };
 
-                this.exp_aw_queue.push(master_axi.aw_id, exp_aw);
-                incr_expected_tests(3)                          ;
+                this.exp_aw_queue.push(slv_port_axi.aw_id, exp_aw);
+                incr_expected_tests(3)                            ;
               end
               // Need to split the incoming burst into several INCR bursts
               else begin
@@ -628,14 +679,14 @@ package tb_axi_dw_pkg;
                 automatic axi_len_t burst_len  ;
 
                 // First burst is a "partial" burst
-                burst_len = 255 - aligned_adjustment;
+                burst_len = 255 - aligned_adjustment(slv_port_axi.aw_addr, slv_port_axi.aw_size);
                 exp_aw    = '{
-                  slv_axi_id  : master_axi.aw_id  ,
-                  slv_axi_addr: master_axi.aw_addr,
-                  slv_axi_len : burst_len
-                }                                               ;
-                this.exp_aw_queue.push(master_axi.aw_id, exp_aw);
-                incr_expected_tests(3)                          ;
+                  axi_id  : slv_port_axi.aw_id  ,
+                  axi_addr: slv_port_axi.aw_addr,
+                  axi_len : burst_len
+                }                                                 ;
+                this.exp_aw_queue.push(slv_port_axi.aw_id, exp_aw);
+                incr_expected_tests(3)                            ;
 
                 // Push the other bursts in a loop
                 num_beats  = num_beats - burst_len - 1                                                                   ;
@@ -643,48 +694,44 @@ package tb_axi_dw_pkg;
                 while (num_beats != 0) begin
                   burst_len = (num_beats - 1) % 256;
                   exp_aw    = '{
-                    slv_axi_id  : master_axi.aw_id,
-                    slv_axi_addr: burst_addr      ,
-                    slv_axi_len : burst_len
-                  }                                               ;
-                  this.exp_aw_queue.push(master_axi.aw_id, exp_aw);
-                  incr_expected_tests(3)                          ;
+                    axi_id  : slv_port_axi.aw_id,
+                    axi_addr: burst_addr        ,
+                    axi_len : burst_len
+                  }                                                 ;
+                  this.exp_aw_queue.push(slv_port_axi.aw_id, exp_aw);
+                  incr_expected_tests(3)                            ;
 
                   num_beats  = num_beats - burst_len - 1                                                                   ;
                   burst_addr = axi_pkg::beat_addr(burst_addr, AxiMstPortMaxSize, burst_len, axi_pkg::BURST_INCR, burst_len);
-                end while (num_beats != 0);
+                end;
               end
             end
           end
           // Passthrough downsize
           axi_pkg::BURST_FIXED: begin
-            automatic int unsigned downsize_ratio = ((1'b1 << master_axi.aw_size) + AxiMstPortStrbWidth - 1) / AxiMstPortStrbWidth;
-
             // Transaction unchanged
-            if (downsize_ratio == 1) begin
+            if (downsize_ratio(slv_port_axi.aw_size) == 1) begin
               exp_aw = '{
-                slv_axi_id  : master_axi.aw_id  ,
-                slv_axi_addr: master_axi.aw_addr,
-                slv_axi_len : master_axi.aw_len
+                axi_id  : slv_port_axi.aw_id  ,
+                axi_addr: slv_port_axi.aw_addr,
+                axi_len : slv_port_axi.aw_len
               };
 
-              this.exp_aw_queue.push(master_axi.aw_id, exp_aw);
-              incr_expected_tests(3)                          ;
+              this.exp_aw_queue.push(slv_port_axi.aw_id, exp_aw);
+              incr_expected_tests(3)                            ;
             end
             // Split into master_axi.aw_len + 1 INCR bursts
             else begin
-              automatic axi_addr_t size_mask          = (1'b1 << master_axi.aw_size) - 1                                            ;
-              automatic axi_addr_t aligned_adjustment = (master_axi.aw_addr & size_mask & ~AxiMstPortByteMask) / AxiMstPortStrbWidth;
+              for (int unsigned j = 0; j <= slv_port_axi.aw_len; j++) begin
+                exp_aw.axi_id   = slv_port_axi.aw_id  ;
+                exp_aw.axi_addr = slv_port_axi.aw_addr;
+                if (downsize_ratio(slv_port_axi.aw_size) >= aligned_adjustment(slv_port_axi.aw_addr, slv_port_axi.aw_size) + 1)
+                  exp_aw.axi_len = downsize_ratio(slv_port_axi.aw_size) - aligned_adjustment(slv_port_axi.aw_addr, slv_port_axi.aw_size) - 1;
+                else
+                  exp_aw.axi_len = 0;
 
-              for (int unsigned j = 0; j <= master_axi.aw_len; j++) begin
-                exp_aw = '{
-                  slv_axi_id  : master_axi.aw_id  ,
-                  slv_axi_addr: master_axi.aw_addr,
-                  slv_axi_len : (downsize_ratio >= aligned_adjustment + 1) ? (downsize_ratio - aligned_adjustment - 1) : 0
-                };
-
-                this.exp_aw_queue.push(master_axi.aw_id, exp_aw);
-                incr_expected_tests(3)                          ;
+                this.exp_aw_queue.push(slv_port_axi.aw_id, exp_aw);
+                incr_expected_tests(3)                            ;
               end
             end
           end
@@ -695,67 +742,65 @@ package tb_axi_dw_pkg;
           end
         endcase
 
-        $display("%0tns > Master: AW to Slave: with ID: %b",
-          $time, master_axi.aw_id);
+        $display("%0tns > Master: AW with ID: %b",
+          $time, slv_port_axi.aw_id);
 
         // Populate the expected B queue
-        exp_b = '{axi_id: master_axi.aw_id, last: 1'b1};
-        this.exp_b_queue.push(master_axi.aw_id, exp_b);
-        incr_expected_tests(1)                        ;
-        $display("        Expect B response.")        ;
+        exp_b = '{axi_id: slv_port_axi.aw_id, last: 1'b1};
+        this.exp_b_queue.push(slv_port_axi.aw_id, exp_b);
+        incr_expected_tests(1)                          ;
+        $display("        Expect B response.")          ;
 
         // Inject expected R beats on this id, if it is an atop
-        if(master_axi.aw_atop[axi_pkg::ATOP_R_RESP]) begin
+        if(slv_port_axi.aw_atop[axi_pkg::ATOP_R_RESP]) begin
           // Push the required R beats into the right fifo (reuse the exp_b variable)
-          $display("        Expect R response, len: %0d.", master_axi.aw_len);
-          for (int unsigned j = 0; j <= master_axi.aw_len; j++) begin
-            exp_b.axi_id = master_axi.aw_id;
-            exp_b.last   = (j == master_axi.aw_len) ? 1'b1 : 1'b0;
-            this.exp_r_queue.push(master_axi.aw_id, exp_b);
-            incr_expected_tests(1)                        ;
+          $display("        Expect R response, len: %0d.", slv_port_axi.aw_len);
+          for (int unsigned j = 0; j <= slv_port_axi.aw_len; j++) begin
+            exp_b.axi_id = slv_port_axi.aw_id;
+            exp_b.last   = (j == slv_port_axi.aw_len) ? 1'b1 : 1'b0;
+            this.exp_r_queue.push(slv_port_axi.aw_id, exp_b);
+            incr_expected_tests(1)                          ;
           end
         end
       end
-    endtask : monitor_mst_aw
+    endtask : mon_slv_port_aw
 
-    // This task monitors the AR channel of a slave port of the downsizer. For each AR it populates
-    // the corresponding ID queue with the number of R beats indicated on the `ar_len` field.
-    // Emphasis on the last flag.
-    task automatic monitor_mst_ar ();
+    /*
+     * This task monitors the slave AR channel of the downsizer. Every time an AR beat is seen, it
+     * populates the corresponding ID queue with the number of R beats indicated on the `ar_len` field.
+     * Emphasis on the last flag.
+     */
+    task automatic mon_slv_port_ar ();
       exp_ax_t exp_slv_ar;
       exp_t    exp_mst_r;
 
-      if (master_axi.ar_valid && master_axi.ar_ready) begin
-        case (master_axi.ar_burst)
+      if (slv_port_axi.ar_valid && slv_port_axi.ar_ready) begin
+        case (slv_port_axi.ar_burst)
           axi_pkg::BURST_INCR: begin
-            automatic int unsigned downsize_ratio = ((1'b1 << master_axi.ar_size) + AxiMstPortStrbWidth - 1) / AxiMstPortStrbWidth ;
-
             // Transaction unchanged
-            if (downsize_ratio == 1) begin
+            if (downsize_ratio(slv_port_axi.ar_size) == 1) begin
               exp_slv_ar = '{
-                slv_axi_id  : master_axi.ar_id  ,
-                slv_axi_addr: master_axi.ar_addr,
-                slv_axi_len : master_axi.ar_len
+                axi_id  : slv_port_axi.ar_id  ,
+                axi_addr: slv_port_axi.ar_addr,
+                axi_len : slv_port_axi.ar_len
               };
 
-              this.exp_ar_queue.push(master_axi.ar_id, exp_slv_ar);
-              incr_expected_tests(1)                              ;
+              this.exp_ar_queue.push(slv_port_axi.ar_id, exp_slv_ar);
+              incr_expected_tests(1)                                ;
             end
             // INCR downsize
             else begin
-              automatic axi_addr_t size_mask          = (1 << master_axi.ar_size) - 1                                               ;
-              automatic axi_addr_t aligned_adjustment = (master_axi.ar_addr & size_mask & ~AxiMstPortByteMask) / AxiMstPortStrbWidth;
-              automatic int unsigned num_beats        = (master_axi.ar_len + 1) * downsize_ratio - aligned_adjustment               ;
+              automatic int unsigned num_beats = (slv_port_axi.ar_len + 1) * downsize_ratio(slv_port_axi.ar_size) - aligned_adjustment(slv_port_axi.ar_addr, slv_port_axi.ar_size);
               // One burst
               if (num_beats <= 256) begin
                 exp_slv_ar = '{
-                  slv_axi_id  : master_axi.ar_id  ,
-                  slv_axi_addr: master_axi.ar_addr,
-                  slv_axi_len : num_beats - 1
+                  axi_id  : slv_port_axi.ar_id  ,
+                  axi_addr: slv_port_axi.ar_addr,
+                  axi_len : num_beats - 1
                 };
 
-                this.exp_ar_queue.push(master_axi.ar_id, exp_slv_ar);
-                incr_expected_tests(1)                              ;
+                this.exp_ar_queue.push(slv_port_axi.ar_id, exp_slv_ar);
+                incr_expected_tests(1)                                ;
               end
               // Need to split the incoming burst into several INCR bursts
               else begin
@@ -763,14 +808,14 @@ package tb_axi_dw_pkg;
                 automatic axi_len_t burst_len  ;
 
                 // First burst is a "partial" burst
-                burst_len  = 255 - aligned_adjustment;
+                burst_len  = 255 - aligned_adjustment(slv_port_axi.ar_addr, slv_port_axi.ar_size);
                 exp_slv_ar = '{
-                  slv_axi_id  : master_axi.ar_id  ,
-                  slv_axi_addr: master_axi.ar_addr,
-                  slv_axi_len : burst_len
-                }                                                   ;
-                this.exp_ar_queue.push(master_axi.ar_id, exp_slv_ar);
-                incr_expected_tests(1)                              ;
+                  axi_id  : slv_port_axi.ar_id  ,
+                  axi_addr: slv_port_axi.ar_addr,
+                  axi_len : burst_len
+                }                                                     ;
+                this.exp_ar_queue.push(slv_port_axi.ar_id, exp_slv_ar);
+                incr_expected_tests(1)                                ;
 
                 // Push the other bursts in a loop
                 num_beats  = num_beats - burst_len - 1                                                                   ;
@@ -778,48 +823,44 @@ package tb_axi_dw_pkg;
                 while (num_beats != 0) begin
                   burst_len  = (num_beats - 1) % 256;
                   exp_slv_ar = '{
-                    slv_axi_id  : master_axi.ar_id,
-                    slv_axi_addr: burst_addr      ,
-                    slv_axi_len : burst_len
-                  }                                                   ;
-                  this.exp_ar_queue.push(master_axi.ar_id, exp_slv_ar);
-                  incr_expected_tests(1)                              ;
+                    axi_id  : slv_port_axi.ar_id,
+                    axi_addr: burst_addr        ,
+                    axi_len : burst_len
+                  }                                                     ;
+                  this.exp_ar_queue.push(slv_port_axi.ar_id, exp_slv_ar);
+                  incr_expected_tests(1)                                ;
 
                   num_beats  = num_beats - burst_len - 1                                                                   ;
                   burst_addr = axi_pkg::beat_addr(burst_addr, AxiMstPortMaxSize, burst_len, axi_pkg::BURST_INCR, burst_len);
-                end while (num_beats != 0);
+                end;
               end
             end
           end
           // Passthrough downsize
           axi_pkg::BURST_FIXED: begin
-            automatic int unsigned downsize_ratio = ((1'b1 << master_axi.ar_size) + AxiMstPortStrbWidth - 1) / AxiMstPortStrbWidth;
-
             // Transaction unchanged
-            if (downsize_ratio == 1) begin
+            if (downsize_ratio(slv_port_axi.ar_size) == 1) begin
               exp_slv_ar = '{
-                slv_axi_id  : master_axi.ar_id  ,
-                slv_axi_addr: master_axi.ar_addr,
-                slv_axi_len : master_axi.ar_len
+                axi_id  : slv_port_axi.ar_id  ,
+                axi_addr: slv_port_axi.ar_addr,
+                axi_len : slv_port_axi.ar_len
               };
 
-              this.exp_ar_queue.push(master_axi.ar_id, exp_slv_ar);
-              incr_expected_tests(1)                              ;
+              this.exp_ar_queue.push(slv_port_axi.ar_id, exp_slv_ar);
+              incr_expected_tests(1)                                ;
             end
             // Split into master_axi.ar_len + 1 INCR bursts
             else begin
-              automatic axi_addr_t size_mask          = (1'b1 << master_axi.ar_size) - 1                                            ;
-              automatic axi_addr_t aligned_adjustment = (master_axi.ar_addr & size_mask & ~AxiMstPortByteMask) / AxiMstPortStrbWidth;
+              for (int unsigned j = 0; j <= slv_port_axi.ar_len; j++) begin
+                exp_slv_ar.axi_id   = slv_port_axi.aw_id  ;
+                exp_slv_ar.axi_addr = slv_port_axi.aw_addr;
+                if (downsize_ratio(slv_port_axi.ar_size) >= aligned_adjustment(slv_port_axi.ar_addr, slv_port_axi.ar_size) + 1)
+                  exp_slv_ar.axi_len = downsize_ratio(slv_port_axi.ar_size) - aligned_adjustment(slv_port_axi.ar_addr, slv_port_axi.ar_size) - 1;
+                else
+                  exp_slv_ar.axi_len = 0;
 
-              for (int unsigned j = 0; j <= master_axi.ar_len; j++) begin
-                exp_slv_ar = '{
-                  slv_axi_id  : master_axi.ar_id  ,
-                  slv_axi_addr: master_axi.ar_addr,
-                  slv_axi_len : (downsize_ratio >= aligned_adjustment + 1) ? (downsize_ratio - aligned_adjustment - 1) : 0
-                };
-
-                this.exp_ar_queue.push(master_axi.ar_id, exp_slv_ar);
-                incr_expected_tests(1)                              ;
+                this.exp_ar_queue.push(slv_port_axi.ar_id, exp_slv_ar);
+                incr_expected_tests(1)                                ;
               end
             end
           end
@@ -830,19 +871,19 @@ package tb_axi_dw_pkg;
           end
         endcase
 
-        $display("%0tns > Master: AR to Slave: with ID: %b",
-          $time, master_axi.ar_id);
+        $display("%0tns > Master: AR with ID: %b",
+          $time, slv_port_axi.ar_id);
 
         // Push the required R beats into the right fifo
-        $display("        Expect R response, len: %0d.", master_axi.ar_len);
-        for (int unsigned j = 0; j <= master_axi.ar_len; j++) begin
-          exp_mst_r.axi_id = master_axi.ar_id;
-          exp_mst_r.last   = (j == master_axi.ar_len) ? 1'b1 : 1'b0;
-          this.exp_r_queue.push(master_axi.ar_id, exp_mst_r);
-          incr_expected_tests(1)                            ;
+        $display("        Expect R response, len: %0d.", slv_port_axi.ar_len);
+        for (int unsigned j = 0; j <= slv_port_axi.ar_len; j++) begin
+          exp_mst_r.axi_id = slv_port_axi.ar_id;
+          exp_mst_r.last   = (j == slv_port_axi.ar_len) ? 1'b1 : 1'b0;
+          this.exp_r_queue.push(slv_port_axi.ar_id, exp_mst_r);
+          incr_expected_tests(1)                              ;
         end
       end
-    endtask : monitor_mst_ar
+    endtask : mon_slv_port_ar
   endclass : axi_dw_downsizer_monitor
 
 endpackage: tb_axi_dw_pkg

--- a/test/tb_axi_dw_pkg.sv
+++ b/test/tb_axi_dw_pkg.sv
@@ -247,7 +247,7 @@ package tb_axi_dw_pkg       ;
             axi_cache: slv_port_axi.ar_cache
           });
 
-      if (slv_port_axi.aw_valid && slv_port_axi.aw_ready)
+      if (slv_port_axi.aw_valid && slv_port_axi.aw_ready) begin
         act_slv_port_aw_queue.push_back('{
             axi_id   : slv_port_axi.aw_id   ,
             axi_burst: slv_port_axi.aw_burst,
@@ -256,6 +256,20 @@ package tb_axi_dw_pkg       ;
             axi_len  : slv_port_axi.aw_len  ,
             axi_cache: slv_port_axi.aw_cache
           });
+
+        // This request generates an R response.
+        // Push this to the AR queue.
+        if (slv_port_axi.aw_atop[axi_pkg::ATOP_R_RESP])
+          act_slv_port_ar_queue.push(slv_port_axi.aw_id,
+            '{
+              axi_id   : slv_port_axi.aw_id   ,
+              axi_burst: slv_port_axi.aw_burst,
+              axi_size : slv_port_axi.aw_size ,
+              axi_addr : slv_port_axi.aw_addr ,
+              axi_len  : slv_port_axi.aw_len  ,
+              axi_cache: slv_port_axi.aw_cache
+            });
+      end
 
       if (slv_port_axi.w_valid && slv_port_axi.w_ready)
         this.act_slv_port_w_queue.push_back('{
@@ -284,7 +298,7 @@ package tb_axi_dw_pkg       ;
             axi_cache: mst_port_axi.ar_cache
           });
 
-      if (mst_port_axi.aw_valid && mst_port_axi.aw_ready)
+      if (mst_port_axi.aw_valid && mst_port_axi.aw_ready) begin
         act_mst_port_aw_queue.push_back('{
             axi_id   : mst_port_axi.aw_id   ,
             axi_burst: mst_port_axi.aw_burst,
@@ -293,6 +307,20 @@ package tb_axi_dw_pkg       ;
             axi_len  : mst_port_axi.aw_len  ,
             axi_cache: mst_port_axi.aw_cache
           });
+
+        // This request generates an R response.
+        // Push this to the AR queue.
+        if (mst_port_axi.aw_atop[axi_pkg::ATOP_R_RESP])
+          act_mst_port_ar_queue.push(mst_port_axi.aw_id,
+            '{
+              axi_id   : mst_port_axi.aw_id   ,
+              axi_burst: mst_port_axi.aw_burst,
+              axi_size : mst_port_axi.aw_size ,
+              axi_addr : mst_port_axi.aw_addr ,
+              axi_len  : mst_port_axi.aw_len  ,
+              axi_cache: mst_port_axi.aw_cache
+            });
+      end
 
       if (mst_port_axi.w_valid && mst_port_axi.w_ready)
         this.act_mst_port_w_queue.push_back('{

--- a/test/tb_axi_dw_upsizer.do
+++ b/test/tb_axi_dw_upsizer.do
@@ -1,4 +1,4 @@
 add wave -position insertpoint  \
-  sim:/tb_axi_dw_upsizer/i_dw_converter/gen_dw_upsize/i_axi_dw_upsizer/AxiMstDataWidth \
-  sim:/tb_axi_dw_upsizer/i_dw_converter/gen_dw_upsize/i_axi_dw_upsizer/AxiSlvDataWidth \
-  sim:/tb_axi_dw_upsizer/i_dw_converter/gen_dw_upsize/i_axi_dw_upsizer/*
+  sim:/tb_axi_dw_upsizer/i_dw_converter/i_axi_dw_converter/gen_dw_upsize/i_axi_dw_upsizer/AxiSlvPortDataWidth \
+  sim:/tb_axi_dw_upsizer/i_dw_converter/i_axi_dw_converter/gen_dw_upsize/i_axi_dw_upsizer/AxiMstPortDataWidth \
+  sim:/tb_axi_dw_upsizer/i_dw_converter/i_axi_dw_converter/gen_dw_upsize/i_axi_dw_upsizer/*

--- a/test/tb_axi_dw_upsizer.sv
+++ b/test/tb_axi_dw_upsizer.sv
@@ -83,7 +83,8 @@ module tb_axi_dw_upsizer #(
     .TA            (ApplTime           ),
     .TT            (TestTime           ),
     .MAX_READ_TXNS (8                  ),
-    .MAX_WRITE_TXNS(8                  )
+    .MAX_WRITE_TXNS(8                  ),
+    .AXI_ATOPS     (1'b1               )
   ) master_drv = new (master_dv);
 
   // Slave port

--- a/test/tb_axi_dw_upsizer.sv
+++ b/test/tb_axi_dw_upsizer.sv
@@ -15,159 +15,146 @@
 // Copyright (C) 2020 ETH Zurich, University of Bologna
 // All rights reserved.
 
-`include "axi/assign.svh"
-`include "axi/typedef.svh"
+module tb_axi_dw_upsizer #(
+    // AXI Parameters
+    parameter int unsigned AxiAddrWidth        = 64  ,
+    parameter int unsigned AxiIdWidth          = 4   ,
+    parameter int unsigned AxiSlvPortDataWidth = 32  ,
+    parameter int unsigned AxiMstPortDataWidth = 64  ,
+    parameter int unsigned AxiUserWidth        = 8   ,
+    // TB Parameters
+    parameter time CyclTime                    = 10ns,
+    parameter time ApplTime                    = 2ns ,
+    parameter time TestTime                    = 8ns
+  );
 
-module tb_axi_dw_upsizer;
+  /****************
+   *  PARAMETERS  *
+   ****************/
 
-  timeunit      1ns;
-  timeprecision 10ps;
+  `include "axi/assign.svh"
+  `include "axi/typedef.svh"
 
-  parameter AW   = 64;
-  parameter IW   = 4;
-  parameter DW   = 32;
-  parameter UW   = 8;
-  parameter MULT = 8;
+  localparam AxiSlvPortStrbWidth = AxiSlvPortDataWidth / 8;
+  localparam AxiMstPortStrbWidth = AxiMstPortDataWidth / 8;
 
-  // Clock
+  localparam AxiSlvPortMaxSize = $clog2(AxiSlvPortStrbWidth);
+  localparam AxiMstPortMaxSize = $clog2(AxiMstPortStrbWidth);
 
-  localparam tCK = 1ns;
+  /*********************
+   *  CLOCK GENERATOR  *
+   *********************/
 
-  logic clk  = 0;
-  logic rst  = 1;
-  logic done = 0;
+  logic clk;
+  logic rst_n;
 
-  initial begin
-    #tCK;
-    rst <= 0;
-    #tCK;
-    rst <= 1;
-    #tCK;
-    while (!done) begin
-      clk <= 1;
-      #(tCK/2);
-      clk <= 0;
-      #(tCK/2);
-    end
-  end
+  clk_rst_gen #(
+    .CLK_PERIOD    (CyclTime),
+    .RST_CLK_CYCLES(5       )
+  ) i_clk_rst_gen (
+    .clk_o (clk  ),
+    .rst_no(rst_n)
+  );
 
-  // AXI Buses
+  /*********
+   *  AXI  *
+   *********/
+
+  // Master port
 
   AXI_BUS_DV #(
-    .AXI_ADDR_WIDTH(AW),
-    .AXI_DATA_WIDTH(DW),
-    .AXI_ID_WIDTH  (IW),
-    .AXI_USER_WIDTH(UW)
-  ) axi_master_dv (
+    .AXI_ADDR_WIDTH(AxiAddrWidth       ),
+    .AXI_DATA_WIDTH(AxiSlvPortDataWidth),
+    .AXI_ID_WIDTH  (AxiIdWidth         ),
+    .AXI_USER_WIDTH(AxiUserWidth       )
+  ) master_dv (
     .clk_i(clk)
   );
+
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH(AxiAddrWidth       ),
+    .AXI_DATA_WIDTH(AxiSlvPortDataWidth),
+    .AXI_ID_WIDTH  (AxiIdWidth         ),
+    .AXI_USER_WIDTH(AxiUserWidth       )
+  ) master ();
+
+  `AXI_ASSIGN(master, master_dv)
 
   axi_test::rand_axi_master #(
-    .AW            (AW   ),
-    .DW            (DW   ),
-    .IW            (IW   ),
-    .UW            (UW   ),
-    .MAX_READ_TXNS (8    ),
-    .MAX_WRITE_TXNS(8    ),
-    .TA            (200ps),
-    .TT            (700ps)
-  ) axi_master_drv = new (axi_master_dv);
+    .AW(AxiAddrWidth       ),
+    .DW(AxiSlvPortDataWidth),
+    .IW(AxiIdWidth         ),
+    .UW(AxiUserWidth       ),
+    .TA(ApplTime           ),
+    .TT(TestTime           )
+  ) master_drv = new (master_dv);
+
+  // Slave port
 
   AXI_BUS_DV #(
-    .AXI_ADDR_WIDTH(AW     ),
-    .AXI_DATA_WIDTH(MULT*DW),
-    .AXI_ID_WIDTH  (IW     ),
-    .AXI_USER_WIDTH(UW     )
-  ) axi_slave_dv (
+    .AXI_ADDR_WIDTH(AxiAddrWidth       ),
+    .AXI_DATA_WIDTH(AxiMstPortDataWidth),
+    .AXI_ID_WIDTH  (AxiIdWidth         ),
+    .AXI_USER_WIDTH(AxiUserWidth       )
+  ) slave_dv (
     .clk_i(clk)
   );
 
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH(AxiAddrWidth       ),
+    .AXI_DATA_WIDTH(AxiMstPortDataWidth),
+    .AXI_ID_WIDTH  (AxiIdWidth         ),
+    .AXI_USER_WIDTH(AxiUserWidth       )
+  ) slave ();
+
   axi_test::rand_axi_slave #(
-    .AW(AW     ),
-    .DW(MULT*DW),
-    .IW(IW     ),
-    .UW(UW     ),
-    .TA(200ps  ),
-    .TT(700ps  )
-  ) axi_slave_drv = new (axi_slave_dv);
+    .AW(AxiAddrWidth       ),
+    .DW(AxiMstPortDataWidth),
+    .IW(AxiIdWidth         ),
+    .UW(AxiUserWidth       ),
+    .TA(ApplTime           ),
+    .TT(TestTime           )
+  ) slave_drv = new (slave_dv);
 
-  // AXI channel types
-  typedef logic [AW-1:0] addr_t           ;
-  typedef logic [IW-1:0] id_t             ;
-  typedef logic [UW-1:0] user_t           ;
-  typedef logic [DW-1:0] mst_data_t       ;
-  typedef logic [DW/8-1:0] mst_strb_t     ;
-  typedef logic [MULT*DW-1:0] slv_data_t  ;
-  typedef logic [MULT*DW/8-1:0] slv_strb_t;
+  `AXI_ASSIGN(slave_dv, slave)
 
-  `AXI_TYPEDEF_AW_CHAN_T(aw_chan_t, addr_t, id_t, user_t)            ;
-  `AXI_TYPEDEF_W_CHAN_T(mst_w_chan_t, mst_data_t, mst_strb_t, user_t);
-  `AXI_TYPEDEF_W_CHAN_T(slv_w_chan_t, slv_data_t, slv_strb_t, user_t);
-  `AXI_TYPEDEF_B_CHAN_T(b_chan_t, id_t, user_t)                      ;
-  `AXI_TYPEDEF_AR_CHAN_T(ar_chan_t, addr_t, id_t, user_t)            ;
-  `AXI_TYPEDEF_R_CHAN_T(mst_r_chan_t, mst_data_t, id_t, user_t)      ;
-  `AXI_TYPEDEF_R_CHAN_T(slv_r_chan_t, slv_data_t, id_t, user_t)      ;
+  /*********
+   *  DUT  *
+   *********/
 
-  `AXI_TYPEDEF_REQ_T(mst_req_t, aw_chan_t, mst_w_chan_t, ar_chan_t);
-  `AXI_TYPEDEF_RESP_T(mst_resp_t, b_chan_t, mst_r_chan_t)          ;
-  `AXI_TYPEDEF_REQ_T(slv_req_t, aw_chan_t, slv_w_chan_t, ar_chan_t);
-  `AXI_TYPEDEF_RESP_T(slv_resp_t, b_chan_t, slv_r_chan_t)          ;
-
-  mst_req_t  axi_mst_req;
-  mst_resp_t axi_mst_resp;
-  `AXI_ASSIGN_TO_REQ(axi_mst_req, axi_master_dv)    ;
-  `AXI_ASSIGN_FROM_RESP(axi_master_dv, axi_mst_resp);
-
-  slv_req_t  axi_slv_req;
-  slv_resp_t axi_slv_resp;
-  `AXI_ASSIGN_FROM_REQ(axi_slave_dv, axi_slv_req);
-  `AXI_ASSIGN_TO_RESP(axi_slv_resp, axi_slave_dv);
-
-  // DUT
-
-  axi_dw_converter #(
-    .AxiMaxReads        (4           ),
-    .AxiSlvPortDataWidth(DW          ),
-    .AxiMstPortDataWidth(MULT * DW   ),
-    .AxiAddrWidth       (AW          ),
-    .AxiIdWidth         (IW          ),
-    .aw_chan_t          (aw_chan_t   ),
-    .mst_w_chan_t       (slv_w_chan_t),
-    .slv_w_chan_t       (mst_w_chan_t),
-    .b_chan_t           (b_chan_t    ),
-    .ar_chan_t          (ar_chan_t   ),
-    .mst_r_chan_t       (slv_r_chan_t),
-    .slv_r_chan_t       (mst_r_chan_t),
-    .axi_mst_req_t      (slv_req_t   ),
-    .axi_mst_resp_t     (slv_resp_t  ),
-    .axi_slv_req_t      (mst_req_t   ),
-    .axi_slv_resp_t     (mst_resp_t  )
+  axi_dw_converter_intf #(
+    .AXI_MAX_READS          (4                  ),
+    .AXI_ADDR_WIDTH         (AxiAddrWidth       ),
+    .AXI_ID_WIDTH           (AxiIdWidth         ),
+    .AXI_SLV_PORT_DATA_WIDTH(AxiSlvPortDataWidth),
+    .AXI_MST_PORT_DATA_WIDTH(AxiMstPortDataWidth),
+    .AXI_USER_WIDTH         (AxiUserWidth       )
   ) i_dw_converter (
-    .clk_i     (clk         ),
-    .rst_ni    (rst         ),
-    .slv_req_i (axi_mst_req ),
-    .slv_resp_o(axi_mst_resp),
-    .mst_req_o (axi_slv_req ),
-    .mst_resp_i(axi_slv_resp)
+    .clk_i (clk   ),
+    .rst_ni(rst_n ),
+    .slv   (master),
+    .mst   (slave )
   );
 
-  initial begin
-    axi_master_drv.reset()                                                             ;
-    axi_master_drv.add_memory_region({AW{1'b0}}, {AW{1'b1}}, axi_pkg::WTHRU_NOALLOCATE);
-    axi_master_drv.run(50, 50)                                                         ;
-    done = 1;
-  end
+  /********
+   *  TB  *
+   ********/
 
   initial begin
-    axi_slave_drv.reset();
-    axi_slave_drv.run()  ;
-  end
+    // Configuration
+    slave_drv.reset()                                                                                  ;
+    master_drv.reset()                                                                                 ;
+    master_drv.add_memory_region({AxiAddrWidth{1'b0}}, {AxiAddrWidth{1'b1}}, axi_pkg::WTHRU_NOALLOCATE);
 
-  // Terminate simulation after all transactions have completed.
-  initial begin
-    wait (done);
-    #(10*tCK)  ;
-    $finish(0) ;
+    fork
+      // Act as a sink
+      slave_drv.run()       ;
+      master_drv.run(50, 50);
+    join_any
+
+    // Done
+    #(10*CyclTime);
+    $finish(0)    ;
   end
 
 // vsim -voptargs=+acc work.tb_axi_dw_upsizer

--- a/test/tb_axi_dw_upsizer.sv
+++ b/test/tb_axi_dw_upsizer.sv
@@ -76,12 +76,14 @@ module tb_axi_dw_upsizer #(
   `AXI_ASSIGN(master, master_dv)
 
   axi_test::rand_axi_master #(
-    .AW(AxiAddrWidth       ),
-    .DW(AxiSlvPortDataWidth),
-    .IW(AxiIdWidth         ),
-    .UW(AxiUserWidth       ),
-    .TA(ApplTime           ),
-    .TT(TestTime           )
+    .AW            (AxiAddrWidth       ),
+    .DW            (AxiSlvPortDataWidth),
+    .IW            (AxiIdWidth         ),
+    .UW            (AxiUserWidth       ),
+    .TA            (ApplTime           ),
+    .TT            (TestTime           ),
+    .MAX_READ_TXNS (8                  ),
+    .MAX_WRITE_TXNS(8                  )
   ) master_drv = new (master_dv);
 
   // Slave port

--- a/test/tb_axi_dw_upsizer.sv
+++ b/test/tb_axi_dw_upsizer.sv
@@ -24,8 +24,8 @@ module tb_axi_dw_upsizer #(
     parameter int unsigned AxiUserWidth        = 8   ,
     // TB Parameters
     parameter time CyclTime                    = 10ns,
-    parameter time ApplTime                    = 2ns ,
-    parameter time TestTime                    = 8ns
+    parameter time ApplTime                    = 0ns ,
+    parameter time TestTime                    = 5ns
   );
 
   /****************
@@ -76,13 +76,12 @@ module tb_axi_dw_upsizer #(
   `AXI_ASSIGN(master, master_dv)
 
   axi_test::rand_axi_master #(
-    .AW       (AxiAddrWidth       ),
-    .DW       (AxiSlvPortDataWidth),
-    .IW       (AxiIdWidth         ),
-    .UW       (AxiUserWidth       ),
-    .TA       (ApplTime           ),
-    .TT       (TestTime           ),
-    .AXI_ATOPS(1'b1               )
+    .AW(AxiAddrWidth       ),
+    .DW(AxiSlvPortDataWidth),
+    .IW(AxiIdWidth         ),
+    .UW(AxiUserWidth       ),
+    .TA(ApplTime           ),
+    .TT(TestTime           )
   ) master_drv = new (master_dv);
 
   // Slave port

--- a/test/tb_axi_dw_upsizer.sv
+++ b/test/tb_axi_dw_upsizer.sv
@@ -24,8 +24,8 @@ module tb_axi_dw_upsizer #(
     parameter int unsigned AxiUserWidth        = 8   ,
     // TB Parameters
     parameter time CyclTime                    = 10ns,
-    parameter time ApplTime                    = 0ns ,
-    parameter time TestTime                    = 5ns
+    parameter time ApplTime                    = 2ns ,
+    parameter time TestTime                    = 8ns
   );
 
   /****************
@@ -143,6 +143,9 @@ module tb_axi_dw_upsizer #(
     master_drv.reset()                                                                                 ;
     master_drv.add_memory_region({AxiAddrWidth{1'b0}}, {AxiAddrWidth{1'b1}}, axi_pkg::WTHRU_NOALLOCATE);
 
+    // Wait for the reset before sending requests
+    @(posedge rst_n);
+
     fork
       // Act as a sink
       slave_drv.run()         ;
@@ -150,7 +153,7 @@ module tb_axi_dw_upsizer #(
     join_any
 
     // Done
-    #(10*CyclTime);
+    repeat (10) @(posedge clk);
     eos = 1'b1;
   end
 

--- a/test/tb_axi_dw_upsizer.sv
+++ b/test/tb_axi_dw_upsizer.sv
@@ -35,18 +35,13 @@ module tb_axi_dw_upsizer #(
   `include "axi/assign.svh"
   `include "axi/typedef.svh"
 
-  localparam AxiSlvPortStrbWidth = AxiSlvPortDataWidth / 8;
-  localparam AxiMstPortStrbWidth = AxiMstPortDataWidth / 8;
-
-  localparam AxiSlvPortMaxSize = $clog2(AxiSlvPortStrbWidth);
-  localparam AxiMstPortMaxSize = $clog2(AxiMstPortStrbWidth);
-
   /*********************
    *  CLOCK GENERATOR  *
    *********************/
 
   logic clk;
   logic rst_n;
+  logic eos;
 
   clk_rst_gen #(
     .CLK_PERIOD    (CyclTime),
@@ -81,12 +76,13 @@ module tb_axi_dw_upsizer #(
   `AXI_ASSIGN(master, master_dv)
 
   axi_test::rand_axi_master #(
-    .AW(AxiAddrWidth       ),
-    .DW(AxiSlvPortDataWidth),
-    .IW(AxiIdWidth         ),
-    .UW(AxiUserWidth       ),
-    .TA(ApplTime           ),
-    .TT(TestTime           )
+    .AW       (AxiAddrWidth       ),
+    .DW       (AxiSlvPortDataWidth),
+    .IW       (AxiIdWidth         ),
+    .UW       (AxiUserWidth       ),
+    .TA       (ApplTime           ),
+    .TT       (TestTime           ),
+    .AXI_ATOPS(1'b1               )
   ) master_drv = new (master_dv);
 
   // Slave port
@@ -136,11 +132,13 @@ module tb_axi_dw_upsizer #(
     .mst   (slave )
   );
 
-  /********
-   *  TB  *
-   ********/
+  /*************
+   *  DRIVERS  *
+   *************/
 
   initial begin
+    eos = 1'b0;
+
     // Configuration
     slave_drv.reset()                                                                                  ;
     master_drv.reset()                                                                                 ;
@@ -148,13 +146,39 @@ module tb_axi_dw_upsizer #(
 
     fork
       // Act as a sink
-      slave_drv.run()       ;
-      master_drv.run(50, 50);
+      slave_drv.run()         ;
+      master_drv.run(200, 200);
     join_any
 
     // Done
     #(10*CyclTime);
-    $finish(0)    ;
+    eos = 1'b1;
+  end
+
+  /*************
+   *  MONITOR  *
+   *************/
+
+  initial begin : proc_monitor
+    static tb_axi_dw_pkg::axi_dw_upsizer_monitor #(
+      .AxiAddrWidth       (AxiAddrWidth       ),
+      .AxiMstPortDataWidth(AxiMstPortDataWidth),
+      .AxiSlvPortDataWidth(AxiSlvPortDataWidth),
+      .AxiIdWidth         (AxiIdWidth         ),
+      .AxiUserWidth       (AxiUserWidth       ),
+      .TimeTest           (TestTime           )
+    ) monitor = new (master_dv, slave_dv);
+    fork
+      monitor.run();
+      forever begin
+        #TestTime;
+        if(eos) begin
+          monitor.print_result();
+          $stop()               ;
+        end
+        @(posedge clk);
+      end
+    join
   end
 
 // vsim -voptargs=+acc work.tb_axi_dw_upsizer


### PR DESCRIPTION
This adds two monitors in the `tb_axi_dw_pkg.sv` file, against which the DW converters are compared on the TB.