### PR TITLE
Add Verilator script

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -55,7 +55,7 @@ sources:
 
   - target: synth_test
     files:
-      - test/synth_bench.sv
+      - test/axi_synth_bench.sv
 
   - target: simulation
     files:

--- a/scripts/run_verilator.sh
+++ b/scripts/run_verilator.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright (c) 2021 ETH Zurich, University of Bologna
+#
+# Copyright and related rights are licensed under the Solderpad Hardware
+# License, Version 0.51 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+# http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+# or agreed to in writing, software, hardware and materials distributed under
+# this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+set -e
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+[ ! -z "$VERILATOR" ] || VERILATOR="verilator"
+
+bender script verilator -t synthesis -t synth_test > ./verilator.f
+
+VERILATOR_FLAGS=()
+VERILATOR_FLAGS+=(-Wno-fatal)
+
+$VERILATOR --top-module axi_synth_bench --lint-only -f verilator.f ${VERILATOR_FLAGS[@]}

--- a/scripts/synth.sh
+++ b/scripts/synth.sh
@@ -21,7 +21,7 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 echo 'remove_design -all' > ./synth.tcl
 bender script synopsys -t synth_test >> ./synth.tcl
-echo 'elaborate synth_bench' >> ./synth.tcl
+echo 'elaborate axi_synth_bench' >> ./synth.tcl
 
 cat ./synth.tcl | $SYNOPSYS_DC | tee synth.log 2>&1
 grep -i "warning:" synth.log || true

--- a/test/axi_synth_bench.sv
+++ b/test/axi_synth_bench.sv
@@ -14,7 +14,7 @@
 // - Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
 
 /// A synthesis test bench which instantiates various adapter variants.
-module synth_bench (
+module axi_synth_bench (
   input logic clk_i,
   input logic rst_ni
 );

--- a/test/synth_bench.sv
+++ b/test/synth_bench.sv
@@ -19,9 +19,9 @@ module synth_bench (
   input logic rst_ni
 );
 
-  localparam int AXI_ADDR_WIDTH[6] = {32, 64, 1, 2, 42, 129};
-  localparam int AXI_ID_USER_WIDTH[3] = {0, 1, 8};
-  localparam int NUM_SLAVE_MASTER[3] = {1, 2, 4};
+  localparam int AXI_ADDR_WIDTH[6] = '{32, 64, 1, 2, 42, 129};
+  localparam int AXI_ID_USER_WIDTH[3] = '{0, 1, 8};
+  localparam int NUM_SLAVE_MASTER[3] = '{1, 2, 4};
 
   // AXI_DATA_WIDTH = {8, 16, 32, 64, 128, 256, 512, 1024}
   for (genvar i = 0; i < 8; i++) begin
@@ -145,7 +145,7 @@ module synth_bench (
 
   // AXI4-Lite Registers
   for (genvar i = 0; i < 6; i++) begin
-    localparam int unsigned NUM_BYTES[6] = {1, 4, 42, 64, 129, 512};
+    localparam int unsigned NUM_BYTES[6] = '{1, 4, 42, 64, 129, 512};
     synth_axi_lite_regs #(
       .REG_NUM_BYTES  ( NUM_BYTES[i]      ),
       .AXI_ADDR_WIDTH ( 32'd32            ),


### PR DESCRIPTION
There was a need to rename the `synth_bench` to `axi_synth_bench` as it would collide with `common_cells` `synth_bench`. I will do the same for the `common_cells` but I figured it would be good to fix this in any case (thanks for the good namespacing support SV :-)).

Furthermore, there it contains a small fix with the unpacked array literals.

Verilator 4.100 works fine with the synthesis testbench but we got quite some warnings. I think we should go through them and figure out which one we want to waive. Then we can also check, that new additions to the repo don't cause any new warnings.

The next step will be to add Verilator to the CI regression, first to check for incompatible constructs, second to check the lint warnings.
