### PR TITLE
axi_id_remap: Check the width of the whole `w` channel

### DIFF
--- a/src/axi_id_remap.sv
+++ b/src/axi_id_remap.sv
@@ -349,6 +349,8 @@ module axi_id_remap #(
       else $fatal(1, "AXI AW address widths are not equal!");
     assert($bits(slv_req_i.w.data) == $bits(mst_req_o.w.data))
       else $fatal(1, "AXI W data widths are not equal!");
+    assert($bits(slv_req_i.w.user) == $bits(mst_req_o.w.user))
+      else $fatal(1, "AXI W user widths are not equal!");
     assert($bits(slv_req_i.ar.addr) == $bits(mst_req_o.ar.addr))
       else $fatal(1, "AXI AR address widths are not equal!");
     assert($bits(slv_resp_o.r.data) == $bits(mst_resp_i.r.data))


### PR DESCRIPTION
Very minor fix. Since the `w` channel has no `id` and is directly forwarded from the input to the output, we can check that the width of the whole channel matches at the input and output. Thereby, the `data`, `strb`, and `user` signals have to match.

Would you prefer checking the `w.data` and the `w.user` width separately to eliminate the case where both signals' width mismatch, but the total width is the same for both ports?