### PR TITLE
axi_lite_cdc_src_intf: Fix interchanged ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- `axi_lite_cdc_src_intf`: Fix `_i` and `_o` suffixes in instantiation of `axi_cdc_src`.
 
 
 ## 0.29.1 - 2021-06-02

--- a/src/axi_cdc_src.sv
+++ b/src/axi_cdc_src.sv
@@ -242,8 +242,8 @@ module axi_lite_cdc_src_intf #(
   ) i_axi_cdc_src (
     .src_clk_i,
     .src_rst_ni,
-    .src_req_o                    ( src_req     ),
-    .src_resp_i                   ( src_resp    ),
+    .src_req_i                    ( src_req     ),
+    .src_resp_o                   ( src_resp    ),
     .async_data_master_aw_data_o  ( dst.aw_data ),
     .async_data_master_aw_wptr_o  ( dst.aw_wptr ),
     .async_data_master_aw_rptr_i  ( dst.aw_rptr ),


### PR DESCRIPTION
It seems the `_i/_o` suffixes got interchanged when instantiating the `axi_cdc_src` module. I do not use this module directly, but Verilator gave me a warning when compiling the `axi` repo.