### PR TITLE
axi_rand_master: Refactor ID legalization

### DIFF
--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -849,6 +849,11 @@ package axi_test;
       automatic id_t id;
       automatic qos_t qos;
       beat.ax_atop[5:4] = $random();
+      if (beat.ax_atop[5:4] != 2'b00 && !AXI_BURST_INCR) begin
+        // We can emit ATOPs only if INCR bursts are allowed.
+        $warning("ATOP suppressed because INCR bursts are disabled!");
+        beat.ax_atop[5:4] = 2'b00;
+      end
       if (beat.ax_atop[5:4] != 2'b00) begin // ATOP
         // Determine `ax_atop`.
         if (beat.ax_atop[5:4] == axi_pkg::ATOP_ATOMICSTORE ||
@@ -1072,12 +1077,7 @@ package axi_test;
             w_flight_cnt[aw_beat.ax_id]++;
             cnt_sem.put();
           end else begin
-            if (AXI_BURST_INCR) begin
-              // We can emit ATOPs only if INCR bursts are allowed.
-              rand_atop_burst(aw_beat);
-            end else begin
-              $warning("ATOP suppressed because INCR bursts are disabled!");
-            end
+            rand_atop_burst(aw_beat);
           end
         end else begin
           cnt_sem.get();

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -839,6 +839,8 @@ package axi_test;
       ax_beat.ax_addr = addr;
       rand_success = std::randomize(id); assert(rand_success);
       rand_success = std::randomize(qos); assert(rand_success);
+      // The random ID *must* be legalized with `legalize_id()` before the beat is sent!  This is
+      // currently done in the functions `create_aws()` and `send_ars()`.
       ax_beat.ax_id = id;
       ax_beat.ax_qos = qos;
       return ax_beat;
@@ -846,8 +848,6 @@ package axi_test;
 
     task rand_atop_burst(inout ax_beat_t beat);
       automatic logic rand_success;
-      automatic id_t id;
-      automatic qos_t qos;
       beat.ax_atop[5:4] = $random();
       if (beat.ax_atop[5:4] != 2'b00 && !AXI_BURST_INCR) begin
         // We can emit ATOPs only if INCR bursts are allowed.
@@ -912,43 +912,7 @@ package axi_test;
           // Only INCR allowed.
           beat.ax_burst = axi_pkg::BURST_INCR;
         end
-        // Determine `ax_id`, which must not be the same as that of any other in-flight AXI
-        // transaction.
-        forever begin
-          cnt_sem.get();
-          rand_success = std::randomize(id); assert(rand_success);
-          if (r_flight_cnt[id] == 0 && w_flight_cnt[id] == 0 && !atop_resp_b[id] &&
-              !atop_resp_r[id]) begin
-            break;
-          end else begin
-            // The random ID does not meet the requirements, so try another ID in the next cycle.
-            cnt_sem.put();
-            rand_wait(1, 1);
-          end
-        end
-        atop_resp_b[id] = 1'b1;
-        if (beat.ax_atop[5] == 1'b1) begin
-          atop_resp_r[id] = 1'b1;
-        end
-      end else begin
-        // Determine `ax_id`, which must not be the same as that of any in-flight ATOP.
-        forever begin
-          cnt_sem.get();
-          rand_success = std::randomize(id); assert(rand_success);
-          if (!atop_resp_b[id] && !atop_resp_r[id]) begin
-            break;
-          end else begin
-            // The random ID does not meet the requirements, so try another ID in the next cycle.
-            cnt_sem.put();
-            rand_wait(1, 1);
-          end
-        end
       end
-      beat.ax_id = id;
-      rand_success = std::randomize(qos); assert(rand_success);
-      beat.ax_qos = qos;
-      w_flight_cnt[id]++;
-      cnt_sem.put();
     endtask
 
     function void rand_excl_ar(inout ax_beat_t ar_beat);
@@ -992,6 +956,65 @@ package axi_test;
       repeat (cycles) @(posedge this.drv.axi.clk_i);
     endtask
 
+    // Determine if the ID of an AXI Ax beat is currently legal.  This function may only be called
+    // while holding the `cnt_sem` semaphore.
+    function bit id_is_legal(input bit is_read, input ax_beat_t beat);
+      if (AXI_ATOPS) begin
+        // The ID must not be the same as that of any in-flight ATOP.
+        if (atop_resp_b[beat.ax_id] || atop_resp_r[beat.ax_id]) return 1'b0;
+        // If this beat starts an ATOP, its ID must not be the same as that of any other in-flight
+        // AXI transaction.
+        if (!is_read && beat.ax_atop[5:4] != 2'b00 && (
+          r_flight_cnt[beat.ax_id] != 0 || w_flight_cnt[beat.ax_id] !=0
+        )) return 1'b0;
+      end
+      // There is no reason why this ID would be illegal, so it is legal.
+      return 1'b1;
+    endfunction
+
+    // Legalize the ID of an AXI Ax beat (drawing a new ID at random if the existing ID is currently
+    // not legal) and add it to the in-flight transactions.
+    task legalize_id(input bit is_read, inout ax_beat_t beat);
+      automatic logic rand_success;
+      automatic id_t id = beat.ax_id;
+      // Loop until a legal ID is found.
+      forever begin
+        // Acquire semaphore on in-flight counters.
+        cnt_sem.get();
+        // Exit loop if the current ID is legal.
+        if (id_is_legal(is_read, beat)) begin
+          break;
+        end else begin
+          // The current ID is currently not legal, so try another ID in the next cycle and
+          // release the semaphore until then.
+          cnt_sem.put();
+          rand_wait(1, 1);
+          if (!beat.ax_lock) begin // The ID of an exclusive transfer must not be changed.
+            rand_success = std::randomize(id); assert(rand_success);
+            beat.ax_id = id;
+          end
+        end
+      end
+      // Mark transfer for decided ID as in flight.
+      if (!is_read) begin
+        w_flight_cnt[beat.ax_id]++;
+        tot_w_flight_cnt++;
+        if (beat.ax_atop != 2'b00) begin
+          // This is an ATOP, so it gives rise to a write response.
+          atop_resp_b[beat.ax_id] = 1'b1;
+          if (beat.ax_atop[5]) begin
+            // This ATOP type additionally gives rise to a read response.
+            atop_resp_r[beat.ax_id] = 1'b1;
+          end
+        end
+      end else begin
+        r_flight_cnt[beat.ax_id]++;
+        tot_r_flight_cnt++;
+      end
+      // Release semaphore on in-flight counters.
+      cnt_sem.put();
+    endtask
+
     task send_ars(input int n_reads);
       automatic logic rand_success;
       repeat (n_reads) begin
@@ -1003,26 +1026,7 @@ package axi_test;
         if (AXI_EXCLS) begin
           rand_excl_ar(ar_beat);
         end
-        if (AXI_ATOPS) begin
-          // The ID must not be the same as that of any in-flight ATOP.
-          forever begin
-            cnt_sem.get();
-            rand_success = std::randomize(id); assert(rand_success);
-            if (!atop_resp_b[id] && !atop_resp_r[id]) begin
-              break;
-            end else begin
-              // The random ID does not meet the requirements, so try another ID in the next cycle.
-              cnt_sem.put();
-              rand_wait(1, 1);
-            end
-          end
-          ar_beat.ax_id = id;
-        end else begin
-          cnt_sem.get();
-        end
-        r_flight_cnt[ar_beat.ax_id]++;
-        tot_r_flight_cnt++;
-        cnt_sem.put();
+        legalize_id(1'b1, ar_beat);
         rand_wait(AX_MIN_WAIT_CYCLES, AX_MAX_WAIT_CYCLES);
         drv.send_ar(ar_beat);
         if (ar_beat.ax_lock) excl_queue.push_back(ar_beat);
@@ -1061,30 +1065,12 @@ package axi_test;
           aw_beat = excl_queue.pop_front();
         end else begin
           aw_beat = new_rand_burst(1'b0);
+          if (AXI_ATOPS) rand_atop_burst(aw_beat);
         end
         while (tot_w_flight_cnt >= MAX_WRITE_TXNS) begin
           rand_wait(1, 1);
         end
-        if (AXI_ATOPS) begin
-          if (excl) begin
-            // Make sure the exclusive transfer does not have the same ID as an in-flight ATOP.
-            forever begin
-              cnt_sem.get();
-              if (!atop_resp_b[aw_beat.ax_id] && !atop_resp_r[aw_beat.ax_id]) break;
-              cnt_sem.put();
-              rand_wait(1, 1);
-            end
-            w_flight_cnt[aw_beat.ax_id]++;
-            cnt_sem.put();
-          end else begin
-            rand_atop_burst(aw_beat);
-          end
-        end else begin
-          cnt_sem.get();
-          w_flight_cnt[aw_beat.ax_id]++;
-          cnt_sem.put();
-        end
-        tot_w_flight_cnt++;
+        legalize_id(1'b0, aw_beat);
         aw_queue.push_back(aw_beat);
         w_queue.push_back(aw_beat);
       end


### PR DESCRIPTION
This refactors the ID legalization of the randomizing AXI master (a testbench class) into one function, `legalize_id()`, which legalizes the ID of the given beat according to the current in-flight transactions.  To determine if an ID is currently legal, that function calls another new function, `id_is_legal()`.  With this, the conditions under which an ID is legal became much easier to understand: they are now concentrated in a single function with only 10 LOC and without deeply nested conditionals.

This prepares the randomizing AXI master for an upcoming feature extension, which allows to constrain it to issue transactions with IDs that are unique among all in-flight transactions.