### PR TITLE
Fix issue 122

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - `axi_xbar`: Improve compatibility with vsim version 10.6c (and earlier) by introducing a
   workaround for a tool limitation (#133).
+- `tb_axi_lite_regs`: Removed superfluous hardcoded assertion.
 
 
 ## 0.24.2 - 2021-01-11

--- a/scripts/run_vsim.sh
+++ b/scripts/run_vsim.sh
@@ -59,7 +59,11 @@ exec_test() {
         axi_lite_regs)
             for PRIV in 0 1; do
                 for SECU in 0 1; do
-                    call_vsim tb_axi_lite_regs -GPrivProtOnly=$PRIV -GSecuProtOnly=$SECU
+                    for BYTES in 42 200 369; do
+                        for SEED in 0 10 42; do
+                            call_vsim tb_axi_lite_regs -gPrivProtOnly=$PRIV -gSecuProtOnly=$SECU -gRegNumBytes=$BYTES -sv_seed $SEED -t 1ps -c
+                        done
+                    done
                 done
             done
             ;;

--- a/test/tb_axi_lite_regs.sv
+++ b/test/tb_axi_lite_regs.sv
@@ -120,8 +120,7 @@ module tb_axi_lite_regs #(
     end else begin
       assert (resp == axi_pkg::RESP_OKAY) else
           $fatal(1, "Access should be granted.");
-      assert (data == axi_data_t'(64'hDEADBEEFDEADBEEF)) else
-          $fatal(1, "Data is unexpected, should be axi_data_t'(64'hDEADBEEFDEADBEEF).");
+      // Checking of the expecetd read data is handled in `proc_check_read_data`.
     end
 
     // Let random stimuli application checking is separate.


### PR DESCRIPTION
This fixes #122.

The tb performs a known write followed by a read at the begining of simulation to a writeable address. The hardcoded data read assertion can be safely removed as the read data is checked by `proc_check_read_data` at the same time against the dynamic model.

Also added some more parameters in the vsim run script for the tb.