### PR TITLE
axi_cdc: Improve compatibility with VCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- `axi_cdc`: Improve compatibility with VCS by restricting a QuestaSim workaround to be used only
+  for QuestaSim (issue #207).
 - `axi_id_remap`: Improve compatibility with Verilator by excluding `assert`s for that tool.
 - `axi_lite_demux`: Improve compatibility with VCS (issue #187 reported for `axi_demux`, which was
   fixed in v0.29.2).

--- a/src/axi_cdc_dst.sv
+++ b/src/axi_cdc_dst.sv
@@ -58,7 +58,13 @@ module axi_cdc_dst #(
 );
 
   cdc_fifo_gray_dst #(
+`ifdef QUESTA
+    // Workaround for a bug in Questa: Pass flat logic vector instead of struct to type parameter.
     .T          ( logic [$bits(aw_chan_t)-1:0]  ),
+`else
+    // Other tools, such as VCS, have problems with type parameters constructed through `$bits()`.
+    .T          ( aw_chan_t                     ),
+`endif
     .LOG_DEPTH  ( LogDepth                      )
   ) i_cdc_fifo_gray_dst_aw (
     .async_data_i ( async_data_slave_aw_data_i  ),
@@ -72,7 +78,11 @@ module axi_cdc_dst #(
   );
 
   cdc_fifo_gray_dst #(
+`ifdef QUESTA
     .T          ( logic [$bits(w_chan_t)-1:0] ),
+`else
+    .T          ( w_chan_t                    ),
+`endif
     .LOG_DEPTH  ( LogDepth                    )
   ) i_cdc_fifo_gray_dst_w (
     .async_data_i ( async_data_slave_w_data_i ),
@@ -86,7 +96,11 @@ module axi_cdc_dst #(
   );
 
   cdc_fifo_gray_src #(
+`ifdef QUESTA
     .T          ( logic [$bits(b_chan_t)-1:0] ),
+`else
+    .T          ( b_chan_t                    ),
+`endif
     .LOG_DEPTH  ( LogDepth                    )
   ) i_cdc_fifo_gray_src_b (
     .src_clk_i    ( dst_clk_i                 ),
@@ -100,7 +114,11 @@ module axi_cdc_dst #(
   );
 
   cdc_fifo_gray_dst #(
+`ifdef QUESTA
     .T          ( logic [$bits(ar_chan_t)-1:0]  ),
+`else
+    .T          ( ar_chan_t                     ),
+`endif
     .LOG_DEPTH  ( LogDepth                      )
   ) i_cdc_fifo_gray_dst_ar (
     .dst_clk_i,
@@ -114,7 +132,11 @@ module axi_cdc_dst #(
   );
 
   cdc_fifo_gray_src #(
+`ifdef QUESTA
     .T          ( logic [$bits(r_chan_t)-1:0] ),
+`else
+    .T          ( r_chan_t                    ),
+`endif
     .LOG_DEPTH  ( LogDepth                    )
   ) i_cdc_fifo_gray_src_r (
     .src_clk_i    ( dst_clk_i                 ),

--- a/src/axi_cdc_src.sv
+++ b/src/axi_cdc_src.sv
@@ -58,7 +58,12 @@ module axi_cdc_src #(
 );
 
   cdc_fifo_gray_src #(
+    // Workaround for a bug in Questa (see comment in `axi_cdc_dst` for details).
+`ifdef QUESTA
     .T         ( logic [$bits(aw_chan_t)-1:0] ),
+`else
+    .T         ( aw_chan_t                    ),
+`endif
     .LOG_DEPTH ( LogDepth                     )
   ) i_cdc_fifo_gray_src_aw (
     .src_clk_i,
@@ -72,7 +77,11 @@ module axi_cdc_src #(
   );
 
   cdc_fifo_gray_src #(
+`ifdef QUESTA
     .T         ( logic [$bits(w_chan_t)-1:0]  ),
+`else
+    .T         ( w_chan_t                     ),
+`endif
     .LOG_DEPTH ( LogDepth                     )
   ) i_cdc_fifo_gray_src_w (
     .src_clk_i,
@@ -86,7 +95,11 @@ module axi_cdc_src #(
   );
 
   cdc_fifo_gray_dst #(
+`ifdef QUESTA
     .T         ( logic [$bits(b_chan_t)-1:0]  ),
+`else
+    .T         ( b_chan_t                     ),
+`endif
     .LOG_DEPTH ( LogDepth                     )
   ) i_cdc_fifo_gray_dst_b (
     .dst_clk_i    ( src_clk_i                   ),
@@ -100,7 +113,11 @@ module axi_cdc_src #(
   );
 
   cdc_fifo_gray_src #(
+`ifdef QUESTA
     .T         ( logic [$bits(ar_chan_t)-1:0] ),
+`else
+    .T         ( ar_chan_t                    ),
+`endif
     .LOG_DEPTH ( LogDepth                     )
   ) i_cdc_fifo_gray_src_ar (
     .src_clk_i,
@@ -114,7 +131,11 @@ module axi_cdc_src #(
   );
 
   cdc_fifo_gray_dst #(
+`ifdef QUESTA
     .T         ( logic [$bits(r_chan_t)-1:0]  ),
+`else
+    .T         ( r_chan_t                     ),
+`endif
     .LOG_DEPTH ( LogDepth                     )
   ) i_cdc_fifo_gray_dst_r (
     .dst_clk_i    ( src_clk_i                   ),


### PR DESCRIPTION
Improve compatibility of `axi_cdc` with VCS by restricting a QuestaSim workaround to be used only for QuestaSim. This fixes issue #207.