### PR TITLE
Fix latch inference on the data width converters with the Mentor Precision synthesis tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- `axi_dw_downsizer` and `axi_dw_upsizer` (part of `axi_dw_converter`): Avoid latch inference on the
+  Mentor Precision synthesis tool.
 - `axi_lite_cdc_src_intf`: Fix `_i` and `_o` suffixes in instantiation of `axi_cdc_src`.
 - `axi_test::axi_scoreboard`: Add default value to parameters to improve compatibility with some
   tools.


### PR DESCRIPTION
Closes #184.

This PR reworks a construct that would case latches to be infered on both the `axi_dw_downsizer` and the `axi_dw_upsizer`, when synthesizing them with the Mentor Precision.