### PR TITLE
Fix ipapprox deps

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -8,7 +8,7 @@ package:
     - "Wolfgang Roenninger <wroennin@ethz.ch>"
 
 dependencies:
-  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.16.4 }
+  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.20.0 }
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.1.1 }
 
 export_include_dirs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
-- Bump `common_cells` to `1.20.0`
+- Update `common_cells` dependency to `1.20.0` to fix file order in IPApproX.
 
 ### Fixed
 - `doc/axi_lite_mailbox`: Fix position of `RFIFOL` and `WFIFOL` in `STATUS` register.
+- IPApproX:
+  - Add missing link against `common_cells_lib`.
+  - Fix include path for `common_cells`.
+  - Fix version specification of `common_verification`.
 
 
 ## 0.24.0 - 2020-10-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- Bump `common_cells` to `1.20.0`
 
 ### Fixed
 - `doc/axi_lite_mailbox`: Fix position of `RFIFOL` and `WFIFOL` in `STATUS` register.

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -1,5 +1,5 @@
 common_cells:
-    commit: v1.16.4
+    commit: v1.20.0
     group: pulp-platform
 
 common_verification:

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -1,7 +1,7 @@
 common_cells:
-    commit: 1.16.4
+    commit: v1.16.4
     group: pulp-platform
 
 common_verification:
-    commit: 0.1.1
+    commit: v0.1.1
     group: pulp-platform

--- a/src_files.yml
+++ b/src_files.yml
@@ -1,6 +1,10 @@
 axi:
+  vlog_opts: [
+    -L common_cells_lib
+  ]
   incdirs:
     - include
+    - ../../common_cells/include
   files:
     # Source files grouped in levels. Files in level 0 have no dependencies on files in this
     # package. Files in level 1 only depend on files in level 0, files in level 2 on files in


### PR DESCRIPTION
* Bump `common_cells` to  fixed version of `v1.20.0` (see https://github.com/pulp-platform/common_cells/pull/104)
* Link against `common_cells_lib`
* Fix include path. Note ipapprox has no understanding of include paths of dependencies or an option for global include paths (afaik). Anyway we have the same hack in other IPs such as fpnew and I'd rather benderize than hack around ipapprox more.