### PR TITLE
axi_demux: Improve compatibility with VCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- `axi_demux`: Improve compatibility with VCS (#187).  The workaround of #169 was not compatible
+  with VCS 2020.12.  That workaround is now only active if `TARGET_VSIM` is defined.
 - `axi_dw_downsizer` and `axi_dw_upsizer` (part of `axi_dw_converter`): Avoid latch inference on the
   Mentor Precision synthesis tool.
 - `axi_lite_cdc_src_intf`: Fix `_i` and `_o` suffixes in instantiation of `axi_cdc_src`.

--- a/src/axi_demux.sv
+++ b/src/axi_demux.sv
@@ -148,9 +148,13 @@ module axi_demux #(
     // AW Channel
     //--------------------------------------
     // spill register at the channel input
+    `ifdef TARGET_VSIM
     // Workaround for bug in Questa 2020.2 and 2021.1: Flatten the struct into a logic vector before
     // instantiating `spill_register`.
     typedef logic [$bits(aw_chan_select_t)-1:0] aw_chan_select_flat_t;
+    `else
+    typedef aw_chan_select_t aw_chan_select_flat_t;
+    `endif
     aw_chan_select_flat_t slv_aw_chan_select_in_flat,
                           slv_aw_chan_select_out_flat;
     assign slv_aw_chan_select_in_flat = {slv_req_i.aw, slv_aw_select_i};
@@ -333,9 +337,13 @@ module axi_demux #(
     //--------------------------------------
     //  AR Channel
     //--------------------------------------
+    `ifdef TARGET_VSIM
     // Workaround for bug in Questa 2020.2 and 2021.1: Flatten the struct into a logic vector before
     // instantiating `spill_register`.
     typedef logic [$bits(ar_chan_select_t)-1:0] ar_chan_select_flat_t;
+    `else
+    typedef ar_chan_select_t ar_chan_select_flat_t;
+    `endif
     ar_chan_select_flat_t slv_ar_chan_select_in_flat,
                           slv_ar_chan_select_out_flat;
     assign slv_ar_chan_select_in_flat = {slv_req_i.ar, slv_ar_select_i};


### PR DESCRIPTION
Closes #187.

This PR guards the workaround of #169 between `TARGET_VSIM` guards, because that workaround was not understood by VCS 2020.12.