### PR TITLE
axi_xbar: Improve compatibility with vsim 10.6c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `AXI_BUS` (et al.) above.
 
 ### Fixed
+- `axi_xbar`: Improve compatibility with vsim version 10.6c (and earlier) by introducing a
+  workaround for a tool limitation (#133).
 
 
 ## 0.24.2 - 2021-01-11

--- a/src/axi_xbar.sv
+++ b/src/axi_xbar.sv
@@ -49,6 +49,9 @@ module axi_xbar #(
   slv_req_t  [Cfg.NoSlvPorts-1:0][Cfg.NoMstPorts:0]  slv_reqs;
   slv_resp_t [Cfg.NoSlvPorts-1:0][Cfg.NoMstPorts:0]  slv_resps;
 
+  // workaround for issue #133 (problem with vsim 10.6c)
+  localparam int unsigned cfg_NoMstPorts = Cfg.NoMstPorts;
+
   // signals into the axi_muxes, are of type slave as the multiplexer extends the ID
   slv_req_t  [Cfg.NoMstPorts-1:0][Cfg.NoSlvPorts-1:0] mst_reqs;
   slv_resp_t [Cfg.NoMstPorts-1:0][Cfg.NoSlvPorts-1:0] mst_resps;
@@ -165,7 +168,7 @@ module axi_xbar #(
       .test_i,  // Testmode enable
       // slave port
       .slv_req_i  ( slv_reqs[i][Cfg.NoMstPorts]   ),
-      .slv_resp_o ( slv_resps[i][Cfg.NoMstPorts]  )
+      .slv_resp_o ( slv_resps[i][cfg_NoMstPorts]  )
     );
   end
 


### PR DESCRIPTION
This is a workaround for a problem with vsim 10.6c, see issue #133.
That version of vsim reports an "illegal output or inout port connection
for port 'slv_resp_o'" error (`vsim-3053`).  More recent versions of
vsim do not have this problem.

This workaround preserves the original functionality.

Thanks @jsailer for implementing this in https://github.com/jsailer/axi/commit/877364c130ed14dce4016410ea004008a118e7ca.

Fixes #133.