### PR TITLE
Update `common_verification` dependency

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -8,8 +8,8 @@ package:
     - "Wolfgang Roenninger <wroennin@ethz.ch>"
 
 dependencies:
-  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.20.1 }
-  common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.1.1 }
+  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.21.0 }
+  common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.0 }
 
 export_include_dirs:
   - include

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - `axi_test::axi_rand_master`: Randomize the QoS field.
-- Update `common_cells` dependency to `1.20.1` to fix out-of-bounds index in `axi_burst_splitter`
-  (#150).
-- Update `common_verification` dependency to `0.2.0` for compatibility, accordingly modify modules.
-- Update `common_cells` dependency to `1.21.0` for `common_verification` update.
-- remove `timeunit/timeprecision` arguments
+- Update `common_verification` dependency to `0.2.0`, which has been released for more than a year.
+- Update `common_cells` dependency to `1.21.0` to align on version `0.2.0` of the
+  `common_verification` dependency.  This includes version `1.20.1` of `common_cells`, which fixes
+  an out-of-bounds index in `axi_burst_splitter` (#150).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   (#150).
 - Update `common_verification` dependency to `0.2.0` for compatibility, accordingly modify modules.
 - Update `common_cells` dependency to `1.21.0` for `common_verification` update.
+- remove `timeunit/timeprecision` arguments
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_test::axi_rand_master`: Randomize the QoS field.
 - Update `common_cells` dependency to `1.20.1` to fix out-of-bounds index in `axi_burst_splitter`
   (#150).
+- Update `common_verification` dependency to `0.2.0` for compatibility, accordingly modify modules.
+- Update `common_cells` dependency to `1.21.0` for `common_verification` update.
 
 ### Fixed
 

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -1,7 +1,7 @@
 common_cells:
-    commit: v1.20.0
+    commit: v1.21.0
     group: pulp-platform
 
 common_verification:
-    commit: v0.1.1
+    commit: v0.2.0
     group: pulp-platform

--- a/test/tb_axi_addr_test.sv
+++ b/test/tb_axi_addr_test.sv
@@ -103,8 +103,8 @@ module tb_axi_addr_test #(
   // Clock generator
   //-----------------------------------
   clk_rst_gen #(
-    .CLK_PERIOD    ( CyclTime ),
-    .RST_CLK_CYCLES( 5        )
+    .ClkPeriod   ( CyclTime ),
+    .RstClkCycles( 5        )
   ) i_clk_gen (
     .clk_o (clk),
     .rst_no(rst_n)

--- a/test/tb_axi_atop_filter.sv
+++ b/test/tb_axi_atop_filter.sv
@@ -34,9 +34,6 @@ module tb_axi_atop_filter #(
   parameter int unsigned N_TXNS = 1000
 );
 
-  timeunit 1ns;
-  timeprecision 10ps;
-
   import axi_pkg::ATOP_ATOMICCMP;
   import axi_pkg::ATOP_ATOMICLOAD;
   import axi_pkg::ATOP_ATOMICSTORE;

--- a/test/tb_axi_atop_filter.sv
+++ b/test/tb_axi_atop_filter.sv
@@ -55,8 +55,8 @@ module tb_axi_atop_filter #(
         rst_n;
 
   clk_rst_gen #(
-    .CLK_PERIOD     (TCLK),
-    .RST_CLK_CYCLES (5)
+    .ClkPeriod    (TCLK),
+    .RstClkCycles (5)
   ) i_clk_rst_gen (
     .clk_o  (clk),
     .rst_no (rst_n)

--- a/test/tb_axi_cdc.sv
+++ b/test/tb_axi_cdc.sv
@@ -37,9 +37,6 @@ module tb_axi_cdc #(
   parameter int unsigned N_TXNS = 1000
 );
 
-  timeunit 1ns;
-  timeprecision 10ps;
-
   localparam int unsigned N_RD_TXNS = N_TXNS / 2;
   localparam int unsigned N_WR_TXNS = N_TXNS / 2;
 

--- a/test/tb_axi_cdc.sv
+++ b/test/tb_axi_cdc.sv
@@ -51,16 +51,16 @@ module tb_axi_cdc #(
         downstream_rst_n;
 
   clk_rst_gen #(
-    .CLK_PERIOD     (TCLK_UPSTREAM),
-    .RST_CLK_CYCLES (5)
+    .ClkPeriod    (TCLK_UPSTREAM),
+    .RstClkCycles (5)
   ) i_clk_rst_gen_upstream (
     .clk_o  (upstream_clk),
     .rst_no (upstream_rst_n)
   );
 
   clk_rst_gen #(
-    .CLK_PERIOD     (TCLK_DOWNSTREAM),
-    .RST_CLK_CYCLES (5)
+    .ClkPeriod    (TCLK_DOWNSTREAM),
+    .RstClkCycles (5)
   ) i_clk_rst_gen_downstream (
     .clk_o  (downstream_clk),
     .rst_no (downstream_rst_n)

--- a/test/tb_axi_dw_downsizer.sv
+++ b/test/tb_axi_dw_downsizer.sv
@@ -35,8 +35,8 @@ module tb_axi_dw_downsizer #(
   logic eos;
 
   clk_rst_gen #(
-    .CLK_PERIOD    (CyclTime),
-    .RST_CLK_CYCLES(5       )
+    .ClkPeriod    (CyclTime),
+    .RstClkCycles (5       )
   ) i_clk_rst_gen (
     .clk_o (clk  ),
     .rst_no(rst_n)

--- a/test/tb_axi_dw_upsizer.sv
+++ b/test/tb_axi_dw_upsizer.sv
@@ -35,8 +35,8 @@ module tb_axi_dw_upsizer #(
   logic eos;
 
   clk_rst_gen #(
-    .CLK_PERIOD    (CyclTime),
-    .RST_CLK_CYCLES(5       )
+    .ClkPeriod    (CyclTime),
+    .RstClkCycles (5       )
   ) i_clk_rst_gen (
     .clk_o (clk  ),
     .rst_no(rst_n)

--- a/test/tb_axi_isolate.sv
+++ b/test/tb_axi_isolate.sv
@@ -105,8 +105,8 @@ module tb_axi_isolate #(
   // Clock generator
   //-----------------------------------
   clk_rst_gen #(
-    .CLK_PERIOD    ( CyclTime ),
-    .RST_CLK_CYCLES( 5        )
+    .ClkPeriod    ( CyclTime ),
+    .RstClkCycles ( 5        )
   ) i_clk_gen (
     .clk_o (clk),
     .rst_no(rst_n)

--- a/test/tb_axi_lite_mailbox.sv
+++ b/test/tb_axi_lite_mailbox.sv
@@ -437,8 +437,8 @@ module tb_axi_lite_mailbox;
   // Clock generator
   //-----------------------------------
   clk_rst_gen #(
-    .CLK_PERIOD    ( CyclTime ),
-    .RST_CLK_CYCLES( 5        )
+    .ClkPeriod    ( CyclTime ),
+    .RstClkCycles ( 5        )
   ) i_clk_gen (
     .clk_o (clk),
     .rst_no(rst_n)

--- a/test/tb_axi_lite_regs.sv
+++ b/test/tb_axi_lite_regs.sv
@@ -331,8 +331,8 @@ module tb_axi_lite_regs #(
   // Clock generator
   //-----------------------------------
   clk_rst_gen #(
-    .CLK_PERIOD    ( CyclTime ),
-    .RST_CLK_CYCLES( 5        )
+    .ClkPeriod    ( CyclTime ),
+    .RstClkCycles ( 5        )
   ) i_clk_gen (
     .clk_o (clk),
     .rst_no(rst_n)

--- a/test/tb_axi_lite_to_apb.sv
+++ b/test/tb_axi_lite_to_apb.sv
@@ -214,8 +214,8 @@ module tb_axi_lite_to_apb;
   // Clock generator
   //-----------------------------------
     clk_rst_gen #(
-    .CLK_PERIOD    ( CyclTime ),
-    .RST_CLK_CYCLES( 5        )
+    .ClkPeriod    ( CyclTime ),
+    .RstClkCycles ( 5        )
   ) i_clk_gen (
     .clk_o  ( clk   ),
     .rst_no ( rst_n )

--- a/test/tb_axi_lite_xbar.sv
+++ b/test/tb_axi_lite_xbar.sv
@@ -181,8 +181,8 @@ module tb_axi_lite_xbar;
   // Clock generator
   //-----------------------------------
   clk_rst_gen #(
-    .CLK_PERIOD    ( CyclTime ),
-    .RST_CLK_CYCLES( 5        )
+    .ClkPeriod    ( CyclTime ),
+    .RstClkCycles ( 5        )
   ) i_clk_gen (
     .clk_o (clk),
     .rst_no(rst_n)

--- a/test/tb_axi_modify_address.sv
+++ b/test/tb_axi_modify_address.sv
@@ -33,9 +33,6 @@ module tb_axi_modify_address #(
   parameter int unsigned N_TXNS = 1000
 );
 
-  timeunit 1ns;
-  timeprecision 10ps;
-
   localparam int unsigned N_RD_TXNS = N_TXNS / 2;
   localparam int unsigned N_WR_TXNS = N_TXNS / 2;
 

--- a/test/tb_axi_modify_address.sv
+++ b/test/tb_axi_modify_address.sv
@@ -43,8 +43,8 @@ module tb_axi_modify_address #(
   logic clk,
         rst_n;
   clk_rst_gen #(
-    .CLK_PERIOD     (TCLK),
-    .RST_CLK_CYCLES (5)
+    .ClkPeriod     (TCLK),
+    .RstClkCycles  (5)
   ) i_clk_rst_gen (
     .clk_o  (clk),
     .rst_no (rst_n)

--- a/test/tb_axi_serializer.sv
+++ b/test/tb_axi_serializer.sv
@@ -102,8 +102,8 @@ module tb_axi_serializer #(
   // Clock generator
   //-----------------------------------
   clk_rst_gen #(
-    .CLK_PERIOD    ( CyclTime ),
-    .RST_CLK_CYCLES( 5        )
+    .ClkPeriod    ( CyclTime ),
+    .RstClkCycles ( 5        )
   ) i_clk_gen (
     .clk_o (clk),
     .rst_no(rst_n)

--- a/test/tb_axi_sim_mem.sv
+++ b/test/tb_axi_sim_mem.sv
@@ -24,8 +24,8 @@ module tb_axi_sim_mem #(
   logic clk,
         rst_n;
   clk_rst_gen #(
-    .CLK_PERIOD     (Tclk),
-    .RST_CLK_CYCLES (5)
+    .ClkPeriod    (Tclk),
+    .RstClkCycles (5)
   ) i_clk_rst_gen (
     .clk_o  (clk),
     .rst_no (rst_n)

--- a/test/tb_axi_xbar.sv
+++ b/test/tb_axi_xbar.sv
@@ -242,8 +242,8 @@ module tb_axi_xbar;
   // Clock generator
   //-----------------------------------
     clk_rst_gen #(
-    .CLK_PERIOD    ( CyclTime ),
-    .RST_CLK_CYCLES( 5        )
+    .ClkPeriod    ( CyclTime ),
+    .RstClkCycles ( 5        )
   ) i_clk_gen (
     .clk_o (clk),
     .rst_no(rst_n)


### PR DESCRIPTION
This PR updates the `common_verification` dependency.
This includes renaming parameters of called modules for compatibility, removing `timeunit/timeprecision` arguments, and updating the `common_cells` dependency with the same updates, avoiding version conflicts.