### PR TITLE
axi_id_remap: Fix verilator ifndef not covering asserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- `axi_id_remap`: Improve compatibility with Verilator by excluding `assert`s for that tool.
 - `axi_lite_demux`: Improve compatibility with VCS (issue #187 reported for `axi_demux`, which was
   fixed in v0.29.2).
 

--- a/src/axi_id_remap.sv
+++ b/src/axi_id_remap.sv
@@ -378,7 +378,6 @@ module axi_id_remap #(
     assert ($bits(mst_req_o.ar.id) == AxiMstPortIdWidth);
     assert ($bits(mst_resp_i.r.id) == AxiMstPortIdWidth);
   end
-  `endif
   default disable iff (!rst_ni);
   assert property (@(posedge clk_i) slv_req_i.aw_valid && slv_resp_o.aw_ready
       |-> mst_req_o.aw_valid && mst_resp_i.aw_ready);
@@ -394,6 +393,7 @@ module axi_id_remap #(
       |=> mst_req_o.ar_valid && $stable(mst_req_o.ar.id));
   assert property (@(posedge clk_i) mst_req_o.aw_valid && !mst_resp_i.aw_ready
       |=> mst_req_o.aw_valid && $stable(mst_req_o.aw.id));
+  `endif
   // pragma translate_on
 endmodule
 


### PR DESCRIPTION
Verilator doesn't like asserts.