### PR TITLE
added req_t and resp_t on initialization axi_lite_demux

### DIFF
--- a/src/axi_lite_demux.sv
+++ b/src/axi_lite_demux.sv
@@ -436,6 +436,8 @@ module axi_lite_demux_intf #(
     .b_chan_t    (  b_chan_t   ),
     .ar_chan_t   ( ar_chan_t   ),
     .r_chan_t    (  r_chan_t   ),
+    .req_t       (     req_t   ),
+    .resp_t      (    resp_t   ),
     .NoMstPorts  ( NoMstPorts  ),
     .MaxTrans    ( MaxTrans    ),
     .FallThrough ( FallThrough ),


### PR DESCRIPTION
Hello!
In this pull request I added missing type parameters in initialization axi_lite_demux.