### PR TITLE
Generalize questa 2020/21 work-around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `axi_sim_mem_intf` interface variant of `axi_sim_mem`.
 
 ### Changed
+- `axi_demux`: Use flat select signal independent of tool-specific defines, to further improve
+  compatibility with known EDA tool bugs (see #202).
 
 ### Fixed
 

--- a/src/axi_demux.sv
+++ b/src/axi_demux.sv
@@ -148,13 +148,9 @@ module axi_demux #(
     // AW Channel
     //--------------------------------------
     // spill register at the channel input
-    `ifdef TARGET_VSIM
     // Workaround for bug in Questa 2020.2 and 2021.1: Flatten the struct into a logic vector before
     // instantiating `spill_register`.
     typedef logic [$bits(aw_chan_select_t)-1:0] aw_chan_select_flat_t;
-    `else
-    typedef aw_chan_select_t aw_chan_select_flat_t;
-    `endif
     aw_chan_select_flat_t slv_aw_chan_select_in_flat,
                           slv_aw_chan_select_out_flat;
     assign slv_aw_chan_select_in_flat = {slv_req_i.aw, slv_aw_select_i};
@@ -337,13 +333,9 @@ module axi_demux #(
     //--------------------------------------
     //  AR Channel
     //--------------------------------------
-    `ifdef TARGET_VSIM
     // Workaround for bug in Questa 2020.2 and 2021.1: Flatten the struct into a logic vector before
     // instantiating `spill_register`.
     typedef logic [$bits(ar_chan_select_t)-1:0] ar_chan_select_flat_t;
-    `else
-    typedef ar_chan_select_t ar_chan_select_flat_t;
-    `endif
     ar_chan_select_flat_t slv_ar_chan_select_in_flat,
                           slv_ar_chan_select_out_flat;
     assign slv_ar_chan_select_in_flat = {slv_req_i.ar, slv_ar_select_i};


### PR DESCRIPTION
As discussed in https://github.com/pulp-platform/axi/issues/202 I submit a PR for the prefered solution (also consistent with `axi_lite_demux`)