### PR TITLE
CI: Test multiple recent vsim versions

### DIFF
--- a/.ci/Memora.yml
+++ b/.ci/Memora.yml
@@ -1,6 +1,6 @@
 cache_root_dir: /home/gitlabci/buildcache/axi
 artifacts:
-  vsim:
+  vsim-%:
     inputs:
       - Bender.yml # external dependencies
       - include
@@ -9,7 +9,7 @@ artifacts:
       - src
       - test
     outputs:
-      - build/work
+      - build/work-%
 
   synopsys_dc:
     inputs:
@@ -22,7 +22,7 @@ artifacts:
     outputs:
       - build/synth.completed
 
-  axi_addr_test:
+  axi_addr_test-%:
     inputs:
       - Bender.yml
       - include
@@ -32,9 +32,9 @@ artifacts:
       - src/axi_test.sv
       - test/tb_axi_addr_test.sv
     outputs:
-      - build/axi_addr_test.tested
+      - build/axi_addr_test-%.tested
 
-  axi_atop_filter:
+  axi_atop_filter-%:
     inputs:
       - Bender.yml
       - include
@@ -45,9 +45,9 @@ artifacts:
       - src/axi_atop_filter.sv
       - test/tb_axi_atop_filter.sv
     outputs:
-      - build/axi_atop_filter.tested
+      - build/axi_atop_filter-%.tested
 
-  axi_cdc:
+  axi_cdc-%:
     inputs:
       - Bender.yml
       - include
@@ -58,9 +58,9 @@ artifacts:
       - src/axi_cdc.sv
       - test/tb_axi_cdc.sv
     outputs:
-      - build/axi_cdc.tested
+      - build/axi_cdc-%.tested
 
-  axi_delayer:
+  axi_delayer-%:
     inputs:
       - Bender.yml
       - include
@@ -71,9 +71,9 @@ artifacts:
       - src/axi_delayer.sv
       - test/tb_axi_delayer.sv
     outputs:
-      - build/axi_delayer.tested
+      - build/axi_delayer-%.tested
 
-  axi_dw_downsizer:
+  axi_dw_downsizer-%:
     inputs:
       - Bender.yml
       - include
@@ -85,9 +85,9 @@ artifacts:
       - src/axi_dw_converter.sv
       - test/tb_axi_dw_downsizer.sv
     outputs:
-      - build/axi_dw_downsizer.tested
+      - build/axi_dw_downsizer-%.tested
 
-  axi_dw_upsizer:
+  axi_dw_upsizer-%:
     inputs:
       - Bender.yml
       - include
@@ -99,9 +99,9 @@ artifacts:
       - src/axi_dw_converter.sv
       - test/tb_axi_dw_upsizer.sv
     outputs:
-      - build/axi_dw_upsizer.tested
+      - build/axi_dw_upsizer-%.tested
 
-  axi_isolate:
+  axi_isolate-%:
     inputs:
       - Bender.yml
       - include
@@ -112,9 +112,9 @@ artifacts:
       - src/axi_isolate.sv
       - test/tb_axi_isolate.sv
     outputs:
-      - build/axi_isolate.tested
+      - build/axi_isolate-%.tested
 
-  axi_lite_regs:
+  axi_lite_regs-%:
     inputs:
       - Bender.yml
       - include
@@ -125,9 +125,9 @@ artifacts:
       - src/axi_lite_regs.sv
       - test/tb_axi_lite_regs.sv
     outputs:
-      - build/axi_lite_regs.tested
+      - build/axi_lite_regs-%.tested
 
-  axi_lite_to_apb:
+  axi_lite_to_apb-%:
     inputs:
       - Bender.yml
       - include
@@ -138,9 +138,9 @@ artifacts:
       - src/axi_lite_to_apb.sv
       - test/tb_axi_lite_to_apb.sv
     outputs:
-      - build/axi_lite_to_apb.tested
+      - build/axi_lite_to_apb-%.tested
 
-  axi_lite_to_axi:
+  axi_lite_to_axi-%:
     inputs:
       - Bender.yml
       - include
@@ -151,9 +151,9 @@ artifacts:
       - src/axi_lite_to_axi.sv
       - test/tb_axi_lite_to_axi.sv
     outputs:
-      - build/axi_lite_to_axi.tested
+      - build/axi_lite_to_axi-%.tested
 
-  axi_lite_mailbox:
+  axi_lite_mailbox-%:
     inputs:
       - Bender.yml
       - include
@@ -164,9 +164,9 @@ artifacts:
       - src/axi_lite_mailbox.sv
       - test/tb_axi_lite_mailbox.sv
     outputs:
-      - build/axi_lite_mailbox.tested
+      - build/axi_lite_mailbox-%.tested
 
-  axi_lite_xbar:
+  axi_lite_xbar-%:
     inputs:
       - Bender.yml
       - include
@@ -181,9 +181,9 @@ artifacts:
       - src/axi_lite_xbar.sv
       - test/tb_axi_lite_xbar.sv
     outputs:
-      - build/axi_lite_xbar.tested
+      - build/axi_lite_xbar-%.tested
 
-  axi_modify_address:
+  axi_modify_address-%:
     inputs:
       - Bender.yml
       - include
@@ -194,9 +194,9 @@ artifacts:
       - src/axi_modify_address.sv
       - test/tb_axi_modify_address.sv
     outputs:
-      - build/axi_modify_address.tested
+      - build/axi_modify_address-%.tested
 
-  axi_serializer:
+  axi_serializer-%:
     inputs:
       - Bender.yml
       - include
@@ -207,9 +207,9 @@ artifacts:
       - src/axi_serializer.sv
       - test/tb_axi_serializer.sv
     outputs:
-      - build/axi_serializer.tested
+      - build/axi_serializer-%.tested
 
-  axi_to_axi_lite:
+  axi_to_axi_lite-%:
     inputs:
       - Bender.yml
       - include
@@ -222,9 +222,9 @@ artifacts:
       - src/axi_to_axi_lite.sv
       - test/tb_axi_to_axi_lite.sv
     outputs:
-      - build/axi_to_axi_lite.tested
+      - build/axi_to_axi_lite-%.tested
 
-  axi_xbar:
+  axi_xbar-%:
     inputs:
       - Bender.yml
       - include
@@ -238,4 +238,4 @@ artifacts:
       - src/axi_xbar.sv
       - test/tb_axi_xbar.sv
     outputs:
-      - build/axi_xbar.tested
+      - build/axi_xbar-%.tested

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ vsim:
   parallel:
     matrix:
       - VSIM_VER: ['10.6b', '10.7b']
+        DUMMY: 'ignored' # workaround for GitLab 13.4; remove for newer versions
 
 synopsys_dc:
   stage: build
@@ -46,6 +47,7 @@ synopsys_dc:
   parallel:
     matrix:
       - VSIM_VER: ['10.6b', '10.7b']
+        DUMMY: 'ignored' # workaround for GitLab 13.4; remove for newer versions
 
 axi_addr_test:
   <<: *run_vsim

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ vsim:
       fi
   parallel:
     matrix:
-      - VSIM_VER: ['10.7b']
+      - VSIM_VER: ['10.6b', '10.7b']
 
 synopsys_dc:
   stage: build
@@ -45,7 +45,7 @@ synopsys_dc:
       fi
   parallel:
     matrix:
-      - VSIM_VER: ['10.7b']
+      - VSIM_VER: ['10.6b', '10.7b']
 
 axi_addr_test:
   <<: *run_vsim

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,9 +9,18 @@ vsim:
   stage: build
   script:
     - export ARTIFACT="vsim-$VSIM_VER"
-    - export VSIM="vsim-$VSIM_VER -64"
-    - export VLIB="vlib-$VSIM_VER"
-    - export VLOG="vlog-$VSIM_VER -64"
+    - >
+      case $VSIM_VER in 20*)
+        export VSIM="questa-$VSIM_VER vsim -64";
+        export VLIB="questa-$VSIM_VER vlib";
+        export VLOG="questa-$VSIM_VER vlog -64";
+        ;;
+      *)
+        export VSIM="vsim-$VSIM_VER -64";
+        export VLIB="vlib-$VSIM_VER";
+        export VLOG="vlog-$VSIM_VER -64";
+        ;;
+      esac
     - >
       if ! $CI_PROJECT_DIR/.gitlab-ci.d/memora_retry.sh lookup $ARTIFACT; then
         cd build && ../scripts/compile_vsim.sh && mv work{,-$VSIM_VER}
@@ -19,7 +28,7 @@ vsim:
       fi
   parallel:
     matrix:
-      - VSIM_VER: ['10.7b', '10.7e']
+      - VSIM_VER: ['10.7b', '10.7e', '2020.1']
         DUMMY: 'ignored' # workaround for GitLab 13.4; remove for newer versions
 
 synopsys_dc:
@@ -35,7 +44,14 @@ synopsys_dc:
   stage: test
   script:
     - export ARTIFACT="$TEST_MODULE-vsim_$VSIM_VER"
-    - export VSIM="vsim-$VSIM_VER -64"
+    - >
+      case $VSIM_VER in 20*)
+        export VSIM="questa-$VSIM_VER vsim -64";
+        ;;
+      *)
+        export VSIM="vsim-$VSIM_VER -64";
+        ;;
+      esac
     - >
       if ! $CI_PROJECT_DIR/.gitlab-ci.d/memora_retry.sh lookup $ARTIFACT; then
         $CI_PROJECT_DIR/.gitlab-ci.d/memora_retry.sh get vsim-$VSIM_VER
@@ -46,7 +62,7 @@ synopsys_dc:
       fi
   parallel:
     matrix:
-      - VSIM_VER: ['10.7b', '10.7e']
+      - VSIM_VER: ['10.7b', '10.7e', '2020.1']
         DUMMY: 'ignored' # workaround for GitLab 13.4; remove for newer versions
 
 axi_addr_test:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,4 @@
 variables:
-  VSIM: vsim-10.7b -64
-  VLIB: vlib-10.7b
-  VLOG: vlog-10.7b -64
   SYNOPSYS_DC: synopsys-2019.12 dc_shell -64bit
 
 before_script:
@@ -11,11 +8,18 @@ before_script:
 vsim:
   stage: build
   script:
+    - export ARTIFACT="vsim-$VSIM_VER"
+    - export VSIM="vsim-$VSIM_VER -64"
+    - export VLIB="vlib-$VSIM_VER"
+    - export VLOG="vlog-$VSIM_VER -64"
     - >
-      if ! $CI_PROJECT_DIR/.gitlab-ci.d/memora_retry.sh lookup vsim; then
-        cd build && ../scripts/compile_vsim.sh
-        $CI_PROJECT_DIR/.gitlab-ci.d/memora_retry.sh insert vsim
+      if ! $CI_PROJECT_DIR/.gitlab-ci.d/memora_retry.sh lookup $ARTIFACT; then
+        cd build && ../scripts/compile_vsim.sh && mv work{,-$VSIM_VER}
+        $CI_PROJECT_DIR/.gitlab-ci.d/memora_retry.sh insert $ARTIFACT
       fi
+  parallel:
+    matrix:
+      - VSIM_VER: ['10.7b']
 
 synopsys_dc:
   stage: build
@@ -26,92 +30,99 @@ synopsys_dc:
         $CI_PROJECT_DIR/.gitlab-ci.d/memora_retry.sh insert synopsys_dc
       fi
 
-.test_module: &test_module
+.run_vsim: &run_vsim
   stage: test
   script:
+    - export ARTIFACT="$TEST_MODULE-vsim_$VSIM_VER"
+    - export VSIM="vsim-$VSIM_VER -64"
     - >
-      if ! $CI_PROJECT_DIR/.gitlab-ci.d/memora_retry.sh lookup $TEST_MODULE; then
-        $CI_PROJECT_DIR/.gitlab-ci.d/memora_retry.sh get vsim
-        cd build && ../scripts/run_vsim.sh $TEST_MODULE
-        $CI_PROJECT_DIR/.gitlab-ci.d/memora_retry.sh insert $TEST_MODULE
+      if ! $CI_PROJECT_DIR/.gitlab-ci.d/memora_retry.sh lookup $ARTIFACT; then
+        $CI_PROJECT_DIR/.gitlab-ci.d/memora_retry.sh get vsim-$VSIM_VER
+        cd build
+        mv work{-$VSIM_VER,}
+        ../scripts/run_vsim.sh $TEST_MODULE && touch $ARTIFACT.tested
+        $CI_PROJECT_DIR/.gitlab-ci.d/memora_retry.sh insert $ARTIFACT
       fi
+  parallel:
+    matrix:
+      - VSIM_VER: ['10.7b']
 
 axi_addr_test:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_addr_test
 
 axi_atop_filter:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_atop_filter
 
 axi_cdc:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_cdc
 
 axi_delayer:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_delayer
 
 axi_dw_downsizer:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_dw_downsizer
 
 axi_dw_upsizer:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_dw_upsizer
 
 axi_isolate:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_isolate
 
 axi_lite_regs:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_lite_regs
 
 axi_lite_to_apb:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_lite_to_apb
 
 axi_lite_to_axi:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_lite_to_axi
 
 axi_lite_mailbox:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_lite_mailbox
 
 axi_lite_xbar:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_lite_xbar
 
 axi_modify_address:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_modify_address
 
 axi_serializer:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_serializer
 
 axi_to_axi_lite:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_to_axi_lite
 
 axi_xbar:
-  <<: *test_module
+  <<: *run_vsim
   variables:
     TEST_MODULE: axi_xbar

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ vsim:
       fi
   parallel:
     matrix:
-      - VSIM_VER: ['10.6b', '10.7b']
+      - VSIM_VER: ['10.7b']
         DUMMY: 'ignored' # workaround for GitLab 13.4; remove for newer versions
 
 synopsys_dc:
@@ -46,7 +46,7 @@ synopsys_dc:
       fi
   parallel:
     matrix:
-      - VSIM_VER: ['10.6b', '10.7b']
+      - VSIM_VER: ['10.7b']
         DUMMY: 'ignored' # workaround for GitLab 13.4; remove for newer versions
 
 axi_addr_test:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ vsim:
       fi
   parallel:
     matrix:
-      - VSIM_VER: ['10.7b']
+      - VSIM_VER: ['10.7b', '10.7e']
         DUMMY: 'ignored' # workaround for GitLab 13.4; remove for newer versions
 
 synopsys_dc:
@@ -46,7 +46,7 @@ synopsys_dc:
       fi
   parallel:
     matrix:
-      - VSIM_VER: ['10.7b']
+      - VSIM_VER: ['10.7b', '10.7e']
         DUMMY: 'ignored' # workaround for GitLab 13.4; remove for newer versions
 
 axi_addr_test:

--- a/scripts/run_vsim.sh
+++ b/scripts/run_vsim.sh
@@ -71,7 +71,6 @@ exec_test() {
             call_vsim tb_$1 -t 1ns -coverage -voptargs="+acc +cover=bcesfx"
             ;;
     esac
-    touch "$1.tested"
 }
 
 if [ "$#" -eq 0 ]; then


### PR DESCRIPTION
CI now includes Questa 2020.1. This PR therefore closes #78, as all tests pass also with Questa 2020.1.