### PR TITLE
AXI4+ATOP on chip memory slave

### DIFF
--- a/.ci/Memora.yml
+++ b/.ci/Memora.yml
@@ -237,6 +237,20 @@ artifacts:
     outputs:
       - build/axi_to_axi_lite-%.tested
 
+  axi_to_mem_banked-%:
+    inputs:
+      - Bender.yml
+      - include
+      - src/axi_pkg.sv
+      - src/axi_intf.sv
+      - src/axi_test.sv
+      - src/axi_demux.sv
+      - src/axi_to_mem.sv
+      - src/axi_to_mem_banked.sv
+      - test/tb_axi_to_mem_banked.sv
+    outputs:
+      - build/axi_to_mem_banked-%.tested
+
   axi_xbar-%:
     inputs:
       - Bender.yml

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 !.ci/
 /.git/
 /build
-/Bender.lock
 /Bender.local

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -145,6 +145,11 @@ axi_to_axi_lite:
   variables:
     TEST_MODULE: axi_to_axi_lite
 
+axi_to_mem_banked:
+  <<: *run_vsim
+  variables:
+    TEST_MODULE: axi_to_mem_banked
+
 axi_xbar:
   <<: *run_vsim
   variables:

--- a/Bender.lock
+++ b/Bender.lock
@@ -1,8 +1,8 @@
 ---
 packages:
   common_cells:
-    revision: eb425a5c76f3c2ae0c1b20f97e6c0d8fd28a1eef
-    version: 1.19.0
+    revision: a06e4beb08b8c0a5ef2c85d9afcfe0d96be76f30
+    version: 1.20.0
     source:
       Git: "https://github.com/pulp-platform/common_cells.git"
     dependencies:
@@ -15,8 +15,8 @@ packages:
       Git: "https://github.com/pulp-platform/common_verification.git"
     dependencies: []
   tech_cells_generic:
-    revision: 627fd6c50733159354df82ea488aeac9b2e076ea
-    version: 0.2.1
+    revision: f5919f811921e5fc30c9ddaedd001b8a9b1dab1f
+    version: 0.2.2
     source:
       Git: "https://github.com/pulp-platform/tech_cells_generic.git"
     dependencies:

--- a/Bender.lock
+++ b/Bender.lock
@@ -1,0 +1,23 @@
+---
+packages:
+  common_cells:
+    revision: eb425a5c76f3c2ae0c1b20f97e6c0d8fd28a1eef
+    version: 1.19.0
+    source:
+      Git: "https://github.com/pulp-platform/common_cells.git"
+    dependencies:
+      - common_verification
+      - tech_cells_generic
+  common_verification:
+    revision: 0143451d43d2026310c802d9c108b6ed2954fcef
+    version: 0.1.2
+    source:
+      Git: "https://github.com/pulp-platform/common_verification.git"
+    dependencies: []
+  tech_cells_generic:
+    revision: 627fd6c50733159354df82ea488aeac9b2e076ea
+    version: 0.2.1
+    source:
+      Git: "https://github.com/pulp-platform/tech_cells_generic.git"
+    dependencies:
+      - common_verification

--- a/Bender.yml
+++ b/Bender.yml
@@ -8,8 +8,9 @@ package:
     - "Wolfgang Roenninger <wroennin@ethz.ch>"
 
 dependencies:
-  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.20.0 }
-  common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.1.1 }
+  common_cells:        { git: "https://github.com/pulp-platform/common_cells.git",        version: 1.20.0 }
+  common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.1.1  }
+  tech_cells_generic:  { git: "https://github.com/pulp-platform/tech_cells_generic.git",  rev:     master }
 
 export_include_dirs:
   - include
@@ -50,6 +51,7 @@ sources:
   - src/axi_dw_converter.sv
   - src/axi_multicut.sv
   - src/axi_to_axi_lite.sv
+  - src/axi_to_mem_banked.sv
   # Level 4
   - src/axi_lite_xbar.sv
   - src/axi_xbar.sv
@@ -85,4 +87,6 @@ sources:
       - test/tb_axi_serializer.sv
       - test/tb_axi_sim_mem.sv
       - test/tb_axi_to_axi_lite.sv
+      - test/tb_axi_to_mem_banked.sv
+      - test/tb_axi_xbar_pkg.sv
       - test/tb_axi_xbar.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,7 +10,7 @@ package:
 dependencies:
   common_cells:        { git: "https://github.com/pulp-platform/common_cells.git",        version: 1.20.0 }
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.1.1  }
-  tech_cells_generic:  { git: "https://github.com/pulp-platform/tech_cells_generic.git",  version: 0.2.1  }
+  tech_cells_generic:  { git: "https://github.com/pulp-platform/tech_cells_generic.git",  version: 0.2.2  }
 
 export_include_dirs:
   - include

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,7 +10,7 @@ package:
 dependencies:
   common_cells:        { git: "https://github.com/pulp-platform/common_cells.git",        version: 1.20.0 }
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.1.1  }
-  tech_cells_generic:  { git: "https://github.com/pulp-platform/tech_cells_generic.git",  rev:     master }
+  tech_cells_generic:  { git: "https://github.com/pulp-platform/tech_cells_generic.git",  version: 0.2.1  }
 
 export_include_dirs:
   - include

--- a/Bender.yml
+++ b/Bender.yml
@@ -44,6 +44,7 @@ sources:
   - src/axi_modify_address.sv
   - src/axi_mux.sv
   - src/axi_serializer.sv
+  - src/axi_to_mem.sv
   # Level 3
   - src/axi_err_slv.sv
   - src/axi_dw_converter.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
                downstream.
 - `axi_xbar`: Add parameter `PipelineStages` to `axi_pkg::xbar_cfg_t`. This adds `axi_multicuts`
               in the crossed connections in the xbar between the demuxes and muxes.
+- `axi_pkg`: Add documentation to `xbar_cfg_t`.
 
 ### Fixed
 - `axi_demux`: Break combinatorial simulation loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `axi_xbar`: Add parameter to disable support for atomic operations (`ATOPs`).
 - `axi_to_mem`: AXI4+ATOP slave to control on chip memory.
+- `axi_to_mem_banked`:  AXI4+ATOP slave to control on chip memory, with banking support, higher
+                        throughput than `axi_to_mem`.
+- `Bender`: Add dependency `tech_cells_generic` `v0.2.1` for generic SRAM macro for simulation.
 
 ### Changed
 - `AXI_BUS`, `AXI_BUS_ASYNC`, `AXI_BUS_DV`, `AXI_LITE`, and `AXI_LITE_DV`: Change type of every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `axi_xbar`: Add parameter to disable support for atomic operations (`ATOPs`).
+- `axi_to_mem`: AXI4+ATOP slave to control on chip memory.
 
 ### Changed
 - `AXI_BUS`, `AXI_BUS_ASYNC`, `AXI_BUS_DV`, `AXI_LITE`, and `AXI_LITE_DV`: Change type of every
@@ -49,9 +50,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_demux`: Replace FIFO between AW and W channel by a register plus a counter.  This prevents
   AWs from being issued to one master port while Ws from another burst are ongoing to another
   master port.  This is required to prevents deadlocks due to circular waits downstream.
-- `axi_xbar`: Add parameter `PipelineStages` to `axi_pkg::xbar_cfg_t`.  This adds `axi_multicuts`
-  in the crossed connections in the xbar between the demuxes and muxes.
-- `axi_pkg`: Add documentation to `xbar_cfg_t`.
+- `axi_xbar`:
+  - Add parameter `PipelineStages`.  This adds `axi_multicuts` in the crossed connections in the
+    xbar between the demuxes and muxes.
+  - `axi_pkg`: Add documentation to `xbar_cfg_t`.
 
 ### Fixed
 - `axi_demux`: Break combinatorial simulation loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_xbar`: Add parameter `PipelineStages` to `axi_pkg::xbar_cfg_t`.  This adds `axi_multicuts`
   in the crossed connections in the xbar between the demuxes and muxes.
 - `axi_pkg`: Add documentation to `xbar_cfg_t`.
+- `axi_demux`: Remove FIFO between AW and W channel, is now a register plus counter.
+               Prevents AWs to be emmitted downstream to a different master port as long as Ws
+               are still in flight to another. This prevents deadlock, if there is stalling
+               downstream.
+- `axi_xbar`: Add parameter `PipelineStages` to `axi_pkg::xbar_cfg_t`. This adds `axi_multicuts`
+              in the crossed connections in the xbar between the demuxes and muxes.
 
 ### Fixed
 - `axi_demux`: Break combinatorial simulation loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_to_mem`: AXI4+ATOP slave to control on chip memory.
 - `axi_to_mem_banked`:  AXI4+ATOP slave to control on chip memory, with banking support, higher
                         throughput than `axi_to_mem`.
-- `Bender`: Add dependency `tech_cells_generic` `v0.2.1` for generic SRAM macro for simulation.
+- `Bender`: Add dependency `tech_cells_generic` `v0.2.2` for generic SRAM macro for simulation.
 
 ### Changed
 - `AXI_BUS`, `AXI_BUS_ASYNC`, `AXI_BUS_DV`, `AXI_LITE`, and `AXI_LITE_DV`: Change type of every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
                downstream.
 - `axi_xbar`: Add parameter `PipelineStages` to `axi_pkg::xbar_cfg_t`. This adds `axi_multicuts`
               in the crossed connections in the xbar between the demuxes and muxes.
+- `axi_pkg`: Add documentation to `xbar_cfg_t`.
 
 ### Fixed
 - `axi_demux`: Break combinatorial simulation loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_test::rand_axi_lite_slave` and `axi_test::rand_axi_lite_master`: Change type of address and
   data width parameters (`AW` and `DW`) from `int` to `int unsigned`.  Same rationale as for
   `AXI_BUS` (et al.) above.
+- `axi_demux`: Remove FIFO between AW and W channel, is now a register plus counter.
+               Prevents AWs to be emmitted downstream to a different master port as long as Ws
+               are still in flight to another. This prevents deadlock, if there is stalling
+               downstream.
+
 
 ### Fixed
 - `axi_demux`: Break combinatorial simulation loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
                Prevents AWs to be emmitted downstream to a different master port as long as Ws
                are still in flight to another. This prevents deadlock, if there is stalling
                downstream.
-
+- `axi_xbar`: Add parameter `PipelineStages` to `axi_pkg::xbar_cfg_t`. This adds `axi_multicuts`
+              in the crossed connections in the xbar between the demuxes and muxes.
 
 ### Fixed
 - `axi_demux`: Break combinatorial simulation loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,12 +46,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_test::rand_axi_lite_slave` and `axi_test::rand_axi_lite_master`: Change type of address and
   data width parameters (`AW` and `DW`) from `int` to `int unsigned`.  Same rationale as for
   `AXI_BUS` (et al.) above.
-- `axi_demux`: Remove FIFO between AW and W channel, is now a register plus counter.
-               Prevents AWs to be emmitted downstream to a different master port as long as Ws
-               are still in flight to another. This prevents deadlock, if there is stalling
-               downstream.
-- `axi_xbar`: Add parameter `PipelineStages` to `axi_pkg::xbar_cfg_t`. This adds `axi_multicuts`
-              in the crossed connections in the xbar between the demuxes and muxes.
+- `axi_demux`: Replace FIFO between AW and W channel by a register plus a counter.  This prevents
+  AWs from being issued to one master port while Ws from another burst are ongoing to another
+  master port.  This is required to prevents deadlocks due to circular waits downstream.
+- `axi_xbar`: Add parameter `PipelineStages` to `axi_pkg::xbar_cfg_t`.  This adds `axi_multicuts`
+  in the crossed connections in the xbar between the demuxes and muxes.
 - `axi_pkg`: Add documentation to `xbar_cfg_t`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,13 +52,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_xbar`: Add parameter `PipelineStages` to `axi_pkg::xbar_cfg_t`.  This adds `axi_multicuts`
   in the crossed connections in the xbar between the demuxes and muxes.
 - `axi_pkg`: Add documentation to `xbar_cfg_t`.
-- `axi_demux`: Remove FIFO between AW and W channel, is now a register plus counter.
-               Prevents AWs to be emmitted downstream to a different master port as long as Ws
-               are still in flight to another. This prevents deadlock, if there is stalling
-               downstream.
-- `axi_xbar`: Add parameter `PipelineStages` to `axi_pkg::xbar_cfg_t`. This adds `axi_multicuts`
-              in the crossed connections in the xbar between the demuxes and muxes.
-- `axi_pkg`: Add documentation to `xbar_cfg_t`.
 
 ### Fixed
 - `axi_demux`: Break combinatorial simulation loop.

--- a/axi.core
+++ b/axi.core
@@ -36,11 +36,13 @@ filesets:
       - src/axi_modify_address.sv
       - src/axi_mux.sv
       - src/axi_serializer.sv
+      - src/axi_to_mem.sv
       # Level 3
       - src/axi_err_slv.sv
       - src/axi_dw_converter.sv
       - src/axi_multicut.sv
       - src/axi_to_axi_lite.sv
+      - src/axi_to_mem_banked.sv
       # Level 4
       - src/axi_lite_xbar.sv
       - src/axi_xbar.sv

--- a/scripts/compile_vsim.sh
+++ b/scripts/compile_vsim.sh
@@ -17,7 +17,7 @@ set -e
 
 [ ! -z "$VSIM" ] || VSIM=vsim
 
-bender script vsim -t test \
+bender script vsim -t test -t rtl \
     --vlog-arg="-svinputport=compat" \
     --vlog-arg="-override_timescale 1ns/1ps" \
     --vlog-arg="-suppress 2583" \

--- a/scripts/run_vsim.sh
+++ b/scripts/run_vsim.sh
@@ -95,8 +95,8 @@ exec_test() {
             ;;
         axi_xbar)
             for GEN_ATOP in 0 1; do
-                for NUM_MST in 1 2 4 6; do
-                    for NUM_SLV in 2 7 9; do
+                for NUM_MST in 1 6; do
+                    for NUM_SLV in 2 9; do
                         for MST_ID_USE in 3 5; do
                             MST_ID=5
                             for DATA_WIDTH in 64 256; do

--- a/scripts/run_vsim.sh
+++ b/scripts/run_vsim.sh
@@ -93,6 +93,29 @@ exec_test() {
                 done
             done
             ;;
+        axi_xbar)
+            for GEN_ATOP in 0 1; do
+                for NUM_MST in 1 2 4 6; do
+                    for NUM_SLV in 2 7 9; do
+                        for MST_ID_USE in 3 5; do
+                            MST_ID=5
+                            for DATA_WIDTH in 64 256; do
+                                for PIPE in 0 1; do
+                                    call_vsim tb_axi_xbar -t 1ns -voptargs="+acc" \
+                                        -gTbNumMasters=$NUM_MST       \
+                                        -gTbNumSlaves=$NUM_SLV        \
+                                        -gTbAxiIdWidthMasters=$MST_ID \
+                                        -gTbAxiIdUsed=$MST_ID_USE     \
+                                        -gTbAxiDataWidth=$DATA_WIDTH  \
+                                        -gTbPipeline=$PIPE            \
+                                        -gTbEnAtop=$GEN_ATOP
+                                done
+                            done
+                        done
+                    done
+                done
+            done
+            ;;
         *)
             call_vsim tb_$1 -t 1ns -coverage -voptargs="+acc +cover=bcesfx"
             ;;

--- a/scripts/run_vsim.sh
+++ b/scripts/run_vsim.sh
@@ -116,6 +116,27 @@ exec_test() {
                 done
             done
             ;;
+        axi_to_mem_banked)
+            for MEM_LAT in 1 2; do
+                for BANK_FACTOR in 1 2; do
+                    for NUM_BANKS in 1 2 4 ; do
+                        for AXI_DATA_WIDTH in 64 256 ; do
+                            for NUM_WORDS in 512 2048; do
+                                ACT_BANKS=$((2*$BANK_FACTOR*$NUM_BANKS))
+                                MEM_DATA_WIDTH=$(($AXI_DATA_WIDTH/$NUM_BANKS))
+                                call_vsim tb_axi_to_mem_banked \
+                                    -voptargs="+acc +cover=bcesfx" \
+                                    -gTbAxiDataWidth=$AXI_DATA_WIDTH \
+                                    -gTbNumWords=$NUM_WORDS \
+                                    -gTbNumBanks=$ACT_BANKS \
+                                    -gTbMemDataWidth=$MEM_DATA_WIDTH \
+                                    -gTbMemLatency=$MEM_LAT
+                            done
+                        done
+                    done
+                done
+            done
+            ;;
         *)
             call_vsim tb_$1 -t 1ns -coverage -voptargs="+acc +cover=bcesfx"
             ;;

--- a/src/axi_demux.sv
+++ b/src/axi_demux.sv
@@ -195,10 +195,10 @@ module axi_demux #(
         // Process can start handling a transaction if its `i_aw_id_counter` and `w_fifo` have
         // space in them. Further check if we could inject something on the AR channel.
         if (!aw_id_cnt_full && (w_open != {IdCounterWidth{1'b1}}) && !ar_id_cnt_full) begin
-          /// There is a valid AW vector make the id lookup and go further, if it passes.
-          /// Also stall if previous transmitted AWs still have active W's in flight.
-          /// This prevents deadlocking of the W channel. The counters are there for the
-          /// Handling of the B responses.
+          // There is a valid AW vector make the id lookup and go further, if it passes.
+          // Also stall if previous transmitted AWs still have active W's in flight.
+          // This prevents deadlocking of the W channel. The counters are there for the
+          // Handling of the B responses.
           if (slv_aw_valid &&
                 ((w_open == '0) || (w_select == slv_aw_chan_select.aw_select)) &&
                 (!aw_select_occupied || (slv_aw_chan_select.aw_select == lookup_aw_select))) begin

--- a/src/axi_demux.sv
+++ b/src/axi_demux.sv
@@ -33,7 +33,7 @@ module axi_demux #(
   parameter bit          SpillAr        = 1'b1,
   parameter bit          SpillR         = 1'b0,
   // Dependent parameters, DO NOT OVERRIDE!
-  parameter int unsigned SelectWidth    = (NoMstPorts > 32'd1) ? $clog2(NoMstPorts) : 32'd1,
+  parameter int unsigned SelectWidth    = cf_math_pkg::idx_width(NoMstPorts),
   parameter type         select_t       = logic [SelectWidth-1:0]
 ) (
   input  logic                     clk_i,
@@ -49,7 +49,8 @@ module axi_demux #(
   input  resp_t   [NoMstPorts-1:0] mst_resps_i
 );
 
-  localparam int unsigned IdCounterWidth = MaxTrans > 1 ? $clog2(MaxTrans) : 1;
+  localparam int unsigned IdCounterWidth = cf_math_pkg::idx_width(MaxTrans);
+  typedef logic [IdCounterWidth-1:0] id_cnt_t;
 
   //--------------------------------------
   // Typedefs for the FIFOs / Queues
@@ -87,14 +88,14 @@ module axi_demux #(
     // AW ID counter
     select_t                  lookup_aw_select;
     logic                     aw_select_occupied, aw_id_cnt_full;
-    logic                     aw_push;
     // Upon an ATOP load, inject IDs from the AW into the AR channel
     logic                     atop_inject;
 
-    // W FIFO: stores the decision to which master W beats should go
-    logic                     w_fifo_pop;
-    logic                     w_fifo_full,        w_fifo_empty;
-    select_t                  w_select;
+    // W select counter: stores the decision to which master W beats should go
+    select_t                  w_select,           w_select_q;
+    logic                     w_select_valid;
+    id_cnt_t                  w_open;
+    logic                     w_cnt_up,           w_cnt_down;
 
     // Register which locks the AW valid signal
     logic                     lock_aw_valid_d,    lock_aw_valid_q, load_aw_lock;
@@ -177,9 +178,9 @@ module axi_demux #(
       lock_aw_valid_d = lock_aw_valid_q;
       load_aw_lock    = 1'b0;
       // AW ID counter and W FIFO
-      aw_push      = 1'b0;
+      w_cnt_up        = 1'b0;
       // ATOP injection into ar counter
-      atop_inject  = 1'b0;
+      atop_inject     = 1'b0;
       // we had an arbitration decision, the valid is locked, wait for the transaction
       if (lock_aw_valid_q) begin
         aw_valid = 1'b1;
@@ -193,14 +194,18 @@ module axi_demux #(
       end else begin
         // Process can start handling a transaction if its `i_aw_id_counter` and `w_fifo` have
         // space in them. Further check if we could inject something on the AR channel.
-        if (!aw_id_cnt_full && !w_fifo_full && !ar_id_cnt_full) begin
-          // there is a valid AW vector make the id lookup and go further, if it passes
-          if (slv_aw_valid && (!aw_select_occupied ||
-             (slv_aw_chan_select.aw_select == lookup_aw_select))) begin
+        if (!aw_id_cnt_full && (w_open != {IdCounterWidth{1'b1}}) && !ar_id_cnt_full) begin
+          /// There is a valid AW vector make the id lookup and go further, if it passes.
+          /// Also stall if previous transmitted AWs still have active W's in flight.
+          /// This prevents deadlocking of the W channel. The counters are there for the
+          /// Handling of the B responses.
+          if (slv_aw_valid &&
+                ((w_open == '0) || (w_select == slv_aw_chan_select.aw_select)) &&
+                (!aw_select_occupied || (slv_aw_chan_select.aw_select == lookup_aw_select))) begin
             // connect the handshake
             aw_valid     = 1'b1;
             // push arbitration to the W FIFO regardless, do not wait for the AW transaction
-            aw_push      = 1'b1;
+            w_cnt_up     = 1'b1;
             // on AW transaction
             if (aw_ready) begin
               slv_aw_ready = 1'b1;
@@ -234,30 +239,33 @@ module axi_demux #(
       .inject_i                     ( 1'b0                                          ),
       .push_axi_id_i                ( slv_aw_chan_select.aw_chan.id[0+:AxiLookBits] ),
       .push_mst_select_i            ( slv_aw_chan_select.aw_select                  ),
-      .push_i                       ( aw_push                                       ),
+      .push_i                       ( w_cnt_up                                      ),
       .pop_axi_id_i                 ( slv_b_chan.id[0+:AxiLookBits]                 ),
       .pop_i                        ( slv_b_valid & slv_b_ready                     )
     );
-    // pop from ID counter on outward transaction
 
-    // FIFO to save W selection
-    fifo_v3 #(
-      .FALL_THROUGH ( FallThrough ),
-      .DEPTH        ( MaxTrans    ),
-      .dtype        ( select_t    )
-    ) i_w_fifo (
-      .clk_i     ( clk_i                        ),
-      .rst_ni    ( rst_ni                       ),
-      .flush_i   ( 1'b0                         ),
-      .testmode_i( test_i                       ),
-      .full_o    ( w_fifo_full                  ),
-      .empty_o   ( w_fifo_empty                 ),
-      .usage_o   (                              ),
-      .data_i    ( slv_aw_chan_select.aw_select ),
-      .push_i    ( aw_push                      ), // controlled from proc_aw_chan
-      .data_o    ( w_select                     ), // where the w beat should go
-      .pop_i     ( w_fifo_pop                   )  // controlled from proc_w_chan
+    // This counter steers the demultiplexer of the W channel.
+    // `w_select` determines, which handshaking is connected.
+    // AWs are only forwarded, if the counter is empty, or `w_select_q` is the same as
+    // `slv_aw_chan_select.aw_select`.
+    counter #(
+      .WIDTH           ( IdCounterWidth ),
+      .STICKY_OVERFLOW ( 1'b0           )
+    ) i_counter_open_w (
+      .clk_i,
+      .rst_ni,
+      .clear_i    ( 1'b0                  ),
+      .en_i       ( w_cnt_up ^ w_cnt_down ),
+      .load_i     ( 1'b0                  ),
+      .down_i     ( w_cnt_down            ),
+      .d_i        ( '0                    ),
+      .q_o        ( w_open                ),
+      .overflow_o ( /*not used*/          )
     );
+
+    `FFLARN(w_select_q, slv_aw_chan_select.aw_select, w_cnt_up, select_t'(0), clk_i, rst_ni)
+    assign w_select       = (|w_open) ? w_select_q : slv_aw_chan_select.aw_select;
+    assign w_select_valid = w_cnt_up | (|w_open);
 
     //--------------------------------------
     //  W Channel
@@ -442,8 +450,8 @@ module axi_demux #(
       .idx_o  (               )
     );
 
-   assign ar_ready = ar_valid & mst_resps_i[slv_ar_chan_select.ar_select].ar_ready;
-   assign aw_ready = aw_valid & mst_resps_i[slv_aw_chan_select.aw_select].aw_ready;
+    assign ar_ready = ar_valid & mst_resps_i[slv_ar_chan_select.ar_select].ar_ready;
+    assign aw_ready = aw_valid & mst_resps_i[slv_aw_chan_select.aw_select].aw_ready;
 
     // process that defines the individual demuxes and assignments for the arbitration
     // as mst_reqs_o has to be drivem from the same always comb block!
@@ -451,7 +459,7 @@ module axi_demux #(
       // default assignments
       mst_reqs_o  = '0;
       slv_w_ready = 1'b0;
-      w_fifo_pop  = 1'b0;
+      w_cnt_down  = 1'b0;
 
       for (int unsigned i = 0; i < NoMstPorts; i++) begin
         // AW channel
@@ -464,10 +472,10 @@ module axi_demux #(
         //  W channel
         mst_reqs_o[i].w       = slv_w_chan;
         mst_reqs_o[i].w_valid = 1'b0;
-        if (!w_fifo_empty && (w_select == i)) begin
+        if (w_select_valid && (w_select == select_t'(i))) begin
           mst_reqs_o[i].w_valid = slv_w_valid;
           slv_w_ready           = mst_resps_i[i].w_ready;
-          w_fifo_pop            = slv_w_valid & mst_resps_i[i].w_ready & slv_w_chan.last;
+          w_cnt_down            = slv_w_valid & mst_resps_i[i].w_ready & slv_w_chan.last;
         end
 
         //  B channel
@@ -529,6 +537,9 @@ module axi_demux #(
     internal_aw_select: assert property( @(posedge clk_i)
         (aw_valid |-> slv_aw_chan_select.aw_select < NoMstPorts))
       else $fatal(1, "slv_aw_chan_select.aw_select illegal while aw_valid.");
+    w_underflow: assert property( @(posedge clk_i)
+        ((w_open == '0) && (w_cnt_up ^ w_cnt_down) |-> !w_cnt_down)) else
+        $fatal(1, "W counter underflowed!");
 `endif
 `endif
 // pragma translate_on

--- a/src/axi_pkg.sv
+++ b/src/axi_pkg.sv
@@ -389,17 +389,42 @@ package axi_pkg;
 
   /// Configuration for `axi_xbar`.
   typedef struct packed {
+    /// Number of slave ports of the crossbar.
+    /// This many master modules are connected to it.
     int unsigned   NoSlvPorts;
+    /// Number of master ports of the crossbar.
+    /// This many slave modules are connected to it.
     int unsigned   NoMstPorts;
+    /// Maximum number of open transactions each master connected to the crossbar can have in
+    /// flight at the same time.
     int unsigned   MaxMstTrans;
+    /// Maximum number of open transactions each slave connected to the crossbar can have in
+    /// flight at the same time.
     int unsigned   MaxSlvTrans;
+    /// Determine if the internal FIFOs of the crossbar are instantiated in fallthrough mode.
+    /// 0: No fallthrough
+    /// 1: Fallthrough
     bit            FallThrough;
+    /// The Latency mode of the xbar. This determines if the channels on the ports have
+    /// a spill register instantiated.
+    /// Example configurations are provided with the enum `xbar_latency_e`.
     xbar_latency_e LatencyMode;
+    /// This is the number of `axi_multicut` stages instantiated in the line cross of the channels.
+    /// Having multiple stages can potentially add a large number of FFs!
     int unsigned   PipelineStages;
+    /// AXI ID width of the salve ports. The ID width of the master ports is determined
+    /// Automatically. See `axi_mux` for details.
     int unsigned   AxiIdWidthSlvPorts;
+    /// The used ID portion to determine if a different salve is used for the same ID.
+    /// See `axi_demux` for details.
     int unsigned   AxiIdUsedSlvPorts;
+    /// AXI4+ATOP address field width.
     int unsigned   AxiAddrWidth;
+    /// AXI4+ATOP data field width.
     int unsigned   AxiDataWidth;
+    /// The number of address rules defined for routing of the transactions.
+    /// Each master port can have multiple rules, should have however at least one.
+    /// If a transaction can not be routed the xbar will answer with an `axi_pkg::RESP_DECERR`.
     int unsigned   NoAddrRules;
   } xbar_cfg_t;
 

--- a/src/axi_pkg.sv
+++ b/src/axi_pkg.sv
@@ -395,6 +395,7 @@ package axi_pkg;
     int unsigned   MaxSlvTrans;
     bit            FallThrough;
     xbar_latency_e LatencyMode;
+    int unsigned   PipelineStages;
     int unsigned   AxiIdWidthSlvPorts;
     int unsigned   AxiIdUsedSlvPorts;
     int unsigned   AxiAddrWidth;

--- a/src/axi_to_mem.sv
+++ b/src/axi_to_mem.sv
@@ -1,0 +1,697 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Authors:
+// - Andreas Kurth <akurth@iis.ee.ethz.ch>
+// - Wolfgang Roenninger <wroennin@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+/// AXI4+ATOP slave module which translates AXI bursts into a memory stream.
+/// If both read and write channels of the AXI4+ATOP are active, both will have an
+/// utilization of 50%.
+module axi_to_mem #(
+  /// AXI4+ATOP request type. See `include/axi/typedef.svh`.
+  parameter type         axi_req_t  = logic,
+  /// AXI4+ATOP response type. See `include/axi/typedef.svh`.
+  parameter type         axi_resp_t = logic,
+  /// Address width, has to be less or equal than the width off the AXI address field.
+  /// Determines the width of `mem_addr_o`. Has to be wide enough to emit the memory region
+  /// which should be accessible.
+  parameter int unsigned AddrWidth  = 0,
+  /// AXI4+ATOP data width.
+  parameter int unsigned DataWidth  = 0,
+  /// AXI4+ATOP ID width.
+  parameter int unsigned IdWidth    = 0,
+  /// Number of banks at output, must evenly divide `DataWidth`.
+  parameter int unsigned NumBanks   = 0,
+  /// Depth of memory response buffer. This should be equal to the memory response latency.
+  parameter int unsigned BufDepth   = 1,
+  /// Dependent parameter, do not override. Memory address type.
+  localparam type addr_t     = logic [AddrWidth-1:0],
+  /// Dependent parameter, do not override. Memory data type.
+  localparam type mem_data_t = logic [DataWidth/NumBanks-1:0],
+  /// Dependent parameter, do not override. Memory write strobe type.
+  localparam type mem_strb_t = logic [DataWidth/NumBanks/8-1:0]
+) (
+  /// Clock input.
+  input  logic                           clk_i,
+  /// Asynchronous reset, active low.
+  input  logic                           rst_ni,
+  /// The unit is busy handling an AXI4+ATOP request.
+  output logic                           busy_o,
+  /// AXI4+ATOP slave port, request input.
+  input  axi_req_t                       axi_req_i,
+  /// AXI4+ATOP slave port, response output.
+  output axi_resp_t                      axi_resp_o,
+  /// Memory stream master, request is valid for this bank.
+  output logic           [NumBanks-1:0]  mem_req_o,
+  /// Memory stream master, request can be granted by this bank.
+  input  logic           [NumBanks-1:0]  mem_gnt_i,
+  /// Memory stream master, byte address of the request.
+  output addr_t          [NumBanks-1:0]  mem_addr_o,
+  /// Memory stream master, write data for this bank. Valid when `mem_req_o`.
+  output mem_data_t      [NumBanks-1:0]  mem_wdata_o,
+  /// Memory stream master, byte-wise strobe (byte enable).
+  output mem_strb_t      [NumBanks-1:0]  mem_strb_o,
+  /// Memory stream master, `axi_pkg::atop_t` signal associated with this request.
+  output axi_pkg::atop_t [NumBanks-1:0]  mem_atop_o,
+  /// Memory stream master, write enable. Then asserted store of `mem_w_data` is requested.
+  output logic           [NumBanks-1:0]  mem_we_o,
+  /// Memory stream master, response is valid. This module expects always a response valid for a
+  /// request regardless if the request was a write or a read.
+  input  logic           [NumBanks-1:0]  mem_rvalid_i,
+  /// Memory stream master, read response data.
+  input  mem_data_t      [NumBanks-1:0]  mem_rdata_i
+);
+
+  typedef logic [DataWidth-1:0]   axi_data_t;
+  typedef logic [DataWidth/8-1:0] axi_strb_t;
+  typedef logic [IdWidth-1:0]     axi_id_t;
+
+  typedef struct packed {
+    addr_t          addr;
+    axi_pkg::atop_t atop;
+    axi_strb_t      strb;
+    axi_data_t      wdata;
+    logic           we;
+  } mem_req_t;
+
+  typedef struct packed {
+    addr_t          addr;
+    axi_pkg::atop_t atop;
+    axi_id_t        id;
+    logic           last;
+    axi_pkg::qos_t  qos;
+    axi_pkg::size_t size;
+    logic           write;
+  } meta_t;
+
+  axi_data_t      mem_rdata,
+                  m2s_resp;
+  axi_pkg::len_t  r_cnt_d,        r_cnt_q,
+                  w_cnt_d,        w_cnt_q;
+  logic           arb_valid,      arb_ready,
+                  rd_valid,       rd_ready,
+                  wr_valid,       wr_ready,
+                  sel_b,          sel_buf_b,
+                  sel_r,          sel_buf_r,
+                  sel_valid,      sel_ready,
+                  sel_buf_valid,  sel_buf_ready,
+                  sel_lock_d,     sel_lock_q,
+                  meta_valid,     meta_ready,
+                  meta_buf_valid, meta_buf_ready,
+                  meta_sel_d,     meta_sel_q,
+                  m2s_req_valid,  m2s_req_ready,
+                  m2s_resp_valid, m2s_resp_ready,
+                  mem_req_valid,  mem_req_ready,
+                  mem_rvalid;
+  mem_req_t       m2s_req,
+                  mem_req;
+  meta_t          rd_meta,
+                  rd_meta_d,      rd_meta_q,
+                  wr_meta,
+                  wr_meta_d,      wr_meta_q,
+                  meta,           meta_buf;
+
+  assign busy_o = axi_req_i.aw_valid | axi_req_i.ar_valid | axi_req_i.w_valid |
+                    axi_resp_o.b_valid | axi_resp_o.r_valid |
+                    (r_cnt_q > 0) | (w_cnt_q > 0);
+
+  // Handle reads.
+  always_comb begin
+    // Default assignments
+    axi_resp_o.ar_ready = 1'b0;
+    rd_meta_d           = rd_meta_q;
+    rd_meta             = 'x;
+    rd_valid            = 1'b0;
+    r_cnt_d             = r_cnt_q;
+    // Handle R burst in progress.
+    if (r_cnt_q > '0) begin
+      rd_meta_d.last = (r_cnt_q == 8'd1);
+      rd_meta        = rd_meta_d;
+      rd_meta.addr   = rd_meta_q.addr + axi_pkg::num_bytes(rd_meta_q.size);
+      rd_valid       = 1'b1;
+      if (rd_ready) begin
+        r_cnt_d--;
+        rd_meta_d.addr = rd_meta.addr;
+      end
+    // Handle new AR if there is one.
+    end else if (axi_req_i.ar_valid) begin
+      rd_meta_d = '{
+        addr:  addr_t'(axi_pkg::aligned_addr(axi_req_i.ar.addr, axi_req_i.ar.size)),
+        atop:  '0,
+        id:    axi_req_i.ar.id,
+        last:  (axi_req_i.ar.len == '0),
+        qos:   axi_req_i.ar.qos,
+        size:  axi_req_i.ar.size,
+        write: 1'b0
+      };
+      rd_meta      = rd_meta_d;
+      rd_meta.addr = addr_t'(axi_req_i.ar.addr);
+      rd_valid     = 1'b1;
+      if (rd_ready) begin
+        r_cnt_d             = axi_req_i.ar.len;
+        axi_resp_o.ar_ready = 1'b1;
+      end
+    end
+  end
+
+  // Handle writes.
+  always_comb begin
+    // Default assignments
+    axi_resp_o.aw_ready = 1'b0;
+    axi_resp_o.w_ready  = 1'b0;
+    wr_meta_d           = wr_meta_q;
+    wr_meta             = 'x;
+    wr_valid            = 1'b0;
+    w_cnt_d             = w_cnt_q;
+    // Handle W bursts in progress.
+    if (w_cnt_q > '0) begin
+      wr_meta_d.last = (w_cnt_q == 8'd1);
+      wr_meta        = wr_meta_d;
+      wr_meta.addr   = wr_meta_q.addr + axi_pkg::num_bytes(wr_meta_q.size);
+      if (axi_req_i.w_valid) begin
+        wr_valid = 1'b1;
+        if (wr_ready) begin
+          axi_resp_o.w_ready = 1'b1;
+          w_cnt_d--;
+          wr_meta_d.addr = wr_meta.addr;
+        end
+      end
+    // Handle new AW if there is one.
+    end else if (axi_req_i.aw_valid && axi_req_i.w_valid) begin
+      wr_meta_d = '{
+        addr:   addr_t'(axi_pkg::aligned_addr(axi_req_i.aw.addr, axi_req_i.aw.size)),
+        atop:   axi_req_i.aw.atop,
+        id:     axi_req_i.aw.id,
+        last:   (axi_req_i.aw.len == '0),
+        qos:    axi_req_i.aw.qos,
+        size:   axi_req_i.aw.size,
+        write:  1'b1
+      };
+      wr_meta = wr_meta_d;
+      wr_meta.addr = addr_t'(axi_req_i.aw.addr);
+      wr_valid = 1'b1;
+      if (wr_ready) begin
+        w_cnt_d = axi_req_i.aw.len;
+        axi_resp_o.aw_ready = 1'b1;
+        axi_resp_o.w_ready = 1'b1;
+      end
+    end
+  end
+
+  // Arbitrate between reads and writes.
+  stream_mux #(
+    .DATA_T (meta_t),
+    .N_INP  (2)
+  ) i_ax_mux (
+    .inp_data_i   ({wr_meta, rd_meta}),
+    .inp_valid_i  ({wr_valid, rd_valid}),
+    .inp_ready_o  ({wr_ready, rd_ready}),
+    .inp_sel_i    (meta_sel_d),
+    .oup_data_o   (meta),
+    .oup_valid_o  (arb_valid),
+    .oup_ready_i  (arb_ready)
+  );
+  always_comb begin
+    meta_sel_d = meta_sel_q;
+    sel_lock_d = sel_lock_q;
+    if (sel_lock_q) begin
+      meta_sel_d = meta_sel_q;
+      if (arb_valid && arb_ready) begin
+        sel_lock_d = 1'b0;
+      end
+    end else begin
+      if (wr_valid ^ rd_valid) begin
+        // If either write or read is valid but not both, select the valid one.
+        meta_sel_d = wr_valid;
+      end else if (wr_valid && rd_valid) begin
+        // If both write and read are valid, decide according to QoS then burst properties.
+        // Prioritize higher QoS.
+        if (wr_meta.qos > rd_meta.qos) begin
+          meta_sel_d = 1'b1;
+        end else if (rd_meta.qos > wr_meta.qos) begin
+          meta_sel_d = 1'b0;
+        // Decide requests with identical QoS.
+        end else if (wr_meta.qos == rd_meta.qos) begin
+          // 1. Prioritize individual writes over read bursts.
+          // Rationale: Read bursts can be interleaved on AXI but write bursts cannot.
+          if (wr_meta.last && !rd_meta.last) begin
+            meta_sel_d = 1'b1;
+          // 2. Prioritize ongoing burst.
+          // Rationale: Stalled bursts create back-pressure or require costly buffers.
+          end else if (w_cnt_q > '0) begin
+            meta_sel_d = 1'b1;
+          end else if (r_cnt_q > '0) begin
+            meta_sel_d = 1'b0;
+          // 3. Otherwise arbitrate round robin to prevent starvation.
+          end else begin
+            meta_sel_d = ~meta_sel_q;
+          end
+        end
+      end
+      // Lock arbitration if valid but not yet ready.
+      if (arb_valid && !arb_ready) begin
+        sel_lock_d = 1'b1;
+      end
+    end
+  end
+
+  // Fork arbitrated stream to meta data, memory requests, and R/B channel selection.
+  stream_fork #(
+    .N_OUP ( 32'd3 )
+  ) i_fork (
+    .clk_i,
+    .rst_ni,
+    .valid_i ( arb_valid                            ),
+    .ready_o ( arb_ready                            ),
+    .valid_o ({sel_valid, meta_valid, m2s_req_valid}),
+    .ready_i ({sel_ready, meta_ready, m2s_req_ready})
+  );
+
+  assign sel_b = meta.write & meta.last;
+  assign sel_r = ~meta.write | meta.atop[5];
+
+  stream_fifo #(
+    .FALL_THROUGH ( 1'b1             ),
+    .DEPTH        ( 32'd1 + BufDepth ),
+    .T            ( logic[1:0]       )
+  ) i_sel_buf (
+    .clk_i,
+    .rst_ni,
+    .flush_i    ( 1'b0                    ),
+    .testmode_i ( 1'b0                    ),
+    .data_i     ({sel_b,        sel_r    }),
+    .valid_i    ( sel_valid               ),
+    .ready_o    ( sel_ready               ),
+    .data_o     ({sel_buf_b,    sel_buf_r}),
+    .valid_o    ( sel_buf_valid           ),
+    .ready_i    ( sel_buf_ready           ),
+    .usage_o    ( /* unused */            )
+  );
+
+  stream_fifo #(
+    .FALL_THROUGH ( 1'b1             ),
+    .DEPTH        ( 32'd1 + BufDepth ),
+    .T            ( meta_t           )
+  ) i_meta_buf (
+    .clk_i,
+    .rst_ni,
+    .flush_i    ( 1'b0           ),
+    .testmode_i ( 1'b0           ),
+    .data_i     ( meta           ),
+    .valid_i    ( meta_valid     ),
+    .ready_o    ( meta_ready     ),
+    .data_o     ( meta_buf       ),
+    .valid_o    ( meta_buf_valid ),
+    .ready_i    ( meta_buf_ready ),
+    .usage_o    ( /* unused */   )
+  );
+
+  // Assemble the actual memory request from meta information and write data.
+  assign m2s_req = '{
+    addr:  meta.addr,
+    atop:  meta.atop,
+    strb:  axi_req_i.w.strb,
+    wdata: axi_req_i.w.data,
+    we:    meta.write
+  };
+
+  // Interface memory as stream.
+  stream_to_mem #(
+    .mem_req_t  ( mem_req_t  ),
+    .mem_resp_t ( axi_data_t ),
+    .BufDepth   ( BufDepth   )
+  ) i_stream_to_mem (
+    .clk_i,
+    .rst_ni,
+    .req_i            ( m2s_req        ),
+    .req_valid_i      ( m2s_req_valid  ),
+    .req_ready_o      ( m2s_req_ready  ),
+    .resp_o           ( m2s_resp       ),
+    .resp_valid_o     ( m2s_resp_valid ),
+    .resp_ready_i     ( m2s_resp_ready ),
+    .mem_req_o        ( mem_req        ),
+    .mem_req_valid_o  ( mem_req_valid  ),
+    .mem_req_ready_i  ( mem_req_ready  ),
+    .mem_resp_i       ( mem_rdata      ),
+    .mem_resp_valid_i ( mem_rvalid     )
+  );
+
+  // Split single memory request to desired number of banks.
+  mem_to_banks #(
+    .AddrWidth  ( AddrWidth ),
+    .DataWidth  ( DataWidth ),
+    .NumBanks   ( NumBanks  )
+  ) i_mem_to_banks (
+    .clk_i,
+    .rst_ni,
+    .req_i         ( mem_req_valid ),
+    .gnt_o         ( mem_req_ready ),
+    .addr_i        ( mem_req.addr  ),
+    .wdata_i       ( mem_req.wdata ),
+    .strb_i        ( mem_req.strb  ),
+    .atop_i        ( mem_req.atop  ),
+    .we_i          ( mem_req.we    ),
+    .rvalid_o      ( mem_rvalid    ),
+    .rdata_o       ( mem_rdata     ),
+    .bank_req_o    ( mem_req_o     ),
+    .bank_gnt_i    ( mem_gnt_i     ),
+    .bank_addr_o   ( mem_addr_o    ),
+    .bank_wdata_o  ( mem_wdata_o   ),
+    .bank_strb_o   ( mem_strb_o    ),
+    .bank_atop_o   ( mem_atop_o    ),
+    .bank_we_o     ( mem_we_o      ),
+    .bank_rvalid_i ( mem_rvalid_i  ),
+    .bank_rdata_i  ( mem_rdata_i   )
+  );
+
+  // Join memory read data and meta data stream.
+  logic mem_join_valid, mem_join_ready;
+  stream_join #(
+    .N_INP ( 32'd2 )
+  ) i_join (
+    .inp_valid_i  ({m2s_resp_valid, meta_buf_valid}),
+    .inp_ready_o  ({m2s_resp_ready, meta_buf_ready}),
+    .oup_valid_o  ( mem_join_valid                 ),
+    .oup_ready_i  ( mem_join_ready                 )
+  );
+
+  // Dynamically fork the joined stream to B and R channels.
+  stream_fork_dynamic #(
+    .N_OUP ( 32'd2 )
+  ) i_fork_dynamic (
+    .clk_i,
+    .rst_ni,
+    .valid_i      ( mem_join_valid                         ),
+    .ready_o      ( mem_join_ready                         ),
+    .sel_i        ({sel_buf_b,          sel_buf_r         }),
+    .sel_valid_i  ( sel_buf_valid                          ),
+    .sel_ready_o  ( sel_buf_ready                          ),
+    .valid_o      ({axi_resp_o.b_valid, axi_resp_o.r_valid}),
+    .ready_i      ({axi_req_i.b_ready,  axi_req_i.r_ready })
+  );
+
+  // Compose B responses.
+  assign axi_resp_o.b = '{
+    id:   meta_buf.id,
+    resp: axi_pkg::RESP_OKAY,
+    user: '0
+  };
+
+  // Compose R responses.
+  assign axi_resp_o.r = '{
+    data: m2s_resp,
+    id:   meta_buf.id,
+    last: meta_buf.last,
+    resp: axi_pkg::RESP_OKAY,
+    user: '0
+  };
+
+  // Registers
+  `FFARN(meta_sel_q, meta_sel_d, 1'b0, clk_i, rst_ni)
+  `FFARN(sel_lock_q, sel_lock_d, 1'b0, clk_i, rst_ni)
+  `FFARN(rd_meta_q, rd_meta_d, '{default: '0}, clk_i, rst_ni)
+  `FFARN(wr_meta_q, wr_meta_d, '{default: '0}, clk_i, rst_ni)
+  `FFARN(r_cnt_q, r_cnt_d, '0, clk_i, rst_ni)
+  `FFARN(w_cnt_q, w_cnt_d, '0, clk_i, rst_ni)
+
+  // Assertions
+  // pragma translate_off
+  `ifndef VERILATOR
+  default disable iff (!rst_ni);
+  assume property (@(posedge clk_i)
+      axi_req_i.ar_valid && !axi_resp_o.ar_ready |=> $stable(axi_req_i.ar))
+    else $error("AR must remain stable until handshake has happened!");
+  assert property (@(posedge clk_i)
+      axi_resp_o.r_valid && !axi_req_i.r_ready |=> $stable(axi_resp_o.r))
+    else $error("R must remain stable until handshake has happened!");
+  assume property (@(posedge clk_i)
+      axi_req_i.aw_valid && !axi_resp_o.aw_ready |=> $stable(axi_req_i.aw))
+    else $error("AW must remain stable until handshake has happened!");
+  assume property (@(posedge clk_i)
+      axi_req_i.w_valid && !axi_resp_o.w_ready |=> $stable(axi_req_i.w))
+    else $error("W must remain stable until handshake has happened!");
+  assert property (@(posedge clk_i)
+      axi_resp_o.b_valid && !axi_req_i.b_ready |=> $stable(axi_resp_o.b))
+    else $error("B must remain stable until handshake has happened!");
+  assert property (@(posedge clk_i) axi_req_i.ar_valid && axi_req_i.ar.len > 0 |->
+      axi_req_i.ar.burst == axi_pkg::BURST_INCR)
+    else $error("Non-incrementing bursts are not supported!");
+  assert property (@(posedge clk_i) axi_req_i.aw_valid && axi_req_i.aw.len > 0 |->
+      axi_req_i.aw.burst == axi_pkg::BURST_INCR)
+    else $error("Non-incrementing bursts are not supported!");
+  assert property (@(posedge clk_i) meta_valid && meta.atop != '0 |-> meta.write)
+    else $warning("Unexpected atomic operation on read.");
+  `endif
+  // pragma translate_on
+endmodule
+
+
+`include "axi/assign.svh"
+`include "axi/typedef.svh"
+/// Interface wrapper for module `axi_to_mem`.
+module axi_to_mem_intf #(
+  /// See `axi_to_mem`, parameter `AddrWidth`.
+  parameter int unsigned ADDR_WIDTH = 32'd0,
+  /// See `axi_to_mem`, parameter `DataWidth`.
+  parameter int unsigned DATA_WIDTH = 32'd0,
+  /// AXI4+ATOP ID width.
+  parameter int unsigned ID_WIDTH   = 32'd0,
+  /// AXI4+ATOP user width.
+  parameter int unsigned USER_WIDTH = 32'd0,
+  /// See `axi_to_mem`, parameter `NumBanks`.
+  parameter int unsigned NUM_BANKS  = 32'd0,
+  /// See `axi_to_mem`, parameter `BufDepth`.
+  parameter int unsigned BUF_DEPTH  = 32'd1,
+  /// Dependent parameter, do not override. See `axi_to_mem`, parameter `addr_t`.
+  localparam type addr_t     = logic [ADDR_WIDTH-1:0],
+  /// Dependent parameter, do not override. See `axi_to_mem`, parameter `mem_data_t`.
+  localparam type mem_data_t = logic [DATA_WIDTH/NUM_BANKS-1:0],
+  /// Dependent parameter, do not override. See `axi_to_mem`, parameter `mem_strb_t`.
+  localparam type mem_strb_t = logic [DATA_WIDTH/NUM_BANKS/8-1:0]
+) (
+  /// Clock input.
+  input  logic                            clk_i,
+  /// Asynchronous reset, active low.
+  input  logic                            rst_ni,
+  /// See `axi_to_mem`, port `busy_o`.
+  output logic                            busy_o,
+  /// AXI4+ATOP slave interface port.
+  AXI_BUS.Slave                           slv,
+  /// See `axi_to_mem`, port `mem_req_o`.
+  output logic           [NUM_BANKS-1:0]  mem_req_o,
+  /// See `axi_to_mem`, port `mem_gnt_i`.
+  input  logic           [NUM_BANKS-1:0]  mem_gnt_i,
+  /// See `axi_to_mem`, port `mem_addr_o`.
+  output addr_t          [NUM_BANKS-1:0]  mem_addr_o,
+  /// See `axi_to_mem`, port `mem_wdata_o`.
+  output mem_data_t      [NUM_BANKS-1:0]  mem_wdata_o,
+  /// See `axi_to_mem`, port `mem_strb_o`.
+  output mem_strb_t      [NUM_BANKS-1:0]  mem_strb_o,
+  /// See `axi_to_mem`, port `mem_atop_o`.
+  output axi_pkg::atop_t [NUM_BANKS-1:0]  mem_atop_o,
+  /// See `axi_to_mem`, port `mem_we_o`.
+  output logic           [NUM_BANKS-1:0]  mem_we_o,
+  /// See `axi_to_mem`, port `mem_rvalid_i`.
+  input  logic           [NUM_BANKS-1:0]  mem_rvalid_i,
+  /// See `axi_to_mem`, port `mem_rdata_i`.
+  input  mem_data_t      [NUM_BANKS-1:0]  mem_rdata_i
+);
+  typedef logic [ID_WIDTH-1:0]     id_t;
+  typedef logic [DATA_WIDTH-1:0]   data_t;
+  typedef logic [DATA_WIDTH/8-1:0] strb_t;
+  typedef logic [USER_WIDTH-1:0]   user_t;
+  `AXI_TYPEDEF_AW_CHAN_T(aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(w_chan_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(b_chan_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(ar_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(r_chan_t, data_t, id_t, user_t)
+  `AXI_TYPEDEF_REQ_T(req_t, aw_chan_t, w_chan_t, ar_chan_t)
+  `AXI_TYPEDEF_RESP_T(resp_t, b_chan_t, r_chan_t)
+  req_t   req;
+  resp_t  resp;
+  `AXI_ASSIGN_TO_REQ(req, slv)
+  `AXI_ASSIGN_FROM_RESP(slv, resp)
+  axi_to_mem #(
+    .axi_req_t  ( req_t     ),
+    .axi_resp_t ( resp_t    ),
+    .AddrWidth  ( ADDR_WIDTH ),
+    .DataWidth  ( DATA_WIDTH ),
+    .IdWidth    ( ID_WIDTH   ),
+    .NumBanks   ( NUM_BANKS  ),
+    .BufDepth   ( BUF_DEPTH  )
+  ) i_axi_to_mem (
+    .clk_i,
+    .rst_ni,
+    .busy_o,
+    .axi_req_i  ( req  ),
+    .axi_resp_o ( resp ),
+    .mem_req_o,
+    .mem_gnt_i,
+    .mem_addr_o,
+    .mem_wdata_o,
+    .mem_strb_o,
+    .mem_atop_o,
+    .mem_we_o,
+    .mem_rvalid_i,
+    .mem_rdata_i
+  );
+endmodule
+
+/// Split memory access over multiple parallel banks, where each bank has its own req/gnt
+/// request and valid response direction.
+module mem_to_banks #(
+  /// Input address width.
+  parameter int unsigned AddrWidth = 32'd0,
+  /// Input data width, must be a power of two.
+  parameter int unsigned DataWidth = 32'd0,
+  /// Number of banks at output, must evenly divide `DataWidth`.
+  parameter int unsigned NumBanks  = 32'd0,
+  /// Dependent parameter, do not override! Address type.
+  localparam type addr_t     = logic [AddrWidth-1:0],
+  /// Dependent parameter, do not override! Input data type.
+  localparam type inp_data_t = logic [DataWidth-1:0],
+  /// Dependent parameter, do not override! Input write strobe type.
+  localparam type inp_strb_t = logic [DataWidth/8-1:0],
+  /// Dependent parameter, do not override! Output data type.
+  localparam type oup_data_t = logic [DataWidth/NumBanks-1:0],
+  /// Dependent parameter, do not override! Output write strobe type.
+  localparam type oup_strb_t = logic [DataWidth/NumBanks/8-1:0]
+) (
+  /// Clock input.
+  input  logic                      clk_i,
+  /// Asynchronous reset, active low.
+  input  logic                      rst_ni,
+  /// Memory request to split, request is valid.
+  input  logic                      req_i,
+  /// Memory request to split, request can be granted.
+  output logic                      gnt_o,
+  /// Memory request to split, request address, byte-wise.
+  input  addr_t                     addr_i,
+  /// Memory request to split, request write data.
+  input  inp_data_t                 wdata_i,
+  /// Memory request to split, request write strobe.
+  input  inp_strb_t                 strb_i,
+  /// Memory request to split, request Atomic signal from AXI4+ATOP.
+  input  axi_pkg::atop_t            atop_i,
+  /// Memory request to split, request write enable, active high.
+  input  logic                      we_i,
+  /// Memory request to split, response is valid. Required for read and write requests
+  output logic                      rvalid_o,
+  /// Memory request to split, response read data.
+  output inp_data_t                 rdata_o,
+  /// Memory bank request, request is valid.
+  output logic           [NumBanks-1:0]  bank_req_o,
+  /// Memory bank request, request can be granted.
+  input  logic           [NumBanks-1:0]  bank_gnt_i,
+  /// Memory bank request, request address, byte-wise. Will be different for each bank.
+  output addr_t          [NumBanks-1:0]  bank_addr_o,
+  /// Memory bank request, request write data.
+  output oup_data_t      [NumBanks-1:0]  bank_wdata_o,
+  /// Memory bank request, request write strobe.
+  output oup_strb_t      [NumBanks-1:0]  bank_strb_o,
+  /// Memory bank request, request Atomic signal from AXI4+ATOP.
+  output axi_pkg::atop_t [NumBanks-1:0]  bank_atop_o,
+  /// Memory bank request, request write enable, active high.
+  output logic           [NumBanks-1:0]  bank_we_o,
+  /// Memory bank request, response is valid. Required for read and write requests
+  input  logic           [NumBanks-1:0]  bank_rvalid_i,
+  /// Memory bank request, response read data.
+  input  oup_data_t      [NumBanks-1:0]  bank_rdata_i
+);
+
+  localparam DataBytes    = $bits(inp_strb_t);
+  localparam BitsPerBank  = $bits(oup_data_t);
+  localparam BytesPerBank = $bits(oup_strb_t);
+
+  typedef struct packed {
+    addr_t          addr;
+    oup_data_t      wdata;
+    oup_strb_t      strb;
+    axi_pkg::atop_t atop;
+    logic           we;
+  } req_t;
+
+  logic                 req_valid;
+  logic [NumBanks-1:0]              req_ready,
+                        resp_valid, resp_ready;
+  req_t [NumBanks-1:0]  bank_req,
+                        bank_oup;
+
+  function automatic addr_t align_addr(input addr_t addr);
+    return (addr >> $clog2(DataBytes)) << $clog2(DataBytes);
+  endfunction
+
+  // Handle requests.
+  assign req_valid = req_i & gnt_o;
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_reqs
+    assign bank_req[i].addr  = align_addr(addr_i) + i * BytesPerBank;
+    assign bank_req[i].wdata = wdata_i[i*BitsPerBank+:BitsPerBank];
+    assign bank_req[i].strb  = strb_i[i*BytesPerBank+:BytesPerBank];
+    assign bank_req[i].atop  = atop_i;
+    assign bank_req[i].we    = we_i;
+    fall_through_register #(
+      .T ( req_t )
+    ) i_ft_reg (
+      .clk_i,
+      .rst_ni,
+      .clr_i      ( 1'b0          ),
+      .testmode_i ( 1'b0          ),
+      .valid_i    ( req_valid     ),
+      .ready_o    ( req_ready[i]  ),
+      .data_i     ( bank_req[i]   ),
+      .valid_o    ( bank_req_o[i] ),
+      .ready_i    ( bank_gnt_i[i] ),
+      .data_o     ( bank_oup[i]   )
+    );
+    assign bank_addr_o[i]  = bank_oup[i].addr;
+    assign bank_wdata_o[i] = bank_oup[i].wdata;
+    assign bank_strb_o[i]  = bank_oup[i].strb;
+    assign bank_atop_o[i]  = bank_oup[i].atop;
+    assign bank_we_o[i]    = bank_oup[i].we;
+  end
+
+  // Grant output if all our requests have been granted.
+  assign gnt_o = (&req_ready) & (&resp_ready);
+
+  // Handle responses.
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_resp_regs
+    fall_through_register #(
+      .T ( oup_data_t )
+    ) i_ft_reg (
+      .clk_i,
+      .rst_ni,
+      .clr_i      ( 1'b0                                ),
+      .testmode_i ( 1'b0                                ),
+      .valid_i    ( bank_rvalid_i[i]                    ),
+      .ready_o    ( resp_ready[i]                       ),
+      .data_i     ( bank_rdata_i[i]                     ),
+      .data_o     ( rdata_o[i*BitsPerBank+:BitsPerBank] ),
+      .ready_i    ( rvalid_o                            ),
+      .valid_o    ( resp_valid[i]                       )
+    );
+  end
+  assign rvalid_o = &resp_valid;
+
+  // Assertions
+  // pragma translate_off
+  `ifndef VERILATOR
+    initial begin
+      assume (DataWidth != 0 && (DataWidth & (DataWidth - 1)) == 0)
+        else $fatal(1, "Data width must be a power of two!");
+      assume (DataWidth % NumBanks == 0)
+        else $fatal(1, "Data width must be evenly divisible over banks!");
+      assume ((DataWidth / NumBanks) % 8 == 0)
+        else $fatal(1, "Data width of each bank must be divisible into 8-bit bytes!");
+    end
+  `endif
+  // pragma translate_on
+endmodule

--- a/src/axi_to_mem.sv
+++ b/src/axi_to_mem.sv
@@ -316,7 +316,7 @@ module axi_to_mem #(
   );
 
   // Assemble the actual memory request from meta information and write data.
-  assign m2s_req = '{
+  assign m2s_req = mem_req_t'{
     addr:  meta.addr,
     atop:  meta.atop,
     strb:  axi_req_i.w.strb,
@@ -632,7 +632,7 @@ module mem_to_banks #(
 
   // Handle requests.
   assign req_valid = req_i & gnt_o;
-  for (genvar i = 0; i < NumBanks; i++) begin : gen_reqs
+  for (genvar i = 0; unsigned'(i) < NumBanks; i++) begin : gen_reqs
     assign bank_req[i].addr  = align_addr(addr_i) + i * BytesPerBank;
     assign bank_req[i].wdata = wdata_i[i*BitsPerBank+:BitsPerBank];
     assign bank_req[i].strb  = strb_i[i*BytesPerBank+:BytesPerBank];
@@ -663,7 +663,7 @@ module mem_to_banks #(
   assign gnt_o = (&req_ready) & (&resp_ready);
 
   // Handle responses.
-  for (genvar i = 0; i < NumBanks; i++) begin : gen_resp_regs
+  for (genvar i = 0; unsigned'(i) < NumBanks; i++) begin : gen_resp_regs
     fall_through_register #(
       .T ( oup_data_t )
     ) i_ft_reg (

--- a/src/axi_to_mem.sv
+++ b/src/axi_to_mem.sv
@@ -129,7 +129,7 @@ module axi_to_mem #(
     // Default assignments
     axi_resp_o.ar_ready = 1'b0;
     rd_meta_d           = rd_meta_q;
-    rd_meta             = 'x;
+    rd_meta             = meta_t'{default: '0};
     rd_valid            = 1'b0;
     r_cnt_d             = r_cnt_q;
     // Handle R burst in progress.
@@ -169,7 +169,7 @@ module axi_to_mem #(
     axi_resp_o.aw_ready = 1'b0;
     axi_resp_o.w_ready  = 1'b0;
     wr_meta_d           = wr_meta_q;
-    wr_meta             = 'x;
+    wr_meta             = meta_t'{default: '0};
     wr_valid            = 1'b0;
     w_cnt_d             = w_cnt_q;
     // Handle W bursts in progress.
@@ -209,16 +209,16 @@ module axi_to_mem #(
 
   // Arbitrate between reads and writes.
   stream_mux #(
-    .DATA_T (meta_t),
-    .N_INP  (2)
+    .DATA_T ( meta_t ),
+    .N_INP  ( 32'd2  )
   ) i_ax_mux (
-    .inp_data_i   ({wr_meta, rd_meta}),
+    .inp_data_i   ({wr_meta,  rd_meta }),
     .inp_valid_i  ({wr_valid, rd_valid}),
     .inp_ready_o  ({wr_ready, rd_ready}),
-    .inp_sel_i    (meta_sel_d),
-    .oup_data_o   (meta),
-    .oup_valid_o  (arb_valid),
-    .oup_ready_i  (arb_ready)
+    .inp_sel_i    ( meta_sel_d         ),
+    .oup_data_o   ( meta               ),
+    .oup_valid_o  ( arb_valid          ),
+    .oup_ready_i  ( arb_ready          )
   );
   always_comb begin
     meta_sel_d = meta_sel_q;

--- a/src/axi_to_mem.sv
+++ b/src/axi_to_mem.sv
@@ -418,8 +418,8 @@ module axi_to_mem #(
   // Registers
   `FFARN(meta_sel_q, meta_sel_d, 1'b0, clk_i, rst_ni)
   `FFARN(sel_lock_q, sel_lock_d, 1'b0, clk_i, rst_ni)
-  `FFARN(rd_meta_q, rd_meta_d, '{default: '0}, clk_i, rst_ni)
-  `FFARN(wr_meta_q, wr_meta_d, '{default: '0}, clk_i, rst_ni)
+  `FFARN(rd_meta_q, rd_meta_d, meta_t'{default: '0}, clk_i, rst_ni)
+  `FFARN(wr_meta_q, wr_meta_d, meta_t'{default: '0}, clk_i, rst_ni)
   `FFARN(r_cnt_q, r_cnt_d, '0, clk_i, rst_ni)
   `FFARN(w_cnt_q, w_cnt_d, '0, clk_i, rst_ni)
 

--- a/src/axi_to_mem_banked.sv
+++ b/src/axi_to_mem_banked.sv
@@ -1,0 +1,423 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Authors:
+// - Wolfgang Rönninger <wroennin@iis.ee.ethz.ch>
+
+/// AXI4+ATOP to banked SRAM memory slave. Allows for parallel read and write transactions.
+/// Address transltion is handled as follows:
+///
+/// Address: {`Ignored`, `Word Address`, `BankSelection`, `ByteOffset`}
+/// - `Ignored`:       .
+/// - `Word Address`:  .
+/// - `BankSelection`: .
+/// - `ByteOffset`:    .
+module axi_to_mem_banked #(
+  /// AXI4+ATOP ID width
+  parameter int unsigned                  AxiIdWidth    = 32'd0,
+  /// AXI4+ATOP address width
+  parameter int unsigned                  AxiAddrWidth  = 32'd0,
+  /// AXI4+ATOP data width
+  parameter int unsigned                  AxiDataWidth  = 32'd0,
+  /// AXI4+ATOP AW channel struct
+  parameter type                          axi_aw_chan_t = logic,
+  /// AXI4+ATOP  W channel struct
+  parameter type                          axi_w_chan_t  = logic,
+  /// AXI4+ATOP  B channel struct
+  parameter type                          axi_b_chan_t  = logic,
+  /// AXI4+ATOP AR channel struct
+  parameter type                          axi_ar_chan_t = logic,
+  /// AXI4+ATOP  R channel struct
+  parameter type                          axi_r_chan_t  = logic,
+  /// AXI4+ATOP request struct
+  parameter type                          axi_req_t     = logic,
+  /// AXI4+ATOP response struct
+  parameter type                          axi_resp_t    = logic,
+  /// Number of memory banks / macros
+  /// Has to satisfy:
+  /// - MemNumBanks >= 2 * AxiDataWidth / MemDataWidth
+  /// - MemNumBanks is a power of 2.
+  parameter int unsigned                  MemNumBanks   = 32'd4,
+  /// Address width of an individual memory bank. This is treated as a word address.
+  parameter int unsigned                  MemAddrWidth  = 32'd11,
+  /// Data width of the memory macros.
+  /// Has to satisfy:
+  /// - AxiDataWidth % MemDataWidth = 0
+  parameter int unsigned                  MemDataWidth  = 32'd32,
+  /// Read latency of the connected memory in cycles
+  parameter int unsigned                  MemLatency    = 32'd1,
+  /// DEPENDENT PARAMETER, DO NOT OVERWRITE! Address type of the memory request.
+  parameter type mem_addr_t = logic [MemAddrWidth-1:0],
+  /// DEPENDENT PARAMETER, DO NOT OVERWRITE! Atomic operation type for the memory request.
+  parameter type mem_atop_t = logic [5:0],
+  /// DEPENDENT PARAMETER, DO NOT OVERWRITE! Data type for the memory request.
+  parameter type mem_data_t = logic [MemDataWidth-1:0],
+  /// DEPENDENT PARAMETER, DO NOT OVERWRITE! Byte strobe/enable signal for the memory request.
+  parameter type mem_strb_t = logic [MemDataWidth/8-1:0]
+) (
+  /// Clock
+  input  logic                        clk_i,
+  /// Asynchronous reset, active low
+  input  logic                        rst_ni,
+  /// Testmode enable
+  input  logic                        test_i,
+  /// AXI4+ATOP slave port, request struct
+  input  axi_req_t                    axi_req_i,
+  /// AXI4+ATOP slave port, response struct
+  output axi_resp_t                   axi_resp_o,
+  /// Memory bank request
+  output logic      [MemNumBanks-1:0] mem_req_o,
+  /// Memory request grant
+  input  logic      [MemNumBanks-1:0] mem_gnt_i,
+  /// Request address
+  output mem_addr_t [MemNumBanks-1:0] mem_add_o,
+  /// Write request enable, active high
+  output logic      [MemNumBanks-1:0] mem_we_o,
+  /// Write data
+  output mem_data_t [MemNumBanks-1:0] mem_wdata_o,
+  /// Write data byte enable, active high
+  output mem_strb_t [MemNumBanks-1:0] mem_be_o,
+  /// Atomic operation
+  output mem_atop_t [MemNumBanks-1:0] mem_atop_o,
+  /// Read data response
+  input  mem_data_t [MemNumBanks-1:0] mem_rdata_i,
+  /// Status output, busy flag of `axi_to_mem`
+  output logic      [1:0]             axi_to_mem_busy_o
+);
+  /// This specifies the number of banks needed to have the full data bandwidth of one
+  /// AXI data channel.
+  localparam int unsigned BanksPerAxiChannel = AxiDataWidth / MemDataWidth;
+  /// Offset of the byte address from AXI to determine, where the selection signal should start
+  localparam int unsigned BankSelOffset = $clog2(MemDataWidth / 32'd8);
+  /// Selection signal width of the xbar.
+  localparam int unsigned BankSelWidth = cf_math_pkg::idx_width(MemNumBanks);
+  typedef logic [BankSelWidth-1:0] xbar_sel_t;
+
+  // Typedef for defining the channels
+  typedef enum logic {
+    ReadAccess  = 1'b0,
+    WriteAccess = 1'b1
+  } access_type_e;
+  typedef logic [AxiAddrWidth-1:0] axi_addr_t;
+  // typedef logic [TcdmDataWidth-1:0] tcdm_data_t;
+
+  /// Payload definition which is sent over the xbar between the macros and the read/write unit.
+  typedef struct packed {
+    /// Address for the memory access
+    mem_addr_t addr;
+    /// Write enable, active high
+    logic      we;
+    /// Write data
+    mem_data_t wdata;
+    /// Strobe signal, byte enable
+    mem_strb_t wstrb;
+    /// Atomic operation, from AXI
+    mem_atop_t atop;
+  } xbar_payload_t;
+
+  /// Read data definition for the shift register, which samples the read response data
+  typedef struct packed {
+    /// Selection signal for response routing
+    xbar_sel_t sel;
+    /// Selection is valid
+    logic      valid;
+  } read_sel_t;
+
+  axi_req_t  [1:0] mem_axi_reqs;
+  axi_resp_t [1:0] mem_axi_resps;
+
+  // Fixed select `axi_demux` to split reads and writes to the two `axi_to_mem`
+  axi_demux #(
+    .AxiIdWidth  ( AxiIdWidth    ),
+    .aw_chan_t   ( axi_aw_chan_t ),
+    .w_chan_t    ( axi_w_chan_t  ),
+    .b_chan_t    ( axi_b_chan_t  ),
+    .ar_chan_t   ( axi_ar_chan_t ),
+    .r_chan_t    ( axi_r_chan_t  ),
+    .req_t       ( axi_req_t     ),
+    .resp_t      ( axi_resp_t    ),
+    .NoMstPorts  ( 32'd2         ),
+    .MaxTrans    ( 32'd4         ), // allow multiple Ax vectors to not starve W channel
+    .AxiLookBits ( 32'd1         ), // select is fixed, do not need it
+    .FallThrough ( 1'b1          ),
+    .SpillAw     ( 1'b1          ),
+    .SpillW      ( 1'b1          ),
+    .SpillB      ( 1'b1          ),
+    .SpillAr     ( 1'b1          ),
+    .SpillR      ( 1'b1          )
+  ) i_axi_demux (
+    .clk_i,
+    .rst_ni,
+    .test_i,
+    .slv_req_i       ( axi_req_i     ),
+    .slv_aw_select_i ( WriteAccess   ),
+    .slv_ar_select_i ( ReadAccess    ),
+    .slv_resp_o      ( axi_resp_o    ),
+    .mst_reqs_o      ( mem_axi_reqs  ),
+    .mst_resps_i     ( mem_axi_resps )
+  );
+
+  xbar_payload_t [1:0][BanksPerAxiChannel-1:0] inter_payload;
+  xbar_sel_t     [1:0][BanksPerAxiChannel-1:0] inter_sel;
+  logic          [1:0][BanksPerAxiChannel-1:0] inter_valid,   inter_ready;
+
+  // axi_to_mem protocol converter
+  for (genvar i = 0; i < 2; i++) begin : gen_axi_to_mem
+    axi_addr_t [BanksPerAxiChannel-1:0] req_addr;  // This is a byte address
+    mem_data_t [BanksPerAxiChannel-1:0] req_wdata, res_rdata;
+    mem_strb_t [BanksPerAxiChannel-1:0] req_wstrb;
+    mem_atop_t [BanksPerAxiChannel-1:0] req_atop;
+
+    logic      [BanksPerAxiChannel-1:0] req_we,    res_valid;
+
+    // Careful, request / grant
+    // Only assert grant, if there is a ready
+    axi_to_mem #(
+      .axi_req_t ( axi_req_t          ),
+      .axi_resp_t( axi_resp_t         ),
+      .AddrWidth ( AxiAddrWidth       ),
+      .DataWidth ( AxiDataWidth       ),
+      .IdWidth   ( AxiIdWidth         ),
+      .NumBanks  ( BanksPerAxiChannel ),
+      .BufDepth  ( MemLatency         )
+    ) i_axi_to_mem (
+      .clk_i,
+      .rst_ni,
+      .busy_o       ( axi_to_mem_busy_o[i]            ),
+      .axi_req_i    ( mem_axi_reqs[i]                 ),
+      .axi_resp_o   ( mem_axi_resps[i]                ),
+      .mem_req_o    ( inter_valid[i]                  ),
+      .mem_gnt_i    ( inter_ready[i] & inter_valid[i] ), // convert valid/ready to req/gnt
+      .mem_addr_o   ( req_addr                        ),
+      .mem_wdata_o  ( req_wdata                       ),
+      .mem_strb_o   ( req_wstrb                       ),
+      .mem_atop_o   ( req_atop                        ),
+      .mem_we_o     ( req_we                          ),
+      .mem_rvalid_i ( res_valid                       ),
+      .mem_rdata_i  ( res_rdata                       )
+    );
+    // Pack the payload data together
+    for (genvar j = 0; j < BanksPerAxiChannel; j++) begin : gen_response_mux
+      // Cut out the bank selection signal.
+      assign inter_sel[i][j] = req_addr[j][BankSelOffset+:BankSelWidth];
+
+      // Assign the xbar payload.
+      assign inter_payload[i][j] = xbar_payload_t'{
+        // Cut out the word address for the banks.
+        addr:    req_addr[j][(BankSelOffset+BankSelWidth)+:MemAddrWidth],
+        we:      req_we[j],
+        wdata:   req_wdata[j],
+        wstrb:   req_wstrb[j],
+        atop:    req_atop[j],
+        default: '0
+      };
+
+      // Cut out the portion of the address for the bank selection, each bank is word addressed!
+      read_sel_t r_shift_inp, r_shift_oup;
+      // Pack the selection into the shift register
+      assign r_shift_inp = read_sel_t'{
+        sel:     inter_sel[i][j],                       // Selection for response multiplexer
+        valid:   inter_valid[i][j] & inter_ready[i][j], // Valid when req to SRAM
+        default: '0
+      };
+
+      // Select the right read response data.
+      // Writes should also generate a `response`.
+      assign res_valid[j] = r_shift_oup.valid;
+      assign res_rdata[j] = mem_rdata_i[r_shift_oup.sel];
+
+      // Connect for the response data `MemLatency` cycles after a request was made to the xbar.
+      shift_reg #(
+        .dtype ( read_sel_t ),
+        .Depth ( MemLatency )
+      ) i_shift_reg_rdata_mux (
+        .clk_i,
+        .rst_ni,
+        .d_i    ( r_shift_inp ),
+        .d_o    ( r_shift_oup )
+      );
+    end
+  end
+
+  // Xbar to arbitrate data over the different memory banks
+  xbar_payload_t [MemNumBanks-1:0] mem_payload;
+
+  stream_xbar #(
+    .NumInp      ( 32'd2 * BanksPerAxiChannel ),
+    .NumOut      ( MemNumBanks                ),
+    .payload_t   ( xbar_payload_t             ),
+    .OutSpillReg ( 1'b0                       ),
+    .ExtPrio     ( 1'b0                       ),
+    .AxiVldRdy   ( 1'b1                       ),
+    .LockIn      ( 1'b1                       )
+  ) i_stream_xbar (
+    .clk_i,
+    .rst_ni,
+    .flush_i ( 1'b0          ),
+    .rr_i    ( '0            ),
+    .data_i  ( inter_payload ),
+    .sel_i   ( inter_sel     ),
+    .valid_i ( inter_valid   ),
+    .ready_o ( inter_ready   ),
+    .data_o  ( mem_payload   ),
+    .idx_o   ( /*not used*/  ),
+    .valid_o ( mem_req_o     ),
+    .ready_i ( mem_gnt_i     )
+  );
+
+  // Memory request output assignment
+  for (genvar i = 0; unsigned'(i) < MemNumBanks; i++) begin : gen_mem_outp
+    assign mem_add_o[i]   = mem_payload[i].addr;
+    assign mem_we_o[i]    = mem_payload[i].we;
+    assign mem_wdata_o[i] = mem_payload[i].wdata;
+    assign mem_be_o[i]    = mem_payload[i].wstrb;
+    assign mem_atop_o[i]  = mem_payload[i].atop;
+  end
+
+// pragma translate_off
+`ifndef VERILATOR
+  initial begin: p_assertions
+    assert (AxiIdWidth   >= 32'd1) else $fatal(1, "AxiIdWidth must be at least 1!");
+    assert (AxiAddrWidth >= 32'd1) else $fatal(1, "AxiAddrWidth must be at least 1!");
+    assert (AxiDataWidth >= 32'd1) else $fatal(1, "AxiDataWidth must be at least 1!");
+    assert (MemNumBanks  >= 32'd2 * AxiDataWidth / MemDataWidth) else
+        $fatal(1, "MemNumBanks has to be >= 2 * AxiDataWidth / MemDataWidth");
+    assert (MemLatency   >= 32'd1) else $fatal(1, "MemLatency has to be at least 1!");
+    assert ($onehot(MemNumBanks))  else $fatal(1, "MemNumBanks has to be a power of 2.");
+    assert (MemAddrWidth >= 32'd1) else $fatal(1, "MemAddrWidth must be at least 1!");
+    assert (MemDataWidth >= 32'd1) else $fatal(1, "MemDataWidth must be at least 1!");
+    assert (AxiDataWidth % MemDataWidth == 0) else
+        $fatal(1, "MemDataWidth has to be a divisor of AxiDataWidth.");
+  end
+`endif
+// pragma translate_on
+endmodule
+
+`include "axi/typedef.svh"
+`include "axi/assign.svh"
+/// AXI4+ATOP interface wrapper for `axi_to_mem`
+module axi_to_mem_banked_intf #(
+  /// AXI4+ATOP ID width
+  parameter int unsigned                  AXI_ID_WIDTH   = 32'd0,
+  /// AXI4+ATOP address width
+  parameter int unsigned                  AXI_ADDR_WIDTH = 32'd0,
+  /// AXI4+ATOP data width
+  parameter int unsigned                  AXI_DATA_WIDTH = 32'd0,
+  /// AXI4+ATOP user width
+  parameter int unsigned                  AXI_USER_WIDTH = 32'd0,
+  /// Number of memory banks / macros
+  /// Has to satisfy:
+  /// - MemNumBanks >= 2 * AxiDataWidth / MemDataWidth
+  /// - MemNumBanks is a power of 2.
+  parameter int unsigned                  MEM_NUM_BANKS  = 32'd4,
+  /// Address width of an individual memory bank.
+  parameter int unsigned                  MEM_ADDR_WIDTH = 32'd11,
+  /// Data width of the memory macros.
+  /// Has to satisfy:
+  /// - AxiDataWidth % MemDataWidth = 0
+  parameter int unsigned                  MEM_DATA_WIDTH = 32'd32,
+  /// Read latency of the connected memory in cycles
+  parameter int unsigned                  MEM_LATENCY    = 32'd1,
+  // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
+  parameter type mem_addr_t = logic [MEM_ADDR_WIDTH-1:0],
+  parameter type mem_atop_t = logic [5:0],
+  parameter type mem_data_t = logic [MEM_DATA_WIDTH-1:0],
+  parameter type mem_strb_t = logic [MEM_DATA_WIDTH/8-1:0]
+) (
+  /// Clock
+  input  logic                          clk_i,
+  /// Asynchronous reset, active low
+  input  logic                          rst_ni,
+  /// Testmode enable
+  input  logic                          test_i,
+  /// AXI4+ATOP slave port
+  AXI_BUS.Slave                         slv,
+  /// Memory bank request
+  output logic      [MEM_NUM_BANKS-1:0] mem_req_o,
+  /// Memory request grant
+  input  logic      [MEM_NUM_BANKS-1:0] mem_gnt_i,
+  /// Request address
+  output mem_addr_t [MEM_NUM_BANKS-1:0] mem_add_o,
+  /// Write request enable, active high
+  output logic      [MEM_NUM_BANKS-1:0] mem_we_o,
+  /// Write data
+  output mem_data_t [MEM_NUM_BANKS-1:0] mem_wdata_o,
+  /// Write data byte enable, active high
+  output mem_strb_t [MEM_NUM_BANKS-1:0] mem_be_o,
+  /// Atomic operation
+  output mem_atop_t [MEM_NUM_BANKS-1:0] mem_atop_o,
+  /// Read data response
+  input  mem_data_t [MEM_NUM_BANKS-1:0] mem_rdata_i,
+  /// Status output, busy flag of `axi_to_mem`
+  output logic      [1:0]               axi_to_mem_busy_o
+);
+  typedef logic [AXI_ID_WIDTH-1:0]     id_t;
+  typedef logic [AXI_ADDR_WIDTH-1:0]   addr_t;
+  typedef logic [AXI_DATA_WIDTH-1:0]   data_t;
+  typedef logic [AXI_DATA_WIDTH/8-1:0] strb_t;
+  typedef logic [AXI_USER_WIDTH-1:0]   user_t;
+  `AXI_TYPEDEF_AW_CHAN_T(aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(w_chan_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(b_chan_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(ar_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(r_chan_t, data_t, id_t, user_t)
+  `AXI_TYPEDEF_REQ_T(axi_req_t, aw_chan_t, w_chan_t, ar_chan_t)
+  `AXI_TYPEDEF_RESP_T(axi_resp_t, b_chan_t, r_chan_t)
+
+  axi_req_t  mem_axi_req;
+  axi_resp_t mem_axi_resp;
+
+  `AXI_ASSIGN_TO_REQ(mem_axi_req, slv)
+  `AXI_ASSIGN_FROM_RESP(slv, mem_axi_resp)
+
+  axi_to_mem_banked #(
+    .AxiIdWidth    ( AXI_ID_WIDTH               ),
+    .AxiAddrWidth  ( AXI_ADDR_WIDTH             ),
+    .AxiDataWidth  ( AXI_DATA_WIDTH             ),
+    .axi_aw_chan_t ( aw_chan_t                  ),
+    .axi_w_chan_t  (  w_chan_t                  ),
+    .axi_b_chan_t  (  b_chan_t                  ),
+    .axi_ar_chan_t ( ar_chan_t                  ),
+    .axi_r_chan_t  (  r_chan_t                  ),
+    .axi_req_t     ( axi_req_t                  ),
+    .axi_resp_t    ( axi_resp_t                 ),
+    .MemNumBanks   ( MEM_NUM_BANKS              ),
+    .MemAddrWidth  ( MEM_ADDR_WIDTH             ),
+    .MemDataWidth  ( MEM_DATA_WIDTH             ),
+    .MemLatency    ( MEM_LATENCY                )
+  ) i_axi_to_mem_banked (
+    .clk_i,
+    .rst_ni,
+    .test_i,
+    .axi_to_mem_busy_o,
+    .axi_req_i      ( mem_axi_req  ),
+    .axi_resp_o     ( mem_axi_resp ),
+    .mem_req_o,
+    .mem_gnt_i,
+    .mem_add_o,
+    .mem_wdata_o,
+    .mem_be_o,
+    .mem_atop_o,
+    .mem_we_o,
+    .mem_rdata_i
+  );
+
+// pragma translate_off
+`ifndef VERILATOR
+  initial begin: p_assertions
+    assert (AXI_ADDR_WIDTH  >= 1) else $fatal(1, "AXI address width must be at least 1!");
+    assert (AXI_DATA_WIDTH  >= 1) else $fatal(1, "AXI data width must be at least 1!");
+    assert (AXI_ID_WIDTH    >= 1) else $fatal(1, "AXI ID   width must be at least 1!");
+    assert (AXI_USER_WIDTH  >= 1) else $fatal(1, "AXI user width must be at least 1!");
+  end
+`endif
+// pragma translate_on
+endmodule
+

--- a/src/axi_to_mem_banked.sv
+++ b/src/axi_to_mem_banked.sv
@@ -203,7 +203,7 @@ module axi_to_mem_banked #(
       .mem_rdata_i  ( res_rdata                       )
     );
     // Pack the payload data together
-    for (genvar j = 0; j < BanksPerAxiChannel; j++) begin : gen_response_mux
+    for (genvar j = 0; unsigned'(j) < BanksPerAxiChannel; j++) begin : gen_response_mux
       // Cut out the bank selection signal.
       assign inter_sel[i][j] = req_addr[j][BankSelOffset+:BankSelWidth];
 

--- a/src/axi_xbar.sv
+++ b/src/axi_xbar.sv
@@ -178,8 +178,25 @@ module axi_xbar #(
   // cross all channels
   for (genvar i = 0; i < Cfg.NoSlvPorts; i++) begin : gen_xbar_slv_cross
     for (genvar j = 0; j < Cfg.NoMstPorts; j++) begin : gen_xbar_mst_cross
-      assign mst_reqs[j][i]  = slv_reqs[i][j];
-      assign slv_resps[i][j] = mst_resps[j][i];
+      // slv_req_t  pipe_req;
+      // slv_resp_t pipe_resp;
+      axi_multicut #(
+        .NoCuts    ( Cfg.PipelineStages ),
+        .aw_chan_t ( slv_aw_chan_t      ),
+        .w_chan_t  ( w_chan_t           ),
+        .b_chan_t  ( slv_b_chan_t       ),
+        .ar_chan_t ( slv_ar_chan_t      ),
+        .r_chan_t  ( slv_r_chan_t       ),
+        .req_t     ( slv_req_t          ),
+        .resp_t    ( slv_resp_t         )
+      ) i_axi_multicut_xbar_pipeline (
+        .clk_i,
+        .rst_ni,
+        .slv_req_i  ( slv_reqs[i][j]  ),
+        .slv_resp_o ( slv_resps[i][j] ),
+        .mst_req_o  ( mst_reqs[j][i]  ),
+        .mst_resp_i ( mst_resps[j][i] )
+      );
     end
   end
 

--- a/src/axi_xbar.sv
+++ b/src/axi_xbar.sv
@@ -93,7 +93,8 @@ module axi_xbar #(
   input  default_idx_t [Cfg.NoSlvPorts-1:0] default_mst_port_i
 );
 
-  typedef logic [Cfg.AxiAddrWidth-1:0]           addr_t;
+  // Address tpye for inidvidual address signals
+  typedef logic [Cfg.AxiAddrWidth-1:0] addr_t;
   // to account for the decoding error slave
   typedef logic [cf_math_pkg::idx_width(Cfg.NoMstPorts + 1)-1:0] mst_port_idx_t;
 

--- a/test/synth_bench.sv
+++ b/test/synth_bench.sv
@@ -153,10 +153,10 @@ module synth_bench (
 
   // AXI4+ATOP on chip memory slave banked
   for (genvar i = 0; i < 5; i++) begin : gen_axi_to_mem_banked_data
-    for (genvar j = 0; j < 5; j++) begin : gen_axi_to_mem_banked_bank_num
+    for (genvar j = 0; j < 4; j++) begin : gen_axi_to_mem_banked_bank_num
       for (genvar k = 0; k < 2; k++) begin : gen_axi_to_mem_banked_bank_addr
         localparam int unsigned DATA_WIDTH_AXI[5]   = {32'd32, 32'd64, 32'd128, 32'd256, 32'd512};
-        localparam int unsigned NUM_BANKS[5]        = {32'd2,  32'd4,  32'd6,   32'd8,   32'd16};
+        localparam int unsigned NUM_BANKS[4]        = {32'd2,  32'd4,  32'd6,   32'd8};
         localparam int unsigned ADDR_WIDTH_BANKS[2] = {32'd5,  32'd11};
 
         synth_axi_to_mem_banked #(

--- a/test/synth_bench.sv
+++ b/test/synth_bench.sv
@@ -151,6 +151,25 @@ module synth_bench (
     ) i_axi_lite_regs (.*);
   end
 
+  // AXI4+ATOP on chip memory slave banked
+  for (genvar i = 0; i < 5; i++) begin : gen_axi_to_mem_banked_data
+    for (genvar j = 0; j < 5; j++) begin : gen_axi_to_mem_banked_bank_num
+      for (genvar k = 0; k < 2; k++) begin : gen_axi_to_mem_banked_bank_addr
+        localparam int unsigned DATA_WIDTH_AXI[5]   = {32'd32, 32'd64, 32'd128, 32'd256, 32'd512};
+        localparam int unsigned NUM_BANKS[5]        = {32'd2,  32'd4,  32'd6,   32'd8,   32'd16};
+        localparam int unsigned ADDR_WIDTH_BANKS[2] = {32'd5,  32'd11};
+
+        synth_axi_to_mem_banked #(
+          .AxiDataWidth  ( DATA_WIDTH_AXI[i]   ),
+          .BankNum       ( NUM_BANKS[j]        ),
+          .BankAddrWidth ( ADDR_WIDTH_BANKS[k] )
+        ) i_axi_to_mem_banked (.*);
+      end
+    end
+  end
+
+
+
 endmodule
 
 
@@ -588,4 +607,72 @@ module synth_axi_lite_regs #(
     .reg_load_i  ( reg_load    ),
     .reg_q_o     ( reg_q       )
   );
+endmodule
+
+module synth_axi_to_mem_banked #(
+  parameter int unsigned AxiDataWidth  = 32'd0,
+  parameter int unsigned BankNum       = 32'd0,
+  parameter int unsigned BankAddrWidth = 32'd0
+) (
+  input logic clk_i,
+  input logic rst_ni
+);
+  localparam int unsigned AxiIdWidth    = 32'd10;
+  localparam int unsigned AxiAddrWidth  = 32'd64;
+  localparam int unsigned AxiStrbWidth  = AxiDataWidth / 32'd8;
+  localparam int unsigned AxiUserWidth  = 32'd8;
+  localparam int unsigned BankDataWidth = 32'd2 * AxiDataWidth / BankNum;
+  localparam int unsigned BankStrbWidth = BankDataWidth / 32'd8;
+  localparam int unsigned BankLatency   = 32'd1;
+
+  typedef logic [BankAddrWidth-1:0] mem_addr_t;
+  typedef logic [BankDataWidth-1:0] mem_data_t;
+  typedef logic [BankStrbWidth-1:0] mem_strb_t;
+
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH ( AxiIdWidth   ),
+    .AXI_DATA_WIDTH ( AxiAddrWidth ),
+    .AXI_ID_WIDTH   ( AxiDataWidth ),
+    .AXI_USER_WIDTH ( AxiUserWidth )
+  ) axi ();
+
+  // Misc signals
+  logic                             test;
+  logic           [1:0]             axi_to_mem_busy;
+  // Signals for mem macros
+  logic           [BankNum-1:0] mem_req;
+  logic           [BankNum-1:0] mem_gnt;
+  mem_addr_t      [BankNum-1:0] mem_addr;
+  logic           [BankNum-1:0] mem_we;
+  mem_data_t      [BankNum-1:0] mem_wdata;
+  mem_strb_t      [BankNum-1:0] mem_be;
+  axi_pkg::atop_t [BankNum-1:0] mem_atop;
+  mem_data_t      [BankNum-1:0] mem_rdata;
+
+
+  axi_to_mem_banked_intf #(
+    .AXI_ID_WIDTH    ( AxiIdWidth    ),
+    .AXI_ADDR_WIDTH  ( AxiAddrWidth  ),
+    .AXI_DATA_WIDTH  ( AxiDataWidth  ),
+    .AXI_USER_WIDTH  ( AxiUserWidth  ),
+    .MEM_NUM_BANKS   ( BankNum       ),
+    .MEM_ADDR_WIDTH  ( BankAddrWidth ),
+    .MEM_DATA_WIDTH  ( BankDataWidth ),
+    .MEM_LATENCY     ( BankLatency   )
+  ) i_axi_to_mem_banked_intf (
+    .clk_i,
+    .rst_ni,
+    .test_i            ( test            ),
+    .slv               ( axi             ),
+    .mem_req_o         ( mem_req         ),
+    .mem_gnt_i         ( mem_gnt         ),
+    .mem_add_o         ( mem_addr        ),
+    .mem_we_o          ( mem_we          ),
+    .mem_wdata_o       ( mem_wdata       ),
+    .mem_be_o          ( mem_be          ),
+    .mem_atop_o        ( mem_atop        ),
+    .mem_rdata_i       ( mem_rdata       ),
+    .axi_to_mem_busy_o ( axi_to_mem_busy )
+  );
+
 endmodule

--- a/test/tb_axi_to_mem_banked.sv
+++ b/test/tb_axi_to_mem_banked.sv
@@ -1,0 +1,417 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Authors:
+// - Wolfgang Roenninger <wroennin@iis.ee.ethz.ch>
+
+`include "axi/typedef.svh"
+`include "axi/assign.svh"
+`include "common_cells/registers.svh"
+
+/// Testbench for axi_to_mem_banked. Monitors the performance for random accesses.
+module tb_axi_to_mem_banked #(
+  /// Data Width of the AXI4+ATOP channels.
+  parameter int unsigned TbAxiDataWidth = 32'd256,
+  /// Number of words of an individual memory bank.
+  /// Determines the address width of the request output.
+  parameter int unsigned TbNumWords     = 32'd8192,
+  /// Number of connected memory banks.
+  parameter int unsigned TbNumBanks     = 32'd8,
+  /// Data width of an individual memory bank.
+  parameter int unsigned TbMemDataWidth = 32'd64,
+  /// Latancy in cycles of a memory bank.
+  parameter int unsigned TbMemLatency   = 32'd2,
+  /// Number of writes performed by the testbench.
+  parameter int unsigned NumWrites    = 32'd5000,
+  /// Number of writes performed by the testbench.
+  parameter int unsigned NumReads     = 32'd10000
+);
+  // test bench params
+  localparam time CyclTime = 10ns;
+  localparam time ApplTime = 2ns;
+  localparam time TestTime = 8ns;
+
+  // localparam and typedefs for AXI4+ATOP
+  localparam int unsigned AxiIdWidth   = 32'd6;
+  localparam int unsigned AxiAddrWidth = 32'd64;
+  localparam int unsigned AxiStrbWidth = TbAxiDataWidth / 8;
+  localparam int unsigned AxiUserWidth = 32'd4;
+
+  typedef logic [AxiAddrWidth-1:0] axi_addr_t;
+
+  // AXI test defines
+  typedef axi_test::rand_axi_master #(
+    // AXI interface parameters
+    .AW ( AxiAddrWidth ),
+    .DW ( TbAxiDataWidth ),
+    .IW ( AxiIdWidth   ),
+    .UW ( AxiUserWidth ),
+    // Stimuli application and test time
+    .TA ( ApplTime     ),
+    .TT ( TestTime     ),
+    // Maximum number of read and write transactions in flight
+    .MAX_READ_TXNS        (   20 ),
+    .MAX_WRITE_TXNS       (   20 ),
+    // Upper and lower bounds on wait cycles on Ax, W, and resp (R and B) channels
+    .AX_MIN_WAIT_CYCLES   (    0 ),
+    .AX_MAX_WAIT_CYCLES   (    0 ),
+    .W_MIN_WAIT_CYCLES    (    0 ),
+    .W_MAX_WAIT_CYCLES    (    0 ),
+    .RESP_MIN_WAIT_CYCLES (    0 ),
+    .RESP_MAX_WAIT_CYCLES (    0 ),
+    // AXI feature usage
+    .AXI_MAX_BURST_LEN    (    0 ), // maximum number of beats in burst; 0 = AXI max (256)
+    .TRAFFIC_SHAPING      (    0 ),
+    .AXI_EXCLS            ( 1'b0 ),
+    .AXI_ATOPS            ( 1'b0 ),
+    .AXI_BURST_FIXED      ( 1'b0 ),
+    .AXI_BURST_INCR       ( 1'b1 ),
+    .AXI_BURST_WRAP       ( 1'b0 )
+  ) rand_axi_master_t;
+
+  // memory defines
+  localparam int unsigned MemAddrWidth = $clog2(TbNumWords);
+
+  localparam int unsigned MemBufDepth  = 1;
+  // addresses
+  localparam axi_addr_t StartAddr = axi_addr_t'(64'h0);
+  localparam axi_addr_t EndAddr   = axi_addr_t'(StartAddr + 32'd2 * TbNumWords * TbAxiDataWidth/32'd8);
+
+  typedef logic [MemAddrWidth-1:0]   mem_addr_t;
+  typedef logic [5:0]                mem_atop_t;
+  typedef logic [TbMemDataWidth-1:0]   mem_data_t;
+  typedef logic [TbMemDataWidth/8-1:0] mem_strb_t;
+
+  // sim signals
+  logic end_of_sim;
+
+  // dut signals
+  logic clk, rst_n, one_dut_active;
+
+  logic      [1:0]          dut_busy;
+  logic      [TbNumBanks-1:0] mem_req;
+  logic      [TbNumBanks-1:0] mem_gnt;
+  mem_addr_t [TbNumBanks-1:0] mem_addr;
+  mem_data_t [TbNumBanks-1:0] mem_wdata;
+  mem_strb_t [TbNumBanks-1:0] mem_strb;
+  logic      [TbNumBanks-1:0] mem_we;
+  mem_atop_t [TbNumBanks-1:0] mem_atop;
+  logic      [TbNumBanks-1:0] mem_rvalid;
+  mem_data_t [TbNumBanks-1:0] mem_rdata;
+
+  assign one_dut_active = |dut_busy;
+
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth ),
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_USER_WIDTH ( AxiUserWidth )
+  ) mem_axi_dv (clk);
+
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth ),
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_USER_WIDTH ( AxiUserWidth )
+  ) mem_axi ();
+  `AXI_ASSIGN(mem_axi, mem_axi_dv)
+
+  // stimuli generation
+  initial begin : proc_axi_master
+    static rand_axi_master_t rand_axi_master = new ( mem_axi_dv );
+    end_of_sim <= 1'b0;
+    rand_axi_master.add_memory_region(StartAddr, EndAddr, axi_pkg::DEVICE_NONBUFFERABLE);
+    rand_axi_master.reset();
+    @(posedge rst_n);
+    @(posedge clk);
+    @(posedge clk);
+
+    rand_axi_master.run(NumReads, NumWrites);
+    end_of_sim <= 1'b1;
+  end
+
+  // memory banks
+  for (genvar i = 0; i < TbNumBanks; i++) begin : gen_tc_sram
+    tc_sram #(
+      .NumWords    ( TbNumWords   ),
+      .DataWidth   ( TbMemDataWidth ),
+      .ByteWidth   ( 32'd8        ),
+      .NumPorts    ( 32'd1        ),
+      .Latency     ( TbMemLatency   ),
+      .SimInit     ( "none"       ),
+      .PrintSimCfg ( 1'b1         )
+    ) i_tc_sram_bank (
+      .clk_i   ( clk          ),
+      .rst_ni  ( rst_n        ),
+      .req_i   ( mem_req[i]   ),
+      .we_i    ( mem_we[i]    ),
+      .addr_i  ( mem_addr[i]  ),
+      .wdata_i ( mem_wdata[i] ),
+      .be_i    ( mem_strb[i]  ),
+      .rdata_o ( mem_rdata[i] )
+    );
+    // always be ready
+    assign mem_gnt[i] = 1'b1;
+    // generate mem_rvalid signal
+    if (TbMemLatency == 0) begin : gen_no_mem__lat
+      assign mem_rvalid[i] = mem_req[i];
+    end else begin : gen_mem_lat
+      logic [TbMemLatency-1:0] mem_lat_q, mem_lat_d;
+      `FFARN(mem_lat_q, mem_lat_d, '0, clk, rst_n)
+      assign mem_lat_d[TbMemLatency-1] = mem_req[i];
+      if (TbMemLatency > 1) begin
+        for (genvar lat_i = 0; lat_i < TbMemLatency - 1; lat_i++) begin
+          assign mem_lat_d[lat_i] = mem_lat_q[lat_i+1];
+        end
+      end
+      assign mem_rvalid[i] = mem_lat_q[0];
+    end
+  end
+
+  // Clock generator
+  clk_rst_gen #(
+    .CLK_PERIOD     ( CyclTime ),
+    .RST_CLK_CYCLES ( 5        )
+  ) i_clk_rst_gen (
+    .clk_o  ( clk   ),
+    .rst_no ( rst_n )
+  );
+
+  // Design under test
+  axi_to_mem_banked_intf #(
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth ),
+    .AXI_USER_WIDTH ( AxiUserWidth ),
+    .MEM_NUM_BANKS  ( TbNumBanks     ),
+    .MEM_ADDR_WIDTH ( MemAddrWidth ),
+    .MEM_DATA_WIDTH ( TbMemDataWidth ),
+    .MEM_LATENCY    ( TbMemLatency   )
+  ) i_axi_to_mem_banked_dut (
+    .clk_i             ( clk       ),
+    .rst_ni            ( rst_n     ),
+    .test_i            ( 1'b0      ),
+    .axi_to_mem_busy_o ( dut_busy  ),
+    .slv               ( mem_axi   ),
+    .mem_req_o         ( mem_req   ),
+    .mem_gnt_i         ( mem_gnt   ),
+    .mem_add_o         ( mem_addr  ), // byte address
+    .mem_wdata_o       ( mem_wdata ), // write data
+    .mem_be_o          ( mem_strb  ), // byte-wise strobe
+    .mem_atop_o        ( mem_atop  ), // atomic operation
+    .mem_we_o          ( mem_we    ), // write enable
+    .mem_rdata_i       ( mem_rdata )  // read data
+  );
+
+  // monitoring
+  logic aw_beat, aw_stall, w_beat, b_beat, ar_beat, ar_stall, r_beat;
+  assign aw_beat  = mem_axi.aw_valid & mem_axi.aw_ready;
+  assign aw_stall = mem_axi.aw_valid & !mem_axi.aw_ready;
+  assign  w_beat  = mem_axi.w_valid  & mem_axi.w_ready;
+  assign  b_beat  = mem_axi.b_valid  & mem_axi.b_ready;
+  assign ar_beat  = mem_axi.ar_valid & mem_axi.ar_ready;
+  assign ar_stall = mem_axi.ar_valid & !mem_axi.ar_ready;
+  assign  r_beat  = mem_axi.r_valid  & mem_axi.r_ready;
+
+  int unsigned aw_open;
+  int unsigned ar_open;
+
+  initial begin : proc_monitor
+    automatic bit aw_new = 1;
+    automatic bit w_new  = 1;
+    automatic bit b_new  = 1;
+    automatic bit ar_new = 1;
+    automatic bit r_new  = 1;
+
+
+    automatic longint      wc_cnt     = 0;
+    automatic longint      rc_cnt     = 0;
+    automatic longint      w_cnt      = 0;
+    automatic longint      r_cnt      = 0;
+
+    automatic longint      busy_cnt;
+    automatic longint      dut_busy_cnt [TbNumBanks];
+    automatic real         bank_busy_percent;
+    automatic real         axi_busy_percent;
+    automatic real         tmp;
+
+    aw_open           = 0;
+    ar_open           = 0;
+    bank_busy_percent = 0;
+    axi_busy_percent  = 0;
+    for (int i = 0; i < TbNumBanks; i++) begin
+      dut_busy_cnt[i] = 0;
+    end
+    $display("###############################################################################");
+    $display("Sim Parameter:");
+    $display("###############################################################################");
+    $display("TbAxiDataWidth: %0d", TbAxiDataWidth);
+    $display("TbMemDataWidth: %0d", TbMemDataWidth);
+    $display("TbNumBanks:     %0d", TbNumBanks);
+    $display("TbMemLatency:   %0d", TbMemLatency);
+    $display("###############################################################################");
+
+    @(posedge rst_n);
+    forever begin
+      @(posedge clk);
+
+      #TestTime;
+      // determine the first valid of an AW transaction
+      if (mem_axi.aw_valid) begin
+        if (aw_new) begin
+          aw_open++;
+          if (!mem_axi.aw_ready) begin
+            aw_new = 0;
+          end
+        end else begin
+          if (mem_axi.aw_ready) begin
+            aw_new = 1;
+          end
+        end
+      end
+
+      // determine the first valid of an AR transaction
+      if (mem_axi.ar_valid) begin
+        if (ar_new) begin
+          ar_open++;
+          if (!mem_axi.ar_ready) begin
+            ar_new = 0;
+          end
+        end else begin
+          if (mem_axi.ar_ready) begin
+            ar_new = 1;
+          end
+        end
+      end
+
+      if (b_beat) begin
+        aw_open--;
+      end
+      if (r_beat && mem_axi.r_last) begin
+        ar_open--;
+      end
+
+      if (aw_open > 0) begin
+        wc_cnt++;
+      end
+      if (ar_open > 0) begin
+        rc_cnt++;
+      end
+
+      if (w_beat) begin
+        w_cnt++;
+      end
+      if (r_beat) begin
+        r_cnt++;
+      end
+
+      if ((aw_open > 0) || (ar_open > 0)) begin
+        busy_cnt++;
+      end
+
+      for (int unsigned i = 0; i < TbNumBanks; i++) begin
+        if (mem_req[i]) begin
+          dut_busy_cnt[i]++;
+        end
+      end
+
+
+      if (end_of_sim) begin
+        @(posedge clk);
+        $display("###############################################################################");
+        $display("Statistics:");
+        $display("###############################################################################");
+        $display("Writes:");
+        $display("Cycles Open write tnx: %0d", wc_cnt);
+        $display("Write beat count:      %0d", w_cnt);
+        $display("Write utilization:     %0f", real'(w_cnt) / real'(wc_cnt) * 100);
+        axi_busy_percent += real'(w_cnt) / real'(wc_cnt) * 100;
+                $display("###############################################################################");
+        $display("Reads:");
+        $display("Cycles Open read tnx:  %0d", rc_cnt);
+        $display("Read beat count:       %0d", r_cnt);
+        $display("Read utilization:      %0f", real'(r_cnt) / real'(rc_cnt) * 100);
+        axi_busy_percent += real'(r_cnt) / real'(rc_cnt) * 100;
+        $display("###############################################################################");
+        for (int unsigned i = 0; i < TbNumBanks; i++) begin
+          bank_busy_percent += real'(dut_busy_cnt[i]) / real'(busy_cnt) * 100;
+          $display("Bank %0d utilization: %0f", i, real'(dut_busy_cnt[i]) / real'(busy_cnt) * 100);
+          tmp = dut_busy_cnt[i];
+          $display("Bank %0d requests: %0f", i, tmp);
+          tmp = busy_cnt;
+          $display("Bank %0d busy cycles: %0f", i, tmp);
+        end
+        $display("Sum bank utilization:      %0f", bank_busy_percent);
+        $display("Sum axi utilization:       %0f", axi_busy_percent);
+        $display("###############################################################################");
+        $stop();
+      end
+    end
+  end
+
+  initial begin : proc_sim_progress
+    longint unsigned       ActAwTnx;
+    longint unsigned       ActArTnx;
+    automatic int unsigned PrintInterv = 100;
+
+    ActAwTnx = 0;
+    ActArTnx = 0;
+    $display("Start Addr: %0h", StartAddr);
+    $display("End   addr: %0h", EndAddr);
+
+    @(posedge rst_n);
+    forever begin
+      @(posedge clk);
+      #TestTime;
+
+      if (aw_beat) begin
+        if (ActAwTnx % PrintInterv == 0) begin
+          $display("%t > AW Transaction %d of %d ", $time(), ActAwTnx, NumWrites);
+        end
+        ActAwTnx++;
+      end
+      if (ar_beat) begin
+        if (ActArTnx % PrintInterv == 0) begin
+          $display("%t > AR Transaction %d of %d ", $time(), ActArTnx, NumReads);
+        end
+        ActArTnx++;
+      end
+
+      if (end_of_sim) begin
+        break;
+      end
+    end
+  end
+
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth ),
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_USER_WIDTH ( AxiUserWidth )
+  ) monitor_dv (clk);
+
+  `AXI_ASSIGN_MONITOR(monitor_dv, mem_axi)
+
+  typedef axi_test::axi_scoreboard #(
+    .IW ( AxiIdWidth   ),
+    .AW ( AxiAddrWidth ),
+    .DW ( TbAxiDataWidth ),
+    .UW ( AxiUserWidth ),
+    .TT ( TestTime     )
+  ) axi_scoreboard_t;
+  axi_scoreboard_t axi_scoreboard = new(monitor_dv);
+  initial begin : proc_scoreboard
+    axi_scoreboard.enable_all_checks();
+    @(posedge rst_n);
+    axi_scoreboard.monitor();
+    wait (end_of_sim);
+  end
+
+endmodule

--- a/test/tb_axi_to_mem_banked.sv
+++ b/test/tb_axi_to_mem_banked.sv
@@ -29,9 +29,9 @@ module tb_axi_to_mem_banked #(
   /// Latancy in cycles of a memory bank.
   parameter int unsigned TbMemLatency   = 32'd2,
   /// Number of writes performed by the testbench.
-  parameter int unsigned NumWrites    = 32'd5000,
+  parameter int unsigned NumWrites      = 32'd10000,
   /// Number of writes performed by the testbench.
-  parameter int unsigned NumReads     = 32'd10000
+  parameter int unsigned NumReads       = 32'd10000
 );
   // test bench params
   localparam time CyclTime = 10ns;

--- a/test/tb_axi_xbar.sv
+++ b/test/tb_axi_xbar.sv
@@ -27,12 +27,12 @@ module tb_axi_xbar #(
   /// Number of AXI slaves connected to the xbar. (Number of master ports)
   parameter int unsigned TbNumSlaves         = 32'd8,
   /// Number of write transactions per master.
-  parameter int unsigned TbNumWrites         = 32'd1000,
+  parameter int unsigned TbNumWrites         = 32'd100,
   /// Number of read transactions per master.
-  parameter int unsigned TbNumReads          = 32'd1000,
+  parameter int unsigned TbNumReads          = 32'd100,
   /// AXI4+ATOP ID wisth of the masters connected to the slave ports of the DUT.
   /// The ID width of the salves is calulated depending on the xbar configuration.
-  parameter int unsigned TbAxiIdWidthMasters = 32'd4,
+  parameter int unsigned TbAxiIdWidthMasters = 32'd5,
   /// The used ID width of the DUT.
   /// Has to be `TbAxiIdWidthMasters >= TbAxiIdUsed`.
   parameter int unsigned TbAxiIdUsed         = 32'd3,

--- a/test/tb_axi_xbar.sv
+++ b/test/tb_axi_xbar.sv
@@ -30,17 +30,17 @@ module tb_axi_xbar #(
   parameter int unsigned TbNumWrites         = 32'd200,
   /// Number of read transactions per master.
   parameter int unsigned TbNumReads          = 32'd200,
-  /// AXI4+ATOP ID wisth of the masters connected to the slave ports of the DUT.
-  /// The ID width of the salves is calulated depending on the xbar configuration.
+  /// AXI4+ATOP ID width of the masters connected to the slave ports of the DUT.
+  /// The ID width of the slaves is calculated depending on the xbar configuration.
   parameter int unsigned TbAxiIdWidthMasters = 32'd5,
   /// The used ID width of the DUT.
   /// Has to be `TbAxiIdWidthMasters >= TbAxiIdUsed`.
   parameter int unsigned TbAxiIdUsed         = 32'd3,
   /// Data width of the AXI channels.
   parameter int unsigned TbAxiDataWidth      = 32'd64,
-  /// Pipeline stages in the xbar itself. (Between Demux and mux)
+  /// Pipeline stages in the xbar itself (between demux and mux).
   parameter int unsigned TbPipeline          = 32'd1,
-  /// Eanable ATOP generation
+  /// Enable ATOP generation
   parameter bit          TbEnAtop            = 1'b1
 );
 

--- a/test/tb_axi_xbar.sv
+++ b/test/tb_axi_xbar.sv
@@ -27,9 +27,9 @@ module tb_axi_xbar #(
   /// Number of AXI slaves connected to the xbar. (Number of master ports)
   parameter int unsigned TbNumSlaves         = 32'd8,
   /// Number of write transactions per master.
-  parameter int unsigned TbNumWrites         = 32'd100,
+  parameter int unsigned TbNumWrites         = 32'd200,
   /// Number of read transactions per master.
-  parameter int unsigned TbNumReads          = 32'd100,
+  parameter int unsigned TbNumReads          = 32'd200,
   /// AXI4+ATOP ID wisth of the masters connected to the slave ports of the DUT.
   /// The ID width of the salves is calulated depending on the xbar configuration.
   parameter int unsigned TbAxiIdWidthMasters = 32'd5,

--- a/test/tb_axi_xbar.sv
+++ b/test/tb_axi_xbar.sv
@@ -20,49 +20,62 @@
 `include "axi/typedef.svh"
 `include "axi/assign.svh"
 
-module tb_axi_xbar;
-  // Dut parameters
-  localparam int unsigned NoMasters   = 6;    // How many Axi Masters there are
-  localparam int unsigned NoSlaves    = 8;    // How many Axi Slaves  there are
-  // Random master no Transactions
-  localparam int unsigned NoWrites   = 1000;  // How many writes per master
-  localparam int unsigned NoReads    = 1000;  // How many reads per master
-  // Random Master Atomics
-  localparam bit          EnAtop     = 1'b1;
-  // timing parameters
+/// Testbench for the module `axi_xbar`.
+module tb_axi_xbar #(
+  /// Number of AXI masters connected to the xbar. (Number of slave ports)
+  parameter int unsigned TbNumMasters        = 32'd6,
+  /// Number of AXI slaves connected to the xbar. (Number of master ports)
+  parameter int unsigned TbNumSlaves         = 32'd8,
+  /// Number of write transactions per master.
+  parameter int unsigned TbNumWrites         = 32'd1000,
+  /// Number of read transactions per master.
+  parameter int unsigned TbNumReads          = 32'd1000,
+  /// AXI4+ATOP ID wisth of the masters connected to the slave ports of the DUT.
+  /// The ID width of the salves is calulated depending on the xbar configuration.
+  parameter int unsigned TbAxiIdWidthMasters = 32'd4,
+  /// The used ID width of the DUT.
+  /// Has to be `TbAxiIdWidthMasters >= TbAxiIdUsed`.
+  parameter int unsigned TbAxiIdUsed         = 32'd3,
+  /// Data width of the AXI channels.
+  parameter int unsigned TbAxiDataWidth      = 32'd64,
+  /// Pipeline stages in the xbar itself. (Between Demux and mux)
+  parameter int unsigned TbPipeline          = 32'd1,
+  /// Eanable ATOP generation
+  parameter bit          TbEnAtop            = 1'b1
+);
+
+  // TB timing parameters
   localparam time CyclTime = 10ns;
   localparam time ApplTime =  2ns;
   localparam time TestTime =  8ns;
 
-  // axi configuration
-  localparam int unsigned AxiIdWidthMasters =  4;
-  localparam int unsigned AxiIdUsed         =  3; // Has to be <= AxiIdWidthMasters
-  localparam int unsigned AxiIdWidthSlaves  =  AxiIdWidthMasters + $clog2(NoMasters);
-  localparam int unsigned AxiAddrWidth      =  32;    // Axi Address Width
-  localparam int unsigned AxiDataWidth      =  64;    // Axi Data Width
-  localparam int unsigned AxiStrbWidth      =  AxiDataWidth / 8;
-  localparam int unsigned AxiUserWidth      =  5;
-  // in the bench can change this variables which are set here freely
+  // AXI configuration which is automatically derived.
+  localparam int unsigned TbAxiIdWidthSlaves =  TbAxiIdWidthMasters + $clog2(TbNumMasters);
+  localparam int unsigned TbAxiAddrWidth     =  32'd32;
+  localparam int unsigned TbAxiStrbWidth     =  TbAxiDataWidth / 8;
+  localparam int unsigned TbAxiUserWidth     =  5;
+  // In the bench can change this variables which are set here freely,
   localparam axi_pkg::xbar_cfg_t xbar_cfg = '{
-    NoSlvPorts:         NoMasters,
-    NoMstPorts:         NoSlaves,
+    NoSlvPorts:         TbNumMasters,
+    NoMstPorts:         TbNumSlaves,
     MaxMstTrans:        10,
     MaxSlvTrans:        6,
     FallThrough:        1'b0,
     LatencyMode:        axi_pkg::CUT_ALL_AX,
-    AxiIdWidthSlvPorts: AxiIdWidthMasters,
-    AxiIdUsedSlvPorts:  AxiIdUsed,
-    AxiAddrWidth:       AxiAddrWidth,
-    AxiDataWidth:       AxiDataWidth,
-    NoAddrRules:        8
+    PipelineStages:     TbPipeline,
+    AxiIdWidthSlvPorts: TbAxiIdWidthMasters,
+    AxiIdUsedSlvPorts:  TbAxiIdUsed,
+    AxiAddrWidth:       TbAxiAddrWidth,
+    AxiDataWidth:       TbAxiDataWidth,
+    NoAddrRules:        TbNumSlaves
   };
-  typedef logic [AxiIdWidthMasters-1:0] id_mst_t;
-  typedef logic [AxiIdWidthSlaves-1:0]  id_slv_t;
-  typedef logic [AxiAddrWidth-1:0]      addr_t;
-  typedef axi_pkg::xbar_rule_32_t       rule_t; // Has to be the same width as axi addr
-  typedef logic [AxiDataWidth-1:0]      data_t;
-  typedef logic [AxiStrbWidth-1:0]      strb_t;
-  typedef logic [AxiUserWidth-1:0]      user_t;
+  typedef logic [TbAxiIdWidthMasters-1:0] id_mst_t;
+  typedef logic [TbAxiIdWidthSlaves-1:0]  id_slv_t;
+  typedef logic [TbAxiAddrWidth-1:0]      addr_t;
+  typedef axi_pkg::xbar_rule_32_t         rule_t; // Has to be the same width as axi addr
+  typedef logic [TbAxiDataWidth-1:0]      data_t;
+  typedef logic [TbAxiStrbWidth-1:0]      strb_t;
+  typedef logic [TbAxiUserWidth-1:0]      user_t;
 
   `AXI_TYPEDEF_AW_CHAN_T(aw_chan_mst_t, addr_t, id_mst_t, user_t)
   `AXI_TYPEDEF_AW_CHAN_T(aw_chan_slv_t, addr_t, id_slv_t, user_t)
@@ -80,40 +93,43 @@ module tb_axi_xbar;
   `AXI_TYPEDEF_REQ_T(slv_req_t, aw_chan_slv_t, w_chan_t, ar_chan_slv_t)
   `AXI_TYPEDEF_RESP_T(slv_resp_t, b_chan_slv_t, r_chan_slv_t)
 
-  localparam rule_t [xbar_cfg.NoAddrRules-1:0] AddrMap = '{
-    '{idx: 32'd7, start_addr: 32'h0001_0000, end_addr: 32'h0001_1000},
-    '{idx: 32'd6, start_addr: 32'h0000_9000, end_addr: 32'h0001_0000},
-    '{idx: 32'd5, start_addr: 32'h0000_8000, end_addr: 32'h0000_9000},
-    '{idx: 32'd4, start_addr: 32'h0000_7000, end_addr: 32'h0000_8000},
-    '{idx: 32'd3, start_addr: 32'h0000_6300, end_addr: 32'h0000_7000},
-    '{idx: 32'd2, start_addr: 32'h0000_4000, end_addr: 32'h0000_6300},
-    '{idx: 32'd1, start_addr: 32'h0000_3000, end_addr: 32'h0000_4000},
-    '{idx: 32'd0, start_addr: 32'h0000_0000, end_addr: 32'h0000_3000}
-  };
+  // Each slave has its own address range:
+  localparam rule_t [xbar_cfg.NoAddrRules-1:0] AddrMap = addr_map_gen();
+
+  function rule_t [xbar_cfg.NoAddrRules-1:0] addr_map_gen ();
+    for (int unsigned i = 0; i < xbar_cfg.NoAddrRules; i++) begin
+      addr_map_gen[i] = rule_t'{
+        idx:        unsigned'(i),
+        start_addr:  i    * 32'h0000_2000,
+        end_addr:   (i+1) * 32'h0000_2000,
+        default:    '0
+      };
+    end
+  endfunction
 
   typedef axi_test::axi_rand_master #(
     // AXI interface parameters
-    .AW ( AxiAddrWidth       ),
-    .DW ( AxiDataWidth       ),
-    .IW ( AxiIdWidthMasters  ),
-    .UW ( AxiUserWidth       ),
+    .AW ( TbAxiAddrWidth       ),
+    .DW ( TbAxiDataWidth       ),
+    .IW ( TbAxiIdWidthMasters  ),
+    .UW ( TbAxiUserWidth       ),
     // Stimuli application and test time
-    .TA ( ApplTime           ),
-    .TT ( TestTime           ),
+    .TA ( ApplTime             ),
+    .TT ( TestTime             ),
     // Maximum number of read and write transactions in flight
-    .MAX_READ_TXNS  ( 20     ),
-    .MAX_WRITE_TXNS ( 20     ),
-    .AXI_ATOPS      ( EnAtop )
+    .MAX_READ_TXNS  ( 20       ),
+    .MAX_WRITE_TXNS ( 20       ),
+    .AXI_ATOPS      ( TbEnAtop )
   ) axi_rand_master_t;
   typedef axi_test::axi_rand_slave #(
     // AXI interface parameters
-    .AW ( AxiAddrWidth     ),
-    .DW ( AxiDataWidth     ),
-    .IW ( AxiIdWidthSlaves ),
-    .UW ( AxiUserWidth     ),
+    .AW ( TbAxiAddrWidth     ),
+    .DW ( TbAxiDataWidth     ),
+    .IW ( TbAxiIdWidthSlaves ),
+    .UW ( TbAxiUserWidth     ),
     // Stimuli application and test time
-    .TA ( ApplTime         ),
-    .TT ( TestTime         )
+    .TA ( ApplTime           ),
+    .TT ( TestTime           )
   ) axi_rand_slave_t;
 
   // -------------
@@ -122,62 +138,62 @@ module tb_axi_xbar;
   logic clk;
   // DUT signals
   logic rst_n;
-  logic [NoMasters-1:0] end_of_sim;
+  logic [TbNumMasters-1:0] end_of_sim;
 
   // master structs
-  mst_req_t  [NoMasters-1:0] masters_req;
-  mst_resp_t [NoMasters-1:0] masters_resp;
+  mst_req_t  [TbNumMasters-1:0] masters_req;
+  mst_resp_t [TbNumMasters-1:0] masters_resp;
 
   // slave structs
-  slv_req_t  [NoSlaves-1:0] slaves_req;
-  slv_resp_t [NoSlaves-1:0] slaves_resp;
+  slv_req_t  [TbNumSlaves-1:0]  slaves_req;
+  slv_resp_t [TbNumSlaves-1:0]  slaves_resp;
 
   // -------------------------------
   // AXI Interfaces
   // -------------------------------
   AXI_BUS #(
-    .AXI_ADDR_WIDTH ( AxiAddrWidth      ),
-    .AXI_DATA_WIDTH ( AxiDataWidth      ),
-    .AXI_ID_WIDTH   ( AxiIdWidthMasters ),
-    .AXI_USER_WIDTH ( AxiUserWidth      )
-  ) master [NoMasters-1:0] ();
+    .AXI_ADDR_WIDTH ( TbAxiAddrWidth      ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth      ),
+    .AXI_ID_WIDTH   ( TbAxiIdWidthMasters ),
+    .AXI_USER_WIDTH ( TbAxiUserWidth      )
+  ) master [TbNumMasters-1:0] ();
   AXI_BUS_DV #(
-    .AXI_ADDR_WIDTH ( AxiAddrWidth      ),
-    .AXI_DATA_WIDTH ( AxiDataWidth      ),
-    .AXI_ID_WIDTH   ( AxiIdWidthMasters ),
-    .AXI_USER_WIDTH ( AxiUserWidth      )
-  ) master_dv [NoMasters-1:0] (clk);
+    .AXI_ADDR_WIDTH ( TbAxiAddrWidth      ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth      ),
+    .AXI_ID_WIDTH   ( TbAxiIdWidthMasters ),
+    .AXI_USER_WIDTH ( TbAxiUserWidth      )
+  ) master_dv [TbNumMasters-1:0] (clk);
   AXI_BUS_DV #(
-    .AXI_ADDR_WIDTH ( AxiAddrWidth      ),
-    .AXI_DATA_WIDTH ( AxiDataWidth      ),
-    .AXI_ID_WIDTH   ( AxiIdWidthMasters ),
-    .AXI_USER_WIDTH ( AxiUserWidth      )
-  ) master_monitor_dv [NoMasters-1:0] (clk);
-  for (genvar i = 0; i < NoMasters; i++) begin : gen_conn_dv_masters
+    .AXI_ADDR_WIDTH ( TbAxiAddrWidth      ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth      ),
+    .AXI_ID_WIDTH   ( TbAxiIdWidthMasters ),
+    .AXI_USER_WIDTH ( TbAxiUserWidth      )
+  ) master_monitor_dv [TbNumMasters-1:0] (clk);
+  for (genvar i = 0; i < TbNumMasters; i++) begin : gen_conn_dv_masters
     `AXI_ASSIGN (master[i], master_dv[i])
     `AXI_ASSIGN_TO_REQ(masters_req[i], master[i])
     `AXI_ASSIGN_FROM_RESP(master[i], masters_resp[i])
   end
 
   AXI_BUS #(
-    .AXI_ADDR_WIDTH ( AxiAddrWidth     ),
-    .AXI_DATA_WIDTH ( AxiDataWidth     ),
-    .AXI_ID_WIDTH   ( AxiIdWidthSlaves ),
-    .AXI_USER_WIDTH ( AxiUserWidth     )
-  ) slave [NoSlaves-1:0] ();
+    .AXI_ADDR_WIDTH ( TbAxiAddrWidth     ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth     ),
+    .AXI_ID_WIDTH   ( TbAxiIdWidthSlaves ),
+    .AXI_USER_WIDTH ( TbAxiUserWidth     )
+  ) slave [TbNumSlaves-1:0] ();
   AXI_BUS_DV #(
-    .AXI_ADDR_WIDTH ( AxiAddrWidth     ),
-    .AXI_DATA_WIDTH ( AxiDataWidth     ),
-    .AXI_ID_WIDTH   ( AxiIdWidthSlaves ),
-    .AXI_USER_WIDTH ( AxiUserWidth     )
-  ) slave_dv [NoSlaves-1:0](clk);
+    .AXI_ADDR_WIDTH ( TbAxiAddrWidth     ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth     ),
+    .AXI_ID_WIDTH   ( TbAxiIdWidthSlaves ),
+    .AXI_USER_WIDTH ( TbAxiUserWidth     )
+  ) slave_dv [TbNumSlaves-1:0](clk);
   AXI_BUS_DV #(
-    .AXI_ADDR_WIDTH ( AxiAddrWidth     ),
-    .AXI_DATA_WIDTH ( AxiDataWidth     ),
-    .AXI_ID_WIDTH   ( AxiIdWidthSlaves ),
-    .AXI_USER_WIDTH ( AxiUserWidth     )
-  ) slave_monitor_dv [NoSlaves-1:0](clk);
-  for (genvar i = 0; i < NoSlaves; i++) begin : gen_conn_dv_slaves
+    .AXI_ADDR_WIDTH ( TbAxiAddrWidth     ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth     ),
+    .AXI_ID_WIDTH   ( TbAxiIdWidthSlaves ),
+    .AXI_USER_WIDTH ( TbAxiUserWidth     )
+  ) slave_monitor_dv [TbNumSlaves-1:0](clk);
+  for (genvar i = 0; i < TbNumSlaves; i++) begin : gen_conn_dv_slaves
     `AXI_ASSIGN(slave_dv[i], slave[i])
     `AXI_ASSIGN_FROM_REQ(slave[i], slaves_req[i])
     `AXI_ASSIGN_TO_RESP(slaves_resp[i], slave[i])
@@ -186,23 +202,23 @@ module tb_axi_xbar;
   // AXI Rand Masters and Slaves
   // -------------------------------
   // Masters control simulation run time
-  for (genvar i = 0; i < NoMasters; i++) begin : gen_rand_master
-      static axi_rand_master_t axi_rand_master = new ( master_dv[i] );
+  for (genvar i = 0; i < TbNumMasters; i++) begin : gen_rand_master
     initial begin
+      static axi_rand_master_t axi_rand_master = new ( master_dv[i] );
       end_of_sim[i] <= 1'b0;
       axi_rand_master.add_memory_region(AddrMap[0].start_addr,
                                       AddrMap[xbar_cfg.NoAddrRules-1].end_addr,
                                       axi_pkg::DEVICE_NONBUFFERABLE);
       axi_rand_master.reset();
       @(posedge rst_n);
-      axi_rand_master.run(NoReads, NoWrites);
+      axi_rand_master.run(TbNumReads, TbNumWrites);
       end_of_sim[i] <= 1'b1;
     end
   end
 
-  for (genvar i = 0; i < NoSlaves; i++) begin : gen_rand_slave
-      static axi_rand_slave_t axi_rand_slave = new( slave_dv[i] );
+  for (genvar i = 0; i < TbNumSlaves; i++) begin : gen_rand_slave
     initial begin
+      static axi_rand_slave_t axi_rand_slave = new( slave_dv[i] );
       axi_rand_slave.reset();
       @(posedge rst_n);
       axi_rand_slave.run();
@@ -211,13 +227,13 @@ module tb_axi_xbar;
 
   initial begin : proc_monitor
     static tb_axi_xbar_pkg::axi_xbar_monitor #(
-      .AxiAddrWidth      ( AxiAddrWidth         ),
-      .AxiDataWidth      ( AxiDataWidth         ),
-      .AxiIdWidthMasters ( AxiIdWidthMasters    ),
-      .AxiIdWidthSlaves  ( AxiIdWidthSlaves     ),
-      .AxiUserWidth      ( AxiUserWidth         ),
-      .NoMasters         ( NoMasters            ),
-      .NoSlaves          ( NoSlaves             ),
+      .AxiAddrWidth      ( TbAxiAddrWidth       ),
+      .AxiDataWidth      ( TbAxiDataWidth       ),
+      .AxiIdWidthMasters ( TbAxiIdWidthMasters  ),
+      .AxiIdWidthSlaves  ( TbAxiIdWidthSlaves   ),
+      .AxiUserWidth      ( TbAxiUserWidth       ),
+      .NoMasters         ( TbNumMasters         ),
+      .NoSlaves          ( TbNumSlaves          ),
       .NoAddrRules       ( xbar_cfg.NoAddrRules ),
       .rule_t            ( rule_t               ),
       .AddrMap           ( AddrMap              ),
@@ -251,36 +267,36 @@ module tb_axi_xbar;
   // DUT
   //-----------------------------------
   axi_xbar #(
-    .Cfg          ( xbar_cfg ),
+    .Cfg          ( xbar_cfg      ),
     .slv_aw_chan_t( aw_chan_mst_t ),
     .mst_aw_chan_t( aw_chan_slv_t ),
-    .w_chan_t     (  w_chan_t     ),
-    .slv_b_chan_t (  b_chan_mst_t ),
-    .mst_b_chan_t (  b_chan_slv_t ),
+    .w_chan_t     ( w_chan_t      ),
+    .slv_b_chan_t ( b_chan_mst_t  ),
+    .mst_b_chan_t ( b_chan_slv_t  ),
     .slv_ar_chan_t( ar_chan_mst_t ),
     .mst_ar_chan_t( ar_chan_slv_t ),
-    .slv_r_chan_t (  r_chan_mst_t ),
-    .mst_r_chan_t (  r_chan_slv_t ),
+    .slv_r_chan_t ( r_chan_mst_t  ),
+    .mst_r_chan_t ( r_chan_slv_t  ),
     .slv_req_t    ( mst_req_t     ),
     .slv_resp_t   ( mst_resp_t    ),
     .mst_req_t    ( slv_req_t     ),
     .mst_resp_t   ( slv_resp_t    ),
-    .rule_t       (rule_t         )
+    .rule_t       ( rule_t        )
   ) i_xbar_dut (
-    .clk_i      ( clk      ),
-    .rst_ni     ( rst_n    ),
-    .test_i     ( 1'b0     ),
-    .slv_ports_req_i  ( masters_req  ),
-    .slv_ports_resp_o ( masters_resp ),
-    .mst_ports_req_o  ( slaves_req   ),
-    .mst_ports_resp_i ( slaves_resp  ),
-    .addr_map_i       ( AddrMap      ),
-    .en_default_mst_port_i ( '0      ),
-    .default_mst_port_i    ( '0      )
+    .clk_i                 ( clk          ),
+    .rst_ni                ( rst_n        ),
+    .test_i                ( 1'b0         ),
+    .slv_ports_req_i       ( masters_req  ),
+    .slv_ports_resp_o      ( masters_resp ),
+    .mst_ports_req_o       ( slaves_req   ),
+    .mst_ports_resp_i      ( slaves_resp  ),
+    .addr_map_i            ( AddrMap      ),
+    .en_default_mst_port_i ( '0           ),
+    .default_mst_port_i    ( '0           )
   );
 
   // logger for master modules
-  for (genvar i = 0; i < NoMasters; i++) begin : gen_master_logger
+  for (genvar i = 0; i < TbNumMasters; i++) begin : gen_master_logger
     axi_chan_logger #(
       .TestTime  ( TestTime      ), // Time after clock, where sampling happens
       .LoggerName( $sformatf("axi_logger_master_%0d", i)),
@@ -316,7 +332,7 @@ module tb_axi_xbar;
     );
   end
   // logger for slave modules
-  for (genvar i = 0; i < NoSlaves; i++) begin : gen_slave_logger
+  for (genvar i = 0; i < TbNumSlaves; i++) begin : gen_slave_logger
     axi_chan_logger #(
       .TestTime  ( TestTime      ), // Time after clock, where sampling happens
       .LoggerName( $sformatf("axi_logger_slave_%0d",i)),
@@ -353,7 +369,7 @@ module tb_axi_xbar;
   end
 
 
-  for (genvar i = 0; i < NoMasters; i++) begin : gen_connect_master_monitor
+  for (genvar i = 0; i < TbNumMasters; i++) begin : gen_connect_master_monitor
     assign master_monitor_dv[i].aw_id     = master[i].aw_id    ;
     assign master_monitor_dv[i].aw_addr   = master[i].aw_addr  ;
     assign master_monitor_dv[i].aw_len    = master[i].aw_len   ;
@@ -400,7 +416,7 @@ module tb_axi_xbar;
     assign master_monitor_dv[i].r_valid   = master[i].r_valid  ;
     assign master_monitor_dv[i].r_ready   = master[i].r_ready  ;
   end
-  for (genvar i = 0; i < NoSlaves; i++) begin : gen_connect_slave_monitor
+  for (genvar i = 0; i < TbNumSlaves; i++) begin : gen_connect_slave_monitor
     assign slave_monitor_dv[i].aw_id     = slave[i].aw_id    ;
     assign slave_monitor_dv[i].aw_addr   = slave[i].aw_addr  ;
     assign slave_monitor_dv[i].aw_len    = slave[i].aw_len   ;


### PR DESCRIPTION
This adds two modules:
- `axi_to_mem`: Salve module, max throughout simultaneous read/writes 50%, read or write 100%.
- `axi_to_mem_banked`: With enough banks 100% throughput with simultaneous reads/writes.

Notes to Bender:
For the  dependencies `pulp-platform/tech_cells_generic` has been directly added. In there the `tc_sram` module is used for the testbench to serve a memory model.
-> For all conflicts in the dependency tree of Bender, the versions specified by the Bender.yml of this repo has to be used.

Edit: Now bender.lock is also checked in so CI should pass now

This depends on changes form #116.