### PR TITLE
axi_demux: Introduce workaround for bug in new vopt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   registers by default.
 
 ### Fixed
+- `axi_demux`: Improve compatibility with new version of QuestaSim's optimizer (`vopt`) (#169).
+  Before this workaround, QuestaSim 2020.2 and 2021.1 could segfault on instances of `axi_demux`.
 
 
 ## 0.27.1 - 2021-02-01

--- a/src/axi_demux.sv
+++ b/src/axi_demux.sv
@@ -56,7 +56,6 @@ module axi_demux #(
   //--------------------------------------
   // Typedefs for the FIFOs / Queues
   //--------------------------------------
-  typedef logic [AxiIdWidth-1:0] axi_id_t;
   typedef struct packed {
     aw_chan_t aw_chan;
     select_t  aw_select;

--- a/src/axi_demux.sv
+++ b/src/axi_demux.sv
@@ -148,23 +148,26 @@ module axi_demux #(
     // AW Channel
     //--------------------------------------
     // spill register at the channel input
-    aw_chan_select_t slv_aw_chan_select_in;
-    assign slv_aw_chan_select_in.aw_chan   = slv_req_i.aw;
-    assign slv_aw_chan_select_in.aw_select = slv_aw_select_i;
-
+    // Workaround for bug in Questa 2020.2 and 2021.1: Flatten the struct into a logic vector before
+    // instantiating `spill_register`.
+    typedef logic [$bits(aw_chan_select_t)-1:0] aw_chan_select_flat_t;
+    aw_chan_select_flat_t slv_aw_chan_select_in_flat,
+                          slv_aw_chan_select_out_flat;
+    assign slv_aw_chan_select_in_flat = {slv_req_i.aw, slv_aw_select_i};
     spill_register #(
-      .T       ( aw_chan_select_t      ),
-      .Bypass  ( ~SpillAw              ) // because module param indicates if we want a spill reg
+      .T       ( aw_chan_select_flat_t        ),
+      .Bypass  ( ~SpillAw                     ) // because module param indicates if we want a spill reg
     ) i_aw_spill_reg (
-      .clk_i   ( clk_i                 ),
-      .rst_ni  ( rst_ni                ),
-      .valid_i ( slv_req_i.aw_valid    ),
-      .ready_o ( slv_resp_o.aw_ready   ),
-      .data_i  ( slv_aw_chan_select_in ),
-      .valid_o ( slv_aw_valid          ),
-      .ready_i ( slv_aw_ready          ),
-      .data_o  ( slv_aw_chan_select    )
+      .clk_i   ( clk_i                        ),
+      .rst_ni  ( rst_ni                       ),
+      .valid_i ( slv_req_i.aw_valid           ),
+      .ready_o ( slv_resp_o.aw_ready          ),
+      .data_i  ( slv_aw_chan_select_in_flat   ),
+      .valid_o ( slv_aw_valid                 ),
+      .ready_i ( slv_aw_ready                 ),
+      .data_o  ( slv_aw_chan_select_out_flat  )
     );
+    assign slv_aw_chan_select = slv_aw_chan_select_out_flat;
 
     // Control of the AW handshake
     always_comb begin
@@ -319,23 +322,26 @@ module axi_demux #(
     //--------------------------------------
     //  AR Channel
     //--------------------------------------
-    ar_chan_select_t slv_ar_chan_select_in;
-    assign slv_ar_chan_select_in.ar_chan   = slv_req_i.ar;
-    // assign slv_ar_chan_select_in.ar_chan   = slv_ar_chan_i;
-    assign slv_ar_chan_select_in.ar_select = slv_ar_select_i;
+    // Workaround for bug in Questa 2020.2 and 2021.1: Flatten the struct into a logic vector before
+    // instantiating `spill_register`.
+    typedef logic [$bits(ar_chan_select_t)-1:0] ar_chan_select_flat_t;
+    ar_chan_select_flat_t slv_ar_chan_select_in_flat,
+                          slv_ar_chan_select_out_flat;
+    assign slv_ar_chan_select_in_flat = {slv_req_i.ar, slv_ar_select_i};
     spill_register #(
-      .T       ( ar_chan_select_t      ),
-      .Bypass  ( ~SpillAr              )
+      .T       ( ar_chan_select_flat_t        ),
+      .Bypass  ( ~SpillAr                     )
     ) i_ar_spill_reg (
-      .clk_i   ( clk_i                 ),
-      .rst_ni  ( rst_ni                ),
-      .valid_i ( slv_req_i.ar_valid    ),
-      .ready_o ( slv_resp_o.ar_ready   ),
-      .data_i  ( slv_ar_chan_select_in ),
-      .valid_o ( slv_ar_valid          ),
-      .ready_i ( slv_ar_ready          ),
-      .data_o  ( slv_ar_chan_select    )
+      .clk_i   ( clk_i                        ),
+      .rst_ni  ( rst_ni                       ),
+      .valid_i ( slv_req_i.ar_valid           ),
+      .ready_o ( slv_resp_o.ar_ready          ),
+      .data_i  ( slv_ar_chan_select_in_flat   ),
+      .valid_o ( slv_ar_valid                 ),
+      .ready_i ( slv_ar_ready                 ),
+      .data_o  ( slv_ar_chan_select_out_flat  )
     );
+    assign slv_ar_chan_select = slv_ar_chan_select_out_flat;
 
     // control of the AR handshake
     always_comb begin


### PR DESCRIPTION
Improve compatibility with new version of QuestaSim's optimizer (`vopt`).  Before this workaround, QuestaSim 2020.2 and 2021.1 could segfault on instances of `axi_demux`.