### PR TITLE
AXI4 on chip memory slave

### DIFF
--- a/.ci/Memora.yml
+++ b/.ci/Memora.yml
@@ -258,6 +258,20 @@ artifacts:
     outputs:
       - build/axi_to_axi_lite-%.tested
 
+  axi_to_mem_banked-%:
+    inputs:
+      - Bender.yml
+      - include
+      - src/axi_pkg.sv
+      - src/axi_intf.sv
+      - src/axi_test.sv
+      - src/axi_demux.sv
+      - src/axi_to_mem.sv
+      - src/axi_to_mem_banked.sv
+      - test/tb_axi_to_mem_banked.sv
+    outputs:
+      - build/axi_to_mem_banked-%.tested
+
   axi_xbar-%:
     inputs:
       - Bender.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,6 +148,11 @@ axi_to_axi_lite:
   variables:
     TEST_MODULE: axi_to_axi_lite
 
+axi_to_mem_banked:
+  <<: *run_vsim
+  variables:
+    TEST_MODULE: axi_to_mem_banked
+
 axi_xbar:
   <<: *run_vsim
   variables:

--- a/Bender.yml
+++ b/Bender.yml
@@ -46,6 +46,7 @@ sources:
   - src/axi_modify_address.sv
   - src/axi_mux.sv
   - src/axi_serializer.sv
+  - src/axi_to_mem.sv
   # Level 3
   - src/axi_cdc.sv
   - src/axi_err_slv.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,7 +10,7 @@ package:
 dependencies:
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.21.0 }
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.0 }
-  tech_cells_generic:  { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.1 }
+  tech_cells_generic:  { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.2 }
 
 export_include_dirs:
   - include

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,6 +10,7 @@ package:
 dependencies:
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.21.0 }
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.0 }
+  tech_cells_generic:  { git: "https://github.com/pulp-platform/tech_cells_generic.git",  rev:     master }
 
 export_include_dirs:
   - include
@@ -54,6 +55,7 @@ sources:
   - src/axi_id_serialize.sv
   - src/axi_multicut.sv
   - src/axi_to_axi_lite.sv
+  - src/axi_to_mem_banked.sv
   # Level 4
   - src/axi_iw_converter.sv
   - src/axi_lite_xbar.sv
@@ -91,4 +93,5 @@ sources:
       - test/tb_axi_serializer.sv
       - test/tb_axi_sim_mem.sv
       - test/tb_axi_to_axi_lite.sv
+      - test/tb_axi_to_mem_banked.sv
       - test/tb_axi_xbar.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,7 +10,7 @@ package:
 dependencies:
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.21.0 }
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.0 }
-  tech_cells_generic:  { git: "https://github.com/pulp-platform/tech_cells_generic.git",  rev:     master }
+  tech_cells_generic:  { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.1 }
 
 export_include_dirs:
   - include

--- a/Bender.yml
+++ b/Bender.yml
@@ -56,6 +56,7 @@ sources:
   - src/axi_multicut.sv
   - src/axi_to_axi_lite.sv
   - src/axi_to_mem_banked.sv
+  - src/axi_to_mem_interleaved.sv
   # Level 4
   - src/axi_iw_converter.sv
   - src/axi_lite_xbar.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -57,6 +57,7 @@ sources:
   - src/axi_to_axi_lite.sv
   - src/axi_to_mem_banked.sv
   - src/axi_to_mem_interleaved.sv
+  - src/axi_to_mem_split.sv
   # Level 4
   - src/axi_iw_converter.sv
   - src/axi_lite_xbar.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_to_mem`: AXI4+ATOP slave to control on chip memory.
 - `axi_to_mem_banked`:  AXI4+ATOP slave to control on chip memory, with banking support, higher
                         throughput than `axi_to_mem`.
-- `Bender`: Add dependency `tech_cells_generic` `v0.2.1` for generic SRAM macro for simulation.
+- `Bender`: Add dependency `tech_cells_generic` `v0.2.2` for generic SRAM macro for simulation.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `axi_to_mem`: AXI4+ATOP slave to control on chip memory.
+- `axi_to_mem_banked`:  AXI4+ATOP slave to control on chip memory, with banking support, higher
+                        throughput than `axi_to_mem`.
+- `Bender`: Add dependency `tech_cells_generic` `v0.2.1` for generic SRAM macro for simulation.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+- `axi_to_mem`: AXI4+ATOP slave to control on chip memory.
 
 ### Changed
 

--- a/axi.core
+++ b/axi.core
@@ -38,6 +38,7 @@ filesets:
       - src/axi_modify_address.sv
       - src/axi_mux.sv
       - src/axi_serializer.sv
+      - src/axi_to_mem.sv
       # Level 3
       - src/axi_cdc.sv
       - src/axi_err_slv.sv
@@ -45,6 +46,7 @@ filesets:
       - src/axi_id_serialize.sv
       - src/axi_multicut.sv
       - src/axi_to_axi_lite.sv
+      - src/axi_to_mem_banked.sv
       # Level 4
       - src/axi_iw_converter.sv
       - src/axi_lite_xbar.sv

--- a/scripts/compile_vsim.sh
+++ b/scripts/compile_vsim.sh
@@ -18,7 +18,7 @@ set -e
 
 [ ! -z "$VSIM" ] || VSIM=vsim
 
-bender script vsim -t test \
+bender script vsim -t test -t rtl \
     --vlog-arg="-svinputport=compat" \
     --vlog-arg="-override_timescale 1ns/1ps" \
     --vlog-arg="-suppress 2583" \

--- a/scripts/run_vsim.sh
+++ b/scripts/run_vsim.sh
@@ -174,6 +174,27 @@ exec_test() {
                 done
             done
             ;;
+        axi_to_mem_banked)
+            for MEM_LAT in 1 2; do
+                for BANK_FACTOR in 1 2; do
+                    for NUM_BANKS in 1 2 4 ; do
+                        for AXI_DATA_WIDTH in 64 256 ; do
+                            for NUM_WORDS in 512 2048; do
+                                ACT_BANKS=$((2*$BANK_FACTOR*$NUM_BANKS))
+                                MEM_DATA_WIDTH=$(($AXI_DATA_WIDTH/$NUM_BANKS))
+                                call_vsim tb_axi_to_mem_banked \
+                                    -voptargs="+acc +cover=bcesfx" \
+                                    -gTbAxiDataWidth=$AXI_DATA_WIDTH \
+                                    -gTbNumWords=$NUM_WORDS \
+                                    -gTbNumBanks=$ACT_BANKS \
+                                    -gTbMemDataWidth=$MEM_DATA_WIDTH \
+                                    -gTbMemLatency=$MEM_LAT
+                            done
+                        done
+                    done
+                done
+            done
+            ;;
         *)
             call_vsim tb_$1 -t 1ns -coverage -voptargs="+acc +cover=bcesfx"
             ;;

--- a/src/axi_to_mem.sv
+++ b/src/axi_to_mem.sv
@@ -1,0 +1,697 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Authors:
+// - Andreas Kurth <akurth@iis.ee.ethz.ch>
+// - Wolfgang Roenninger <wroennin@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+/// AXI4+ATOP slave module which translates AXI bursts into a memory stream.
+/// If both read and write channels of the AXI4+ATOP are active, both will have an
+/// utilization of 50%.
+module axi_to_mem #(
+  /// AXI4+ATOP request type. See `include/axi/typedef.svh`.
+  parameter type         axi_req_t  = logic,
+  /// AXI4+ATOP response type. See `include/axi/typedef.svh`.
+  parameter type         axi_resp_t = logic,
+  /// Address width, has to be less or equal than the width off the AXI address field.
+  /// Determines the width of `mem_addr_o`. Has to be wide enough to emit the memory region
+  /// which should be accessible.
+  parameter int unsigned AddrWidth  = 0,
+  /// AXI4+ATOP data width.
+  parameter int unsigned DataWidth  = 0,
+  /// AXI4+ATOP ID width.
+  parameter int unsigned IdWidth    = 0,
+  /// Number of banks at output, must evenly divide `DataWidth`.
+  parameter int unsigned NumBanks   = 0,
+  /// Depth of memory response buffer. This should be equal to the memory response latency.
+  parameter int unsigned BufDepth   = 1,
+  /// Dependent parameter, do not override. Memory address type.
+  localparam type addr_t     = logic [AddrWidth-1:0],
+  /// Dependent parameter, do not override. Memory data type.
+  localparam type mem_data_t = logic [DataWidth/NumBanks-1:0],
+  /// Dependent parameter, do not override. Memory write strobe type.
+  localparam type mem_strb_t = logic [DataWidth/NumBanks/8-1:0]
+) (
+  /// Clock input.
+  input  logic                           clk_i,
+  /// Asynchronous reset, active low.
+  input  logic                           rst_ni,
+  /// The unit is busy handling an AXI4+ATOP request.
+  output logic                           busy_o,
+  /// AXI4+ATOP slave port, request input.
+  input  axi_req_t                       axi_req_i,
+  /// AXI4+ATOP slave port, response output.
+  output axi_resp_t                      axi_resp_o,
+  /// Memory stream master, request is valid for this bank.
+  output logic           [NumBanks-1:0]  mem_req_o,
+  /// Memory stream master, request can be granted by this bank.
+  input  logic           [NumBanks-1:0]  mem_gnt_i,
+  /// Memory stream master, byte address of the request.
+  output addr_t          [NumBanks-1:0]  mem_addr_o,
+  /// Memory stream master, write data for this bank. Valid when `mem_req_o`.
+  output mem_data_t      [NumBanks-1:0]  mem_wdata_o,
+  /// Memory stream master, byte-wise strobe (byte enable).
+  output mem_strb_t      [NumBanks-1:0]  mem_strb_o,
+  /// Memory stream master, `axi_pkg::atop_t` signal associated with this request.
+  output axi_pkg::atop_t [NumBanks-1:0]  mem_atop_o,
+  /// Memory stream master, write enable. Then asserted store of `mem_w_data` is requested.
+  output logic           [NumBanks-1:0]  mem_we_o,
+  /// Memory stream master, response is valid. This module expects always a response valid for a
+  /// request regardless if the request was a write or a read.
+  input  logic           [NumBanks-1:0]  mem_rvalid_i,
+  /// Memory stream master, read response data.
+  input  mem_data_t      [NumBanks-1:0]  mem_rdata_i
+);
+
+  typedef logic [DataWidth-1:0]   axi_data_t;
+  typedef logic [DataWidth/8-1:0] axi_strb_t;
+  typedef logic [IdWidth-1:0]     axi_id_t;
+
+  typedef struct packed {
+    addr_t          addr;
+    axi_pkg::atop_t atop;
+    axi_strb_t      strb;
+    axi_data_t      wdata;
+    logic           we;
+  } mem_req_t;
+
+  typedef struct packed {
+    addr_t          addr;
+    axi_pkg::atop_t atop;
+    axi_id_t        id;
+    logic           last;
+    axi_pkg::qos_t  qos;
+    axi_pkg::size_t size;
+    logic           write;
+  } meta_t;
+
+  axi_data_t      mem_rdata,
+                  m2s_resp;
+  axi_pkg::len_t  r_cnt_d,        r_cnt_q,
+                  w_cnt_d,        w_cnt_q;
+  logic           arb_valid,      arb_ready,
+                  rd_valid,       rd_ready,
+                  wr_valid,       wr_ready,
+                  sel_b,          sel_buf_b,
+                  sel_r,          sel_buf_r,
+                  sel_valid,      sel_ready,
+                  sel_buf_valid,  sel_buf_ready,
+                  sel_lock_d,     sel_lock_q,
+                  meta_valid,     meta_ready,
+                  meta_buf_valid, meta_buf_ready,
+                  meta_sel_d,     meta_sel_q,
+                  m2s_req_valid,  m2s_req_ready,
+                  m2s_resp_valid, m2s_resp_ready,
+                  mem_req_valid,  mem_req_ready,
+                  mem_rvalid;
+  mem_req_t       m2s_req,
+                  mem_req;
+  meta_t          rd_meta,
+                  rd_meta_d,      rd_meta_q,
+                  wr_meta,
+                  wr_meta_d,      wr_meta_q,
+                  meta,           meta_buf;
+
+  assign busy_o = axi_req_i.aw_valid | axi_req_i.ar_valid | axi_req_i.w_valid |
+                    axi_resp_o.b_valid | axi_resp_o.r_valid |
+                    (r_cnt_q > 0) | (w_cnt_q > 0);
+
+  // Handle reads.
+  always_comb begin
+    // Default assignments
+    axi_resp_o.ar_ready = 1'b0;
+    rd_meta_d           = rd_meta_q;
+    rd_meta             = 'x;
+    rd_valid            = 1'b0;
+    r_cnt_d             = r_cnt_q;
+    // Handle R burst in progress.
+    if (r_cnt_q > '0) begin
+      rd_meta_d.last = (r_cnt_q == 8'd1);
+      rd_meta        = rd_meta_d;
+      rd_meta.addr   = rd_meta_q.addr + axi_pkg::num_bytes(rd_meta_q.size);
+      rd_valid       = 1'b1;
+      if (rd_ready) begin
+        r_cnt_d--;
+        rd_meta_d.addr = rd_meta.addr;
+      end
+    // Handle new AR if there is one.
+    end else if (axi_req_i.ar_valid) begin
+      rd_meta_d = '{
+        addr:  addr_t'(axi_pkg::aligned_addr(axi_req_i.ar.addr, axi_req_i.ar.size)),
+        atop:  '0,
+        id:    axi_req_i.ar.id,
+        last:  (axi_req_i.ar.len == '0),
+        qos:   axi_req_i.ar.qos,
+        size:  axi_req_i.ar.size,
+        write: 1'b0
+      };
+      rd_meta      = rd_meta_d;
+      rd_meta.addr = addr_t'(axi_req_i.ar.addr);
+      rd_valid     = 1'b1;
+      if (rd_ready) begin
+        r_cnt_d             = axi_req_i.ar.len;
+        axi_resp_o.ar_ready = 1'b1;
+      end
+    end
+  end
+
+  // Handle writes.
+  always_comb begin
+    // Default assignments
+    axi_resp_o.aw_ready = 1'b0;
+    axi_resp_o.w_ready  = 1'b0;
+    wr_meta_d           = wr_meta_q;
+    wr_meta             = 'x;
+    wr_valid            = 1'b0;
+    w_cnt_d             = w_cnt_q;
+    // Handle W bursts in progress.
+    if (w_cnt_q > '0) begin
+      wr_meta_d.last = (w_cnt_q == 8'd1);
+      wr_meta        = wr_meta_d;
+      wr_meta.addr   = wr_meta_q.addr + axi_pkg::num_bytes(wr_meta_q.size);
+      if (axi_req_i.w_valid) begin
+        wr_valid = 1'b1;
+        if (wr_ready) begin
+          axi_resp_o.w_ready = 1'b1;
+          w_cnt_d--;
+          wr_meta_d.addr = wr_meta.addr;
+        end
+      end
+    // Handle new AW if there is one.
+    end else if (axi_req_i.aw_valid && axi_req_i.w_valid) begin
+      wr_meta_d = '{
+        addr:   addr_t'(axi_pkg::aligned_addr(axi_req_i.aw.addr, axi_req_i.aw.size)),
+        atop:   axi_req_i.aw.atop,
+        id:     axi_req_i.aw.id,
+        last:   (axi_req_i.aw.len == '0),
+        qos:    axi_req_i.aw.qos,
+        size:   axi_req_i.aw.size,
+        write:  1'b1
+      };
+      wr_meta = wr_meta_d;
+      wr_meta.addr = addr_t'(axi_req_i.aw.addr);
+      wr_valid = 1'b1;
+      if (wr_ready) begin
+        w_cnt_d = axi_req_i.aw.len;
+        axi_resp_o.aw_ready = 1'b1;
+        axi_resp_o.w_ready = 1'b1;
+      end
+    end
+  end
+
+  // Arbitrate between reads and writes.
+  stream_mux #(
+    .DATA_T (meta_t),
+    .N_INP  (2)
+  ) i_ax_mux (
+    .inp_data_i   ({wr_meta, rd_meta}),
+    .inp_valid_i  ({wr_valid, rd_valid}),
+    .inp_ready_o  ({wr_ready, rd_ready}),
+    .inp_sel_i    (meta_sel_d),
+    .oup_data_o   (meta),
+    .oup_valid_o  (arb_valid),
+    .oup_ready_i  (arb_ready)
+  );
+  always_comb begin
+    meta_sel_d = meta_sel_q;
+    sel_lock_d = sel_lock_q;
+    if (sel_lock_q) begin
+      meta_sel_d = meta_sel_q;
+      if (arb_valid && arb_ready) begin
+        sel_lock_d = 1'b0;
+      end
+    end else begin
+      if (wr_valid ^ rd_valid) begin
+        // If either write or read is valid but not both, select the valid one.
+        meta_sel_d = wr_valid;
+      end else if (wr_valid && rd_valid) begin
+        // If both write and read are valid, decide according to QoS then burst properties.
+        // Prioritize higher QoS.
+        if (wr_meta.qos > rd_meta.qos) begin
+          meta_sel_d = 1'b1;
+        end else if (rd_meta.qos > wr_meta.qos) begin
+          meta_sel_d = 1'b0;
+        // Decide requests with identical QoS.
+        end else if (wr_meta.qos == rd_meta.qos) begin
+          // 1. Prioritize individual writes over read bursts.
+          // Rationale: Read bursts can be interleaved on AXI but write bursts cannot.
+          if (wr_meta.last && !rd_meta.last) begin
+            meta_sel_d = 1'b1;
+          // 2. Prioritize ongoing burst.
+          // Rationale: Stalled bursts create back-pressure or require costly buffers.
+          end else if (w_cnt_q > '0) begin
+            meta_sel_d = 1'b1;
+          end else if (r_cnt_q > '0) begin
+            meta_sel_d = 1'b0;
+          // 3. Otherwise arbitrate round robin to prevent starvation.
+          end else begin
+            meta_sel_d = ~meta_sel_q;
+          end
+        end
+      end
+      // Lock arbitration if valid but not yet ready.
+      if (arb_valid && !arb_ready) begin
+        sel_lock_d = 1'b1;
+      end
+    end
+  end
+
+  // Fork arbitrated stream to meta data, memory requests, and R/B channel selection.
+  stream_fork #(
+    .N_OUP ( 32'd3 )
+  ) i_fork (
+    .clk_i,
+    .rst_ni,
+    .valid_i ( arb_valid                            ),
+    .ready_o ( arb_ready                            ),
+    .valid_o ({sel_valid, meta_valid, m2s_req_valid}),
+    .ready_i ({sel_ready, meta_ready, m2s_req_ready})
+  );
+
+  assign sel_b = meta.write & meta.last;
+  assign sel_r = ~meta.write | meta.atop[5];
+
+  stream_fifo #(
+    .FALL_THROUGH ( 1'b1             ),
+    .DEPTH        ( 32'd1 + BufDepth ),
+    .T            ( logic[1:0]       )
+  ) i_sel_buf (
+    .clk_i,
+    .rst_ni,
+    .flush_i    ( 1'b0                    ),
+    .testmode_i ( 1'b0                    ),
+    .data_i     ({sel_b,        sel_r    }),
+    .valid_i    ( sel_valid               ),
+    .ready_o    ( sel_ready               ),
+    .data_o     ({sel_buf_b,    sel_buf_r}),
+    .valid_o    ( sel_buf_valid           ),
+    .ready_i    ( sel_buf_ready           ),
+    .usage_o    ( /* unused */            )
+  );
+
+  stream_fifo #(
+    .FALL_THROUGH ( 1'b1             ),
+    .DEPTH        ( 32'd1 + BufDepth ),
+    .T            ( meta_t           )
+  ) i_meta_buf (
+    .clk_i,
+    .rst_ni,
+    .flush_i    ( 1'b0           ),
+    .testmode_i ( 1'b0           ),
+    .data_i     ( meta           ),
+    .valid_i    ( meta_valid     ),
+    .ready_o    ( meta_ready     ),
+    .data_o     ( meta_buf       ),
+    .valid_o    ( meta_buf_valid ),
+    .ready_i    ( meta_buf_ready ),
+    .usage_o    ( /* unused */   )
+  );
+
+  // Assemble the actual memory request from meta information and write data.
+  assign m2s_req = '{
+    addr:  meta.addr,
+    atop:  meta.atop,
+    strb:  axi_req_i.w.strb,
+    wdata: axi_req_i.w.data,
+    we:    meta.write
+  };
+
+  // Interface memory as stream.
+  stream_to_mem #(
+    .mem_req_t  ( mem_req_t  ),
+    .mem_resp_t ( axi_data_t ),
+    .BufDepth   ( BufDepth   )
+  ) i_stream_to_mem (
+    .clk_i,
+    .rst_ni,
+    .req_i            ( m2s_req        ),
+    .req_valid_i      ( m2s_req_valid  ),
+    .req_ready_o      ( m2s_req_ready  ),
+    .resp_o           ( m2s_resp       ),
+    .resp_valid_o     ( m2s_resp_valid ),
+    .resp_ready_i     ( m2s_resp_ready ),
+    .mem_req_o        ( mem_req        ),
+    .mem_req_valid_o  ( mem_req_valid  ),
+    .mem_req_ready_i  ( mem_req_ready  ),
+    .mem_resp_i       ( mem_rdata      ),
+    .mem_resp_valid_i ( mem_rvalid     )
+  );
+
+  // Split single memory request to desired number of banks.
+  mem_to_banks #(
+    .AddrWidth  ( AddrWidth ),
+    .DataWidth  ( DataWidth ),
+    .NumBanks   ( NumBanks  )
+  ) i_mem_to_banks (
+    .clk_i,
+    .rst_ni,
+    .req_i         ( mem_req_valid ),
+    .gnt_o         ( mem_req_ready ),
+    .addr_i        ( mem_req.addr  ),
+    .wdata_i       ( mem_req.wdata ),
+    .strb_i        ( mem_req.strb  ),
+    .atop_i        ( mem_req.atop  ),
+    .we_i          ( mem_req.we    ),
+    .rvalid_o      ( mem_rvalid    ),
+    .rdata_o       ( mem_rdata     ),
+    .bank_req_o    ( mem_req_o     ),
+    .bank_gnt_i    ( mem_gnt_i     ),
+    .bank_addr_o   ( mem_addr_o    ),
+    .bank_wdata_o  ( mem_wdata_o   ),
+    .bank_strb_o   ( mem_strb_o    ),
+    .bank_atop_o   ( mem_atop_o    ),
+    .bank_we_o     ( mem_we_o      ),
+    .bank_rvalid_i ( mem_rvalid_i  ),
+    .bank_rdata_i  ( mem_rdata_i   )
+  );
+
+  // Join memory read data and meta data stream.
+  logic mem_join_valid, mem_join_ready;
+  stream_join #(
+    .N_INP ( 32'd2 )
+  ) i_join (
+    .inp_valid_i  ({m2s_resp_valid, meta_buf_valid}),
+    .inp_ready_o  ({m2s_resp_ready, meta_buf_ready}),
+    .oup_valid_o  ( mem_join_valid                 ),
+    .oup_ready_i  ( mem_join_ready                 )
+  );
+
+  // Dynamically fork the joined stream to B and R channels.
+  stream_fork_dynamic #(
+    .N_OUP ( 32'd2 )
+  ) i_fork_dynamic (
+    .clk_i,
+    .rst_ni,
+    .valid_i      ( mem_join_valid                         ),
+    .ready_o      ( mem_join_ready                         ),
+    .sel_i        ({sel_buf_b,          sel_buf_r         }),
+    .sel_valid_i  ( sel_buf_valid                          ),
+    .sel_ready_o  ( sel_buf_ready                          ),
+    .valid_o      ({axi_resp_o.b_valid, axi_resp_o.r_valid}),
+    .ready_i      ({axi_req_i.b_ready,  axi_req_i.r_ready })
+  );
+
+  // Compose B responses.
+  assign axi_resp_o.b = '{
+    id:   meta_buf.id,
+    resp: axi_pkg::RESP_OKAY,
+    user: '0
+  };
+
+  // Compose R responses.
+  assign axi_resp_o.r = '{
+    data: m2s_resp,
+    id:   meta_buf.id,
+    last: meta_buf.last,
+    resp: axi_pkg::RESP_OKAY,
+    user: '0
+  };
+
+  // Registers
+  `FFARN(meta_sel_q, meta_sel_d, 1'b0, clk_i, rst_ni)
+  `FFARN(sel_lock_q, sel_lock_d, 1'b0, clk_i, rst_ni)
+  `FFARN(rd_meta_q, rd_meta_d, '{default: '0}, clk_i, rst_ni)
+  `FFARN(wr_meta_q, wr_meta_d, '{default: '0}, clk_i, rst_ni)
+  `FFARN(r_cnt_q, r_cnt_d, '0, clk_i, rst_ni)
+  `FFARN(w_cnt_q, w_cnt_d, '0, clk_i, rst_ni)
+
+  // Assertions
+  // pragma translate_off
+  `ifndef VERILATOR
+  default disable iff (!rst_ni);
+  assume property (@(posedge clk_i)
+      axi_req_i.ar_valid && !axi_resp_o.ar_ready |=> $stable(axi_req_i.ar))
+    else $error("AR must remain stable until handshake has happened!");
+  assert property (@(posedge clk_i)
+      axi_resp_o.r_valid && !axi_req_i.r_ready |=> $stable(axi_resp_o.r))
+    else $error("R must remain stable until handshake has happened!");
+  assume property (@(posedge clk_i)
+      axi_req_i.aw_valid && !axi_resp_o.aw_ready |=> $stable(axi_req_i.aw))
+    else $error("AW must remain stable until handshake has happened!");
+  assume property (@(posedge clk_i)
+      axi_req_i.w_valid && !axi_resp_o.w_ready |=> $stable(axi_req_i.w))
+    else $error("W must remain stable until handshake has happened!");
+  assert property (@(posedge clk_i)
+      axi_resp_o.b_valid && !axi_req_i.b_ready |=> $stable(axi_resp_o.b))
+    else $error("B must remain stable until handshake has happened!");
+  assert property (@(posedge clk_i) axi_req_i.ar_valid && axi_req_i.ar.len > 0 |->
+      axi_req_i.ar.burst == axi_pkg::BURST_INCR)
+    else $error("Non-incrementing bursts are not supported!");
+  assert property (@(posedge clk_i) axi_req_i.aw_valid && axi_req_i.aw.len > 0 |->
+      axi_req_i.aw.burst == axi_pkg::BURST_INCR)
+    else $error("Non-incrementing bursts are not supported!");
+  assert property (@(posedge clk_i) meta_valid && meta.atop != '0 |-> meta.write)
+    else $warning("Unexpected atomic operation on read.");
+  `endif
+  // pragma translate_on
+endmodule
+
+
+`include "axi/assign.svh"
+`include "axi/typedef.svh"
+/// Interface wrapper for module `axi_to_mem`.
+module axi_to_mem_intf #(
+  /// See `axi_to_mem`, parameter `AddrWidth`.
+  parameter int unsigned ADDR_WIDTH = 32'd0,
+  /// See `axi_to_mem`, parameter `DataWidth`.
+  parameter int unsigned DATA_WIDTH = 32'd0,
+  /// AXI4+ATOP ID width.
+  parameter int unsigned ID_WIDTH   = 32'd0,
+  /// AXI4+ATOP user width.
+  parameter int unsigned USER_WIDTH = 32'd0,
+  /// See `axi_to_mem`, parameter `NumBanks`.
+  parameter int unsigned NUM_BANKS  = 32'd0,
+  /// See `axi_to_mem`, parameter `BufDepth`.
+  parameter int unsigned BUF_DEPTH  = 32'd1,
+  /// Dependent parameter, do not override. See `axi_to_mem`, parameter `addr_t`.
+  localparam type addr_t     = logic [ADDR_WIDTH-1:0],
+  /// Dependent parameter, do not override. See `axi_to_mem`, parameter `mem_data_t`.
+  localparam type mem_data_t = logic [DATA_WIDTH/NUM_BANKS-1:0],
+  /// Dependent parameter, do not override. See `axi_to_mem`, parameter `mem_strb_t`.
+  localparam type mem_strb_t = logic [DATA_WIDTH/NUM_BANKS/8-1:0]
+) (
+  /// Clock input.
+  input  logic                            clk_i,
+  /// Asynchronous reset, active low.
+  input  logic                            rst_ni,
+  /// See `axi_to_mem`, port `busy_o`.
+  output logic                            busy_o,
+  /// AXI4+ATOP slave interface port.
+  AXI_BUS.Slave                           slv,
+  /// See `axi_to_mem`, port `mem_req_o`.
+  output logic           [NUM_BANKS-1:0]  mem_req_o,
+  /// See `axi_to_mem`, port `mem_gnt_i`.
+  input  logic           [NUM_BANKS-1:0]  mem_gnt_i,
+  /// See `axi_to_mem`, port `mem_addr_o`.
+  output addr_t          [NUM_BANKS-1:0]  mem_addr_o,
+  /// See `axi_to_mem`, port `mem_wdata_o`.
+  output mem_data_t      [NUM_BANKS-1:0]  mem_wdata_o,
+  /// See `axi_to_mem`, port `mem_strb_o`.
+  output mem_strb_t      [NUM_BANKS-1:0]  mem_strb_o,
+  /// See `axi_to_mem`, port `mem_atop_o`.
+  output axi_pkg::atop_t [NUM_BANKS-1:0]  mem_atop_o,
+  /// See `axi_to_mem`, port `mem_we_o`.
+  output logic           [NUM_BANKS-1:0]  mem_we_o,
+  /// See `axi_to_mem`, port `mem_rvalid_i`.
+  input  logic           [NUM_BANKS-1:0]  mem_rvalid_i,
+  /// See `axi_to_mem`, port `mem_rdata_i`.
+  input  mem_data_t      [NUM_BANKS-1:0]  mem_rdata_i
+);
+  typedef logic [ID_WIDTH-1:0]     id_t;
+  typedef logic [DATA_WIDTH-1:0]   data_t;
+  typedef logic [DATA_WIDTH/8-1:0] strb_t;
+  typedef logic [USER_WIDTH-1:0]   user_t;
+  `AXI_TYPEDEF_AW_CHAN_T(aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(w_chan_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(b_chan_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(ar_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(r_chan_t, data_t, id_t, user_t)
+  `AXI_TYPEDEF_REQ_T(req_t, aw_chan_t, w_chan_t, ar_chan_t)
+  `AXI_TYPEDEF_RESP_T(resp_t, b_chan_t, r_chan_t)
+  req_t   req;
+  resp_t  resp;
+  `AXI_ASSIGN_TO_REQ(req, slv)
+  `AXI_ASSIGN_FROM_RESP(slv, resp)
+  axi_to_mem #(
+    .axi_req_t  ( req_t     ),
+    .axi_resp_t ( resp_t    ),
+    .AddrWidth  ( ADDR_WIDTH ),
+    .DataWidth  ( DATA_WIDTH ),
+    .IdWidth    ( ID_WIDTH   ),
+    .NumBanks   ( NUM_BANKS  ),
+    .BufDepth   ( BUF_DEPTH  )
+  ) i_axi_to_mem (
+    .clk_i,
+    .rst_ni,
+    .busy_o,
+    .axi_req_i  ( req  ),
+    .axi_resp_o ( resp ),
+    .mem_req_o,
+    .mem_gnt_i,
+    .mem_addr_o,
+    .mem_wdata_o,
+    .mem_strb_o,
+    .mem_atop_o,
+    .mem_we_o,
+    .mem_rvalid_i,
+    .mem_rdata_i
+  );
+endmodule
+
+/// Split memory access over multiple parallel banks, where each bank has its own req/gnt
+/// request and valid response direction.
+module mem_to_banks #(
+  /// Input address width.
+  parameter int unsigned AddrWidth = 32'd0,
+  /// Input data width, must be a power of two.
+  parameter int unsigned DataWidth = 32'd0,
+  /// Number of banks at output, must evenly divide `DataWidth`.
+  parameter int unsigned NumBanks  = 32'd0,
+  /// Dependent parameter, do not override! Address type.
+  localparam type addr_t     = logic [AddrWidth-1:0],
+  /// Dependent parameter, do not override! Input data type.
+  localparam type inp_data_t = logic [DataWidth-1:0],
+  /// Dependent parameter, do not override! Input write strobe type.
+  localparam type inp_strb_t = logic [DataWidth/8-1:0],
+  /// Dependent parameter, do not override! Output data type.
+  localparam type oup_data_t = logic [DataWidth/NumBanks-1:0],
+  /// Dependent parameter, do not override! Output write strobe type.
+  localparam type oup_strb_t = logic [DataWidth/NumBanks/8-1:0]
+) (
+  /// Clock input.
+  input  logic                      clk_i,
+  /// Asynchronous reset, active low.
+  input  logic                      rst_ni,
+  /// Memory request to split, request is valid.
+  input  logic                      req_i,
+  /// Memory request to split, request can be granted.
+  output logic                      gnt_o,
+  /// Memory request to split, request address, byte-wise.
+  input  addr_t                     addr_i,
+  /// Memory request to split, request write data.
+  input  inp_data_t                 wdata_i,
+  /// Memory request to split, request write strobe.
+  input  inp_strb_t                 strb_i,
+  /// Memory request to split, request Atomic signal from AXI4+ATOP.
+  input  axi_pkg::atop_t            atop_i,
+  /// Memory request to split, request write enable, active high.
+  input  logic                      we_i,
+  /// Memory request to split, response is valid. Required for read and write requests
+  output logic                      rvalid_o,
+  /// Memory request to split, response read data.
+  output inp_data_t                 rdata_o,
+  /// Memory bank request, request is valid.
+  output logic           [NumBanks-1:0]  bank_req_o,
+  /// Memory bank request, request can be granted.
+  input  logic           [NumBanks-1:0]  bank_gnt_i,
+  /// Memory bank request, request address, byte-wise. Will be different for each bank.
+  output addr_t          [NumBanks-1:0]  bank_addr_o,
+  /// Memory bank request, request write data.
+  output oup_data_t      [NumBanks-1:0]  bank_wdata_o,
+  /// Memory bank request, request write strobe.
+  output oup_strb_t      [NumBanks-1:0]  bank_strb_o,
+  /// Memory bank request, request Atomic signal from AXI4+ATOP.
+  output axi_pkg::atop_t [NumBanks-1:0]  bank_atop_o,
+  /// Memory bank request, request write enable, active high.
+  output logic           [NumBanks-1:0]  bank_we_o,
+  /// Memory bank request, response is valid. Required for read and write requests
+  input  logic           [NumBanks-1:0]  bank_rvalid_i,
+  /// Memory bank request, response read data.
+  input  oup_data_t      [NumBanks-1:0]  bank_rdata_i
+);
+
+  localparam DataBytes    = $bits(inp_strb_t);
+  localparam BitsPerBank  = $bits(oup_data_t);
+  localparam BytesPerBank = $bits(oup_strb_t);
+
+  typedef struct packed {
+    addr_t          addr;
+    oup_data_t      wdata;
+    oup_strb_t      strb;
+    axi_pkg::atop_t atop;
+    logic           we;
+  } req_t;
+
+  logic                 req_valid;
+  logic [NumBanks-1:0]              req_ready,
+                        resp_valid, resp_ready;
+  req_t [NumBanks-1:0]  bank_req,
+                        bank_oup;
+
+  function automatic addr_t align_addr(input addr_t addr);
+    return (addr >> $clog2(DataBytes)) << $clog2(DataBytes);
+  endfunction
+
+  // Handle requests.
+  assign req_valid = req_i & gnt_o;
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_reqs
+    assign bank_req[i].addr  = align_addr(addr_i) + i * BytesPerBank;
+    assign bank_req[i].wdata = wdata_i[i*BitsPerBank+:BitsPerBank];
+    assign bank_req[i].strb  = strb_i[i*BytesPerBank+:BytesPerBank];
+    assign bank_req[i].atop  = atop_i;
+    assign bank_req[i].we    = we_i;
+    fall_through_register #(
+      .T ( req_t )
+    ) i_ft_reg (
+      .clk_i,
+      .rst_ni,
+      .clr_i      ( 1'b0          ),
+      .testmode_i ( 1'b0          ),
+      .valid_i    ( req_valid     ),
+      .ready_o    ( req_ready[i]  ),
+      .data_i     ( bank_req[i]   ),
+      .valid_o    ( bank_req_o[i] ),
+      .ready_i    ( bank_gnt_i[i] ),
+      .data_o     ( bank_oup[i]   )
+    );
+    assign bank_addr_o[i]  = bank_oup[i].addr;
+    assign bank_wdata_o[i] = bank_oup[i].wdata;
+    assign bank_strb_o[i]  = bank_oup[i].strb;
+    assign bank_atop_o[i]  = bank_oup[i].atop;
+    assign bank_we_o[i]    = bank_oup[i].we;
+  end
+
+  // Grant output if all our requests have been granted.
+  assign gnt_o = (&req_ready) & (&resp_ready);
+
+  // Handle responses.
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_resp_regs
+    fall_through_register #(
+      .T ( oup_data_t )
+    ) i_ft_reg (
+      .clk_i,
+      .rst_ni,
+      .clr_i      ( 1'b0                                ),
+      .testmode_i ( 1'b0                                ),
+      .valid_i    ( bank_rvalid_i[i]                    ),
+      .ready_o    ( resp_ready[i]                       ),
+      .data_i     ( bank_rdata_i[i]                     ),
+      .data_o     ( rdata_o[i*BitsPerBank+:BitsPerBank] ),
+      .ready_i    ( rvalid_o                            ),
+      .valid_o    ( resp_valid[i]                       )
+    );
+  end
+  assign rvalid_o = &resp_valid;
+
+  // Assertions
+  // pragma translate_off
+  `ifndef VERILATOR
+    initial begin
+      assume (DataWidth != 0 && (DataWidth & (DataWidth - 1)) == 0)
+        else $fatal(1, "Data width must be a power of two!");
+      assume (DataWidth % NumBanks == 0)
+        else $fatal(1, "Data width must be evenly divisible over banks!");
+      assume ((DataWidth / NumBanks) % 8 == 0)
+        else $fatal(1, "Data width of each bank must be divisible into 8-bit bytes!");
+    end
+  `endif
+  // pragma translate_on
+endmodule

--- a/src/axi_to_mem.sv
+++ b/src/axi_to_mem.sv
@@ -316,7 +316,7 @@ module axi_to_mem #(
   );
 
   // Assemble the actual memory request from meta information and write data.
-  assign m2s_req = '{
+  assign m2s_req = mem_req_t'{
     addr:  meta.addr,
     atop:  meta.atop,
     strb:  axi_req_i.w.strb,
@@ -632,7 +632,7 @@ module mem_to_banks #(
 
   // Handle requests.
   assign req_valid = req_i & gnt_o;
-  for (genvar i = 0; i < NumBanks; i++) begin : gen_reqs
+  for (genvar i = 0; unsigned'(i) < NumBanks; i++) begin : gen_reqs
     assign bank_req[i].addr  = align_addr(addr_i) + i * BytesPerBank;
     assign bank_req[i].wdata = wdata_i[i*BitsPerBank+:BitsPerBank];
     assign bank_req[i].strb  = strb_i[i*BytesPerBank+:BytesPerBank];
@@ -663,7 +663,7 @@ module mem_to_banks #(
   assign gnt_o = (&req_ready) & (&resp_ready);
 
   // Handle responses.
-  for (genvar i = 0; i < NumBanks; i++) begin : gen_resp_regs
+  for (genvar i = 0; unsigned'(i) < NumBanks; i++) begin : gen_resp_regs
     fall_through_register #(
       .T ( oup_data_t )
     ) i_ft_reg (

--- a/src/axi_to_mem.sv
+++ b/src/axi_to_mem.sv
@@ -129,7 +129,7 @@ module axi_to_mem #(
     // Default assignments
     axi_resp_o.ar_ready = 1'b0;
     rd_meta_d           = rd_meta_q;
-    rd_meta             = 'x;
+    rd_meta             = meta_t'{default: '0};
     rd_valid            = 1'b0;
     r_cnt_d             = r_cnt_q;
     // Handle R burst in progress.
@@ -169,7 +169,7 @@ module axi_to_mem #(
     axi_resp_o.aw_ready = 1'b0;
     axi_resp_o.w_ready  = 1'b0;
     wr_meta_d           = wr_meta_q;
-    wr_meta             = 'x;
+    wr_meta             = meta_t'{default: '0};
     wr_valid            = 1'b0;
     w_cnt_d             = w_cnt_q;
     // Handle W bursts in progress.
@@ -209,16 +209,16 @@ module axi_to_mem #(
 
   // Arbitrate between reads and writes.
   stream_mux #(
-    .DATA_T (meta_t),
-    .N_INP  (2)
+    .DATA_T ( meta_t ),
+    .N_INP  ( 32'd2  )
   ) i_ax_mux (
-    .inp_data_i   ({wr_meta, rd_meta}),
+    .inp_data_i   ({wr_meta,  rd_meta }),
     .inp_valid_i  ({wr_valid, rd_valid}),
     .inp_ready_o  ({wr_ready, rd_ready}),
-    .inp_sel_i    (meta_sel_d),
-    .oup_data_o   (meta),
-    .oup_valid_o  (arb_valid),
-    .oup_ready_i  (arb_ready)
+    .inp_sel_i    ( meta_sel_d         ),
+    .oup_data_o   ( meta               ),
+    .oup_valid_o  ( arb_valid          ),
+    .oup_ready_i  ( arb_ready          )
   );
   always_comb begin
     meta_sel_d = meta_sel_q;

--- a/src/axi_to_mem.sv
+++ b/src/axi_to_mem.sv
@@ -418,8 +418,8 @@ module axi_to_mem #(
   // Registers
   `FFARN(meta_sel_q, meta_sel_d, 1'b0, clk_i, rst_ni)
   `FFARN(sel_lock_q, sel_lock_d, 1'b0, clk_i, rst_ni)
-  `FFARN(rd_meta_q, rd_meta_d, '{default: '0}, clk_i, rst_ni)
-  `FFARN(wr_meta_q, wr_meta_d, '{default: '0}, clk_i, rst_ni)
+  `FFARN(rd_meta_q, rd_meta_d, meta_t'{default: '0}, clk_i, rst_ni)
+  `FFARN(wr_meta_q, wr_meta_d, meta_t'{default: '0}, clk_i, rst_ni)
   `FFARN(r_cnt_q, r_cnt_d, '0, clk_i, rst_ni)
   `FFARN(w_cnt_q, w_cnt_d, '0, clk_i, rst_ni)
 

--- a/src/axi_to_mem_banked.sv
+++ b/src/axi_to_mem_banked.sv
@@ -1,0 +1,423 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Authors:
+// - Wolfgang Rönninger <wroennin@iis.ee.ethz.ch>
+
+/// AXI4+ATOP to banked SRAM memory slave. Allows for parallel read and write transactions.
+/// Address transltion is handled as follows:
+///
+/// Address: {`Ignored`, `Word Address`, `BankSelection`, `ByteOffset`}
+/// - `Ignored`:       .
+/// - `Word Address`:  .
+/// - `BankSelection`: .
+/// - `ByteOffset`:    .
+module axi_to_mem_banked #(
+  /// AXI4+ATOP ID width
+  parameter int unsigned                  AxiIdWidth    = 32'd0,
+  /// AXI4+ATOP address width
+  parameter int unsigned                  AxiAddrWidth  = 32'd0,
+  /// AXI4+ATOP data width
+  parameter int unsigned                  AxiDataWidth  = 32'd0,
+  /// AXI4+ATOP AW channel struct
+  parameter type                          axi_aw_chan_t = logic,
+  /// AXI4+ATOP  W channel struct
+  parameter type                          axi_w_chan_t  = logic,
+  /// AXI4+ATOP  B channel struct
+  parameter type                          axi_b_chan_t  = logic,
+  /// AXI4+ATOP AR channel struct
+  parameter type                          axi_ar_chan_t = logic,
+  /// AXI4+ATOP  R channel struct
+  parameter type                          axi_r_chan_t  = logic,
+  /// AXI4+ATOP request struct
+  parameter type                          axi_req_t     = logic,
+  /// AXI4+ATOP response struct
+  parameter type                          axi_resp_t    = logic,
+  /// Number of memory banks / macros
+  /// Has to satisfy:
+  /// - MemNumBanks >= 2 * AxiDataWidth / MemDataWidth
+  /// - MemNumBanks is a power of 2.
+  parameter int unsigned                  MemNumBanks   = 32'd4,
+  /// Address width of an individual memory bank. This is treated as a word address.
+  parameter int unsigned                  MemAddrWidth  = 32'd11,
+  /// Data width of the memory macros.
+  /// Has to satisfy:
+  /// - AxiDataWidth % MemDataWidth = 0
+  parameter int unsigned                  MemDataWidth  = 32'd32,
+  /// Read latency of the connected memory in cycles
+  parameter int unsigned                  MemLatency    = 32'd1,
+  /// DEPENDENT PARAMETER, DO NOT OVERWRITE! Address type of the memory request.
+  parameter type mem_addr_t = logic [MemAddrWidth-1:0],
+  /// DEPENDENT PARAMETER, DO NOT OVERWRITE! Atomic operation type for the memory request.
+  parameter type mem_atop_t = logic [5:0],
+  /// DEPENDENT PARAMETER, DO NOT OVERWRITE! Data type for the memory request.
+  parameter type mem_data_t = logic [MemDataWidth-1:0],
+  /// DEPENDENT PARAMETER, DO NOT OVERWRITE! Byte strobe/enable signal for the memory request.
+  parameter type mem_strb_t = logic [MemDataWidth/8-1:0]
+) (
+  /// Clock
+  input  logic                        clk_i,
+  /// Asynchronous reset, active low
+  input  logic                        rst_ni,
+  /// Testmode enable
+  input  logic                        test_i,
+  /// AXI4+ATOP slave port, request struct
+  input  axi_req_t                    axi_req_i,
+  /// AXI4+ATOP slave port, response struct
+  output axi_resp_t                   axi_resp_o,
+  /// Memory bank request
+  output logic      [MemNumBanks-1:0] mem_req_o,
+  /// Memory request grant
+  input  logic      [MemNumBanks-1:0] mem_gnt_i,
+  /// Request address
+  output mem_addr_t [MemNumBanks-1:0] mem_add_o,
+  /// Write request enable, active high
+  output logic      [MemNumBanks-1:0] mem_we_o,
+  /// Write data
+  output mem_data_t [MemNumBanks-1:0] mem_wdata_o,
+  /// Write data byte enable, active high
+  output mem_strb_t [MemNumBanks-1:0] mem_be_o,
+  /// Atomic operation
+  output mem_atop_t [MemNumBanks-1:0] mem_atop_o,
+  /// Read data response
+  input  mem_data_t [MemNumBanks-1:0] mem_rdata_i,
+  /// Status output, busy flag of `axi_to_mem`
+  output logic      [1:0]             axi_to_mem_busy_o
+);
+  /// This specifies the number of banks needed to have the full data bandwidth of one
+  /// AXI data channel.
+  localparam int unsigned BanksPerAxiChannel = AxiDataWidth / MemDataWidth;
+  /// Offset of the byte address from AXI to determine, where the selection signal should start
+  localparam int unsigned BankSelOffset = $clog2(MemDataWidth / 32'd8);
+  /// Selection signal width of the xbar.
+  localparam int unsigned BankSelWidth = cf_math_pkg::idx_width(MemNumBanks);
+  typedef logic [BankSelWidth-1:0] xbar_sel_t;
+
+  // Typedef for defining the channels
+  typedef enum logic {
+    ReadAccess  = 1'b0,
+    WriteAccess = 1'b1
+  } access_type_e;
+  typedef logic [AxiAddrWidth-1:0] axi_addr_t;
+  // typedef logic [TcdmDataWidth-1:0] tcdm_data_t;
+
+  /// Payload definition which is sent over the xbar between the macros and the read/write unit.
+  typedef struct packed {
+    /// Address for the memory access
+    mem_addr_t addr;
+    /// Write enable, active high
+    logic      we;
+    /// Write data
+    mem_data_t wdata;
+    /// Strobe signal, byte enable
+    mem_strb_t wstrb;
+    /// Atomic operation, from AXI
+    mem_atop_t atop;
+  } xbar_payload_t;
+
+  /// Read data definition for the shift register, which samples the read response data
+  typedef struct packed {
+    /// Selection signal for response routing
+    xbar_sel_t sel;
+    /// Selection is valid
+    logic      valid;
+  } read_sel_t;
+
+  axi_req_t  [1:0] mem_axi_reqs;
+  axi_resp_t [1:0] mem_axi_resps;
+
+  // Fixed select `axi_demux` to split reads and writes to the two `axi_to_mem`
+  axi_demux #(
+    .AxiIdWidth  ( AxiIdWidth    ),
+    .aw_chan_t   ( axi_aw_chan_t ),
+    .w_chan_t    ( axi_w_chan_t  ),
+    .b_chan_t    ( axi_b_chan_t  ),
+    .ar_chan_t   ( axi_ar_chan_t ),
+    .r_chan_t    ( axi_r_chan_t  ),
+    .req_t       ( axi_req_t     ),
+    .resp_t      ( axi_resp_t    ),
+    .NoMstPorts  ( 32'd2         ),
+    .MaxTrans    ( 32'd4         ), // allow multiple Ax vectors to not starve W channel
+    .AxiLookBits ( 32'd1         ), // select is fixed, do not need it
+    .FallThrough ( 1'b1          ),
+    .SpillAw     ( 1'b1          ),
+    .SpillW      ( 1'b1          ),
+    .SpillB      ( 1'b1          ),
+    .SpillAr     ( 1'b1          ),
+    .SpillR      ( 1'b1          )
+  ) i_axi_demux (
+    .clk_i,
+    .rst_ni,
+    .test_i,
+    .slv_req_i       ( axi_req_i     ),
+    .slv_aw_select_i ( WriteAccess   ),
+    .slv_ar_select_i ( ReadAccess    ),
+    .slv_resp_o      ( axi_resp_o    ),
+    .mst_reqs_o      ( mem_axi_reqs  ),
+    .mst_resps_i     ( mem_axi_resps )
+  );
+
+  xbar_payload_t [1:0][BanksPerAxiChannel-1:0] inter_payload;
+  xbar_sel_t     [1:0][BanksPerAxiChannel-1:0] inter_sel;
+  logic          [1:0][BanksPerAxiChannel-1:0] inter_valid,   inter_ready;
+
+  // axi_to_mem protocol converter
+  for (genvar i = 0; i < 2; i++) begin : gen_axi_to_mem
+    axi_addr_t [BanksPerAxiChannel-1:0] req_addr;  // This is a byte address
+    mem_data_t [BanksPerAxiChannel-1:0] req_wdata, res_rdata;
+    mem_strb_t [BanksPerAxiChannel-1:0] req_wstrb;
+    mem_atop_t [BanksPerAxiChannel-1:0] req_atop;
+
+    logic      [BanksPerAxiChannel-1:0] req_we,    res_valid;
+
+    // Careful, request / grant
+    // Only assert grant, if there is a ready
+    axi_to_mem #(
+      .axi_req_t ( axi_req_t          ),
+      .axi_resp_t( axi_resp_t         ),
+      .AddrWidth ( AxiAddrWidth       ),
+      .DataWidth ( AxiDataWidth       ),
+      .IdWidth   ( AxiIdWidth         ),
+      .NumBanks  ( BanksPerAxiChannel ),
+      .BufDepth  ( MemLatency         )
+    ) i_axi_to_mem (
+      .clk_i,
+      .rst_ni,
+      .busy_o       ( axi_to_mem_busy_o[i]            ),
+      .axi_req_i    ( mem_axi_reqs[i]                 ),
+      .axi_resp_o   ( mem_axi_resps[i]                ),
+      .mem_req_o    ( inter_valid[i]                  ),
+      .mem_gnt_i    ( inter_ready[i] & inter_valid[i] ), // convert valid/ready to req/gnt
+      .mem_addr_o   ( req_addr                        ),
+      .mem_wdata_o  ( req_wdata                       ),
+      .mem_strb_o   ( req_wstrb                       ),
+      .mem_atop_o   ( req_atop                        ),
+      .mem_we_o     ( req_we                          ),
+      .mem_rvalid_i ( res_valid                       ),
+      .mem_rdata_i  ( res_rdata                       )
+    );
+    // Pack the payload data together
+    for (genvar j = 0; j < BanksPerAxiChannel; j++) begin : gen_response_mux
+      // Cut out the bank selection signal.
+      assign inter_sel[i][j] = req_addr[j][BankSelOffset+:BankSelWidth];
+
+      // Assign the xbar payload.
+      assign inter_payload[i][j] = xbar_payload_t'{
+        // Cut out the word address for the banks.
+        addr:    req_addr[j][(BankSelOffset+BankSelWidth)+:MemAddrWidth],
+        we:      req_we[j],
+        wdata:   req_wdata[j],
+        wstrb:   req_wstrb[j],
+        atop:    req_atop[j],
+        default: '0
+      };
+
+      // Cut out the portion of the address for the bank selection, each bank is word addressed!
+      read_sel_t r_shift_inp, r_shift_oup;
+      // Pack the selection into the shift register
+      assign r_shift_inp = read_sel_t'{
+        sel:     inter_sel[i][j],                       // Selection for response multiplexer
+        valid:   inter_valid[i][j] & inter_ready[i][j], // Valid when req to SRAM
+        default: '0
+      };
+
+      // Select the right read response data.
+      // Writes should also generate a `response`.
+      assign res_valid[j] = r_shift_oup.valid;
+      assign res_rdata[j] = mem_rdata_i[r_shift_oup.sel];
+
+      // Connect for the response data `MemLatency` cycles after a request was made to the xbar.
+      shift_reg #(
+        .dtype ( read_sel_t ),
+        .Depth ( MemLatency )
+      ) i_shift_reg_rdata_mux (
+        .clk_i,
+        .rst_ni,
+        .d_i    ( r_shift_inp ),
+        .d_o    ( r_shift_oup )
+      );
+    end
+  end
+
+  // Xbar to arbitrate data over the different memory banks
+  xbar_payload_t [MemNumBanks-1:0] mem_payload;
+
+  stream_xbar #(
+    .NumInp      ( 32'd2 * BanksPerAxiChannel ),
+    .NumOut      ( MemNumBanks                ),
+    .payload_t   ( xbar_payload_t             ),
+    .OutSpillReg ( 1'b0                       ),
+    .ExtPrio     ( 1'b0                       ),
+    .AxiVldRdy   ( 1'b1                       ),
+    .LockIn      ( 1'b1                       )
+  ) i_stream_xbar (
+    .clk_i,
+    .rst_ni,
+    .flush_i ( 1'b0          ),
+    .rr_i    ( '0            ),
+    .data_i  ( inter_payload ),
+    .sel_i   ( inter_sel     ),
+    .valid_i ( inter_valid   ),
+    .ready_o ( inter_ready   ),
+    .data_o  ( mem_payload   ),
+    .idx_o   ( /*not used*/  ),
+    .valid_o ( mem_req_o     ),
+    .ready_i ( mem_gnt_i     )
+  );
+
+  // Memory request output assignment
+  for (genvar i = 0; unsigned'(i) < MemNumBanks; i++) begin : gen_mem_outp
+    assign mem_add_o[i]   = mem_payload[i].addr;
+    assign mem_we_o[i]    = mem_payload[i].we;
+    assign mem_wdata_o[i] = mem_payload[i].wdata;
+    assign mem_be_o[i]    = mem_payload[i].wstrb;
+    assign mem_atop_o[i]  = mem_payload[i].atop;
+  end
+
+// pragma translate_off
+`ifndef VERILATOR
+  initial begin: p_assertions
+    assert (AxiIdWidth   >= 32'd1) else $fatal(1, "AxiIdWidth must be at least 1!");
+    assert (AxiAddrWidth >= 32'd1) else $fatal(1, "AxiAddrWidth must be at least 1!");
+    assert (AxiDataWidth >= 32'd1) else $fatal(1, "AxiDataWidth must be at least 1!");
+    assert (MemNumBanks  >= 32'd2 * AxiDataWidth / MemDataWidth) else
+        $fatal(1, "MemNumBanks has to be >= 2 * AxiDataWidth / MemDataWidth");
+    assert (MemLatency   >= 32'd1) else $fatal(1, "MemLatency has to be at least 1!");
+    assert ($onehot(MemNumBanks))  else $fatal(1, "MemNumBanks has to be a power of 2.");
+    assert (MemAddrWidth >= 32'd1) else $fatal(1, "MemAddrWidth must be at least 1!");
+    assert (MemDataWidth >= 32'd1) else $fatal(1, "MemDataWidth must be at least 1!");
+    assert (AxiDataWidth % MemDataWidth == 0) else
+        $fatal(1, "MemDataWidth has to be a divisor of AxiDataWidth.");
+  end
+`endif
+// pragma translate_on
+endmodule
+
+`include "axi/typedef.svh"
+`include "axi/assign.svh"
+/// AXI4+ATOP interface wrapper for `axi_to_mem`
+module axi_to_mem_banked_intf #(
+  /// AXI4+ATOP ID width
+  parameter int unsigned                  AXI_ID_WIDTH   = 32'd0,
+  /// AXI4+ATOP address width
+  parameter int unsigned                  AXI_ADDR_WIDTH = 32'd0,
+  /// AXI4+ATOP data width
+  parameter int unsigned                  AXI_DATA_WIDTH = 32'd0,
+  /// AXI4+ATOP user width
+  parameter int unsigned                  AXI_USER_WIDTH = 32'd0,
+  /// Number of memory banks / macros
+  /// Has to satisfy:
+  /// - MemNumBanks >= 2 * AxiDataWidth / MemDataWidth
+  /// - MemNumBanks is a power of 2.
+  parameter int unsigned                  MEM_NUM_BANKS  = 32'd4,
+  /// Address width of an individual memory bank.
+  parameter int unsigned                  MEM_ADDR_WIDTH = 32'd11,
+  /// Data width of the memory macros.
+  /// Has to satisfy:
+  /// - AxiDataWidth % MemDataWidth = 0
+  parameter int unsigned                  MEM_DATA_WIDTH = 32'd32,
+  /// Read latency of the connected memory in cycles
+  parameter int unsigned                  MEM_LATENCY    = 32'd1,
+  // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
+  parameter type mem_addr_t = logic [MEM_ADDR_WIDTH-1:0],
+  parameter type mem_atop_t = logic [5:0],
+  parameter type mem_data_t = logic [MEM_DATA_WIDTH-1:0],
+  parameter type mem_strb_t = logic [MEM_DATA_WIDTH/8-1:0]
+) (
+  /// Clock
+  input  logic                          clk_i,
+  /// Asynchronous reset, active low
+  input  logic                          rst_ni,
+  /// Testmode enable
+  input  logic                          test_i,
+  /// AXI4+ATOP slave port
+  AXI_BUS.Slave                         slv,
+  /// Memory bank request
+  output logic      [MEM_NUM_BANKS-1:0] mem_req_o,
+  /// Memory request grant
+  input  logic      [MEM_NUM_BANKS-1:0] mem_gnt_i,
+  /// Request address
+  output mem_addr_t [MEM_NUM_BANKS-1:0] mem_add_o,
+  /// Write request enable, active high
+  output logic      [MEM_NUM_BANKS-1:0] mem_we_o,
+  /// Write data
+  output mem_data_t [MEM_NUM_BANKS-1:0] mem_wdata_o,
+  /// Write data byte enable, active high
+  output mem_strb_t [MEM_NUM_BANKS-1:0] mem_be_o,
+  /// Atomic operation
+  output mem_atop_t [MEM_NUM_BANKS-1:0] mem_atop_o,
+  /// Read data response
+  input  mem_data_t [MEM_NUM_BANKS-1:0] mem_rdata_i,
+  /// Status output, busy flag of `axi_to_mem`
+  output logic      [1:0]               axi_to_mem_busy_o
+);
+  typedef logic [AXI_ID_WIDTH-1:0]     id_t;
+  typedef logic [AXI_ADDR_WIDTH-1:0]   addr_t;
+  typedef logic [AXI_DATA_WIDTH-1:0]   data_t;
+  typedef logic [AXI_DATA_WIDTH/8-1:0] strb_t;
+  typedef logic [AXI_USER_WIDTH-1:0]   user_t;
+  `AXI_TYPEDEF_AW_CHAN_T(aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(w_chan_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(b_chan_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(ar_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(r_chan_t, data_t, id_t, user_t)
+  `AXI_TYPEDEF_REQ_T(axi_req_t, aw_chan_t, w_chan_t, ar_chan_t)
+  `AXI_TYPEDEF_RESP_T(axi_resp_t, b_chan_t, r_chan_t)
+
+  axi_req_t  mem_axi_req;
+  axi_resp_t mem_axi_resp;
+
+  `AXI_ASSIGN_TO_REQ(mem_axi_req, slv)
+  `AXI_ASSIGN_FROM_RESP(slv, mem_axi_resp)
+
+  axi_to_mem_banked #(
+    .AxiIdWidth    ( AXI_ID_WIDTH               ),
+    .AxiAddrWidth  ( AXI_ADDR_WIDTH             ),
+    .AxiDataWidth  ( AXI_DATA_WIDTH             ),
+    .axi_aw_chan_t ( aw_chan_t                  ),
+    .axi_w_chan_t  (  w_chan_t                  ),
+    .axi_b_chan_t  (  b_chan_t                  ),
+    .axi_ar_chan_t ( ar_chan_t                  ),
+    .axi_r_chan_t  (  r_chan_t                  ),
+    .axi_req_t     ( axi_req_t                  ),
+    .axi_resp_t    ( axi_resp_t                 ),
+    .MemNumBanks   ( MEM_NUM_BANKS              ),
+    .MemAddrWidth  ( MEM_ADDR_WIDTH             ),
+    .MemDataWidth  ( MEM_DATA_WIDTH             ),
+    .MemLatency    ( MEM_LATENCY                )
+  ) i_axi_to_mem_banked (
+    .clk_i,
+    .rst_ni,
+    .test_i,
+    .axi_to_mem_busy_o,
+    .axi_req_i      ( mem_axi_req  ),
+    .axi_resp_o     ( mem_axi_resp ),
+    .mem_req_o,
+    .mem_gnt_i,
+    .mem_add_o,
+    .mem_wdata_o,
+    .mem_be_o,
+    .mem_atop_o,
+    .mem_we_o,
+    .mem_rdata_i
+  );
+
+// pragma translate_off
+`ifndef VERILATOR
+  initial begin: p_assertions
+    assert (AXI_ADDR_WIDTH  >= 1) else $fatal(1, "AXI address width must be at least 1!");
+    assert (AXI_DATA_WIDTH  >= 1) else $fatal(1, "AXI data width must be at least 1!");
+    assert (AXI_ID_WIDTH    >= 1) else $fatal(1, "AXI ID   width must be at least 1!");
+    assert (AXI_USER_WIDTH  >= 1) else $fatal(1, "AXI user width must be at least 1!");
+  end
+`endif
+// pragma translate_on
+endmodule
+

--- a/src/axi_to_mem_banked.sv
+++ b/src/axi_to_mem_banked.sv
@@ -50,6 +50,8 @@ module axi_to_mem_banked #(
   parameter int unsigned                  MemDataWidth  = 32'd32,
   /// Read latency of the connected memory in cycles
   parameter int unsigned                  MemLatency    = 32'd1,
+  /// Hide write requests if the strb == '0
+  parameter bit                           HideStrb      = 1'b0,
   /// DEPENDENT PARAMETER, DO NOT OVERWRITE! Address type of the memory request.
   parameter type mem_addr_t = logic [MemAddrWidth-1:0],
   /// DEPENDENT PARAMETER, DO NOT OVERWRITE! Atomic operation type for the memory request.
@@ -185,7 +187,8 @@ module axi_to_mem_banked #(
       .DataWidth ( AxiDataWidth       ),
       .IdWidth   ( AxiIdWidth         ),
       .NumBanks  ( BanksPerAxiChannel ),
-      .BufDepth  ( MemLatency         )
+      .BufDepth  ( MemLatency         ),
+      .HideStrb  ( HideStrb           )
     ) i_axi_to_mem (
       .clk_i,
       .rst_ni,
@@ -324,6 +327,8 @@ module axi_to_mem_banked_intf #(
   parameter int unsigned                  MEM_DATA_WIDTH = 32'd32,
   /// Read latency of the connected memory in cycles
   parameter int unsigned                  MEM_LATENCY    = 32'd1,
+  /// Hide write requests if the strb == '0
+  parameter bit                           HIDE_STRB      = 1'b0,
   // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
   parameter type mem_addr_t = logic [MEM_ADDR_WIDTH-1:0],
   parameter type mem_atop_t = logic [5:0],
@@ -390,7 +395,8 @@ module axi_to_mem_banked_intf #(
     .MemNumBanks   ( MEM_NUM_BANKS              ),
     .MemAddrWidth  ( MEM_ADDR_WIDTH             ),
     .MemDataWidth  ( MEM_DATA_WIDTH             ),
-    .MemLatency    ( MEM_LATENCY                )
+    .MemLatency    ( MEM_LATENCY                ),
+    .HideStrb      ( HIDE_STRB                  )
   ) i_axi_to_mem_banked (
     .clk_i,
     .rst_ni,

--- a/src/axi_to_mem_banked.sv
+++ b/src/axi_to_mem_banked.sv
@@ -203,7 +203,7 @@ module axi_to_mem_banked #(
       .mem_rdata_i  ( res_rdata                       )
     );
     // Pack the payload data together
-    for (genvar j = 0; j < BanksPerAxiChannel; j++) begin : gen_response_mux
+    for (genvar j = 0; unsigned'(j) < BanksPerAxiChannel; j++) begin : gen_response_mux
       // Cut out the bank selection signal.
       assign inter_sel[i][j] = req_addr[j][BankSelOffset+:BankSelWidth];
 

--- a/src/axi_to_mem_interleaved.sv
+++ b/src/axi_to_mem_interleaved.sv
@@ -1,0 +1,242 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author:
+// Thomas Benz <tbenz@iis.ee.ethz.ch>
+
+/// AXI4+ATOP to SRAM memory slave. Allows for parallel read and write transactions.
+/// Allows reads to bypass writes, in contrast to `axi_to_mem`, however needs more hardware.
+module axi_to_mem_interleaved #(
+  /// AXI4+ATOP request type. See `include/axi/typedef.svh`.
+  parameter type         axi_req_t  = logic,
+  /// AXI4+ATOP response type. See `include/axi/typedef.svh`.
+  parameter type         axi_resp_t = logic,
+  /// Address width, has to be less or equal than the width off the AXI address field.
+  /// Determines the width of `mem_addr_o`. Has to be wide enough to emit the memory region
+  /// which should be accessible.
+  parameter int unsigned AddrWidth  = 0,
+  /// AXI4+ATOP data width.
+  parameter int unsigned DataWidth  = 0,
+  /// AXI4+ATOP ID width.
+  parameter int unsigned IdWidth    = 0,
+  /// Number of banks at output, must evenly divide `DataWidth`.
+  parameter int unsigned NumBanks   = 0,
+  /// Depth of memory response buffer. This should be equal to the memory response latency.
+  parameter int unsigned BufDepth   = 1,
+  /// Hide write requests if the strb == '0
+  parameter bit          HideStrb   = 1'b0,
+  /// Dependent parameter, do not override. Memory address type.
+  parameter type addr_t     = logic [AddrWidth-1:0],
+  /// Dependent parameter, do not override. Memory data type.
+  parameter type mem_data_t = logic [DataWidth/NumBanks-1:0],
+  /// Dependent parameter, do not override. Memory write strobe type.
+  parameter type mem_strb_t = logic [DataWidth/NumBanks/8-1:0]
+) (
+  /// Clock input.
+  input  logic                           clk_i,
+  /// Asynchronous reset, active low.
+  input  logic                           rst_ni,
+  /// The unit is busy handling an AXI4+ATOP request.
+  output logic                           busy_o,
+  /// AXI4+ATOP slave port, request input.
+  input  axi_req_t                       axi_req_i,
+  /// AXI4+ATOP slave port, response output.
+  output axi_resp_t                      axi_resp_o,
+  /// Memory stream master, request is valid for this bank.
+  output logic           [NumBanks-1:0]  mem_req_o,
+  /// Memory stream master, request can be granted by this bank.
+  input  logic           [NumBanks-1:0]  mem_gnt_i,
+  /// Memory stream master, byte address of the request.
+  output addr_t          [NumBanks-1:0]  mem_addr_o,
+  /// Memory stream master, write data for this bank. Valid when `mem_req_o`.
+  output mem_data_t      [NumBanks-1:0]  mem_wdata_o,
+  /// Memory stream master, byte-wise strobe (byte enable).
+  output mem_strb_t      [NumBanks-1:0]  mem_strb_o,
+  /// Memory stream master, `axi_pkg::atop_t` signal associated with this request.
+  output axi_pkg::atop_t [NumBanks-1:0]  mem_atop_o,
+  /// Memory stream master, write enable. Then asserted store of `mem_w_data` is requested.
+  output logic           [NumBanks-1:0]  mem_we_o,
+  /// Memory stream master, response is valid. This module expects always a response valid for a
+  /// request regardless if the request was a write or a read.
+  input  logic           [NumBanks-1:0]  mem_rvalid_i,
+  /// Memory stream master, read response data.
+  input  mem_data_t      [NumBanks-1:0]  mem_rdata_i
+);
+
+  // internal signals
+  logic w_busy, r_busy;
+  logic [NumBanks-1:0] arb_outcome, arb_outcome_head;
+
+  // internal AXI buses
+  axi_req_t  r_axi_req,  w_axi_req;
+  axi_resp_t r_axi_resp, w_axi_resp;
+
+  // internal TCDM buses
+  logic           [NumBanks-1:0]  r_mem_req,    w_mem_req;
+  logic           [NumBanks-1:0]  r_mem_gnt,    w_mem_gnt;
+  addr_t          [NumBanks-1:0]  r_mem_addr,   w_mem_addr;
+  mem_data_t      [NumBanks-1:0]  r_mem_wdata,  w_mem_wdata;
+  mem_strb_t      [NumBanks-1:0]  r_mem_strb,   w_mem_strb;
+  axi_pkg::atop_t [NumBanks-1:0]  r_mem_atop,   w_mem_atop;
+  logic           [NumBanks-1:0]  r_mem_we,     w_mem_we;
+  logic           [NumBanks-1:0]  r_mem_rvalid, w_mem_rvalid;
+  mem_data_t      [NumBanks-1:0]  r_mem_rdata,  w_mem_rdata;
+
+  // split AXI bus in read and write
+  always_comb begin : proc_axi_rw_split
+    axi_resp_o.r          = r_axi_resp.r;
+    axi_resp_o.r_valid    = r_axi_resp.r_valid;
+    axi_resp_o.ar_ready   = r_axi_resp.ar_ready;
+    axi_resp_o.b          = w_axi_resp.b;
+    axi_resp_o.b_valid    = w_axi_resp.b_valid;
+    axi_resp_o.w_ready    = w_axi_resp.w_ready;
+    axi_resp_o.aw_ready   = w_axi_resp.aw_ready;
+
+    w_axi_req             = '0;
+    w_axi_req.aw          = axi_req_i.aw;
+    w_axi_req.aw_valid    = axi_req_i.aw_valid;
+    w_axi_req.w           = axi_req_i.w;
+    w_axi_req.w_valid     = axi_req_i.w_valid;
+    w_axi_req.b_ready     = axi_req_i.b_ready;
+
+    r_axi_req             = '0;
+    r_axi_req.ar          = axi_req_i.ar;
+    r_axi_req.ar_valid    = axi_req_i.ar_valid;
+    r_axi_req.r_ready     = axi_req_i.r_ready;
+  end
+
+  axi_to_mem #(
+    .axi_req_t   ( axi_req_t  ),
+    .axi_resp_t  ( axi_resp_t ),
+    .AddrWidth   ( AddrWidth  ),
+    .DataWidth   ( DataWidth  ),
+    .IdWidth     ( IdWidth    ),
+    .NumBanks    ( NumBanks   ),
+    .BufDepth    ( BufDepth   ),
+    .HideStrb    ( HideStrb   )
+  ) i_axi_to_mem_write (
+    .clk_i        ( clk_i         ),
+    .rst_ni       ( rst_ni        ),
+    .busy_o       ( w_busy        ),
+    .axi_req_i    ( w_axi_req     ),
+    .axi_resp_o   ( w_axi_resp    ),
+    .mem_req_o    ( w_mem_req     ),
+    .mem_gnt_i    ( w_mem_gnt     ),
+    .mem_addr_o   ( w_mem_addr    ),
+    .mem_wdata_o  ( w_mem_wdata   ),
+    .mem_strb_o   ( w_mem_strb    ),
+    .mem_atop_o   ( w_mem_atop    ),
+    .mem_we_o     ( w_mem_we      ),
+    .mem_rvalid_i ( w_mem_rvalid  ),
+    .mem_rdata_i  ( w_mem_rdata   )
+  );
+
+  axi_to_mem #(
+    .axi_req_t   ( axi_req_t  ),
+    .axi_resp_t  ( axi_resp_t ),
+    .AddrWidth   ( AddrWidth  ),
+    .DataWidth   ( DataWidth  ),
+    .IdWidth     ( IdWidth    ),
+    .NumBanks    ( NumBanks   ),
+    .BufDepth    ( BufDepth   ),
+    .HideStrb    ( HideStrb   )
+  ) i_axi_to_mem_read (
+    .clk_i        ( clk_i         ),
+    .rst_ni       ( rst_ni        ),
+    .busy_o       ( r_busy        ),
+    .axi_req_i    ( r_axi_req     ),
+    .axi_resp_o   ( r_axi_resp    ),
+    .mem_req_o    ( r_mem_req     ),
+    .mem_gnt_i    ( r_mem_gnt     ),
+    .mem_addr_o   ( r_mem_addr    ),
+    .mem_wdata_o  ( r_mem_wdata   ),
+    .mem_strb_o   ( r_mem_strb    ),
+    .mem_atop_o   ( r_mem_atop    ),
+    .mem_we_o     ( r_mem_we      ),
+    .mem_rvalid_i ( r_mem_rvalid  ),
+    .mem_rdata_i  ( r_mem_rdata   )
+  );
+
+  // create a struct for the rr-arb-tree
+  typedef struct packed {
+    addr_t          addr;
+    mem_data_t      wdata;
+    mem_strb_t      strb;
+    logic           we;
+    axi_pkg::atop_t atop;
+  } mem_req_payload_t;
+
+  mem_req_payload_t [NumBanks-1:0] r_payload, w_payload, payload;
+
+  for (genvar i = 0; i < NumBanks; i++) begin
+    // pack the mem
+    assign r_payload[i].addr  = r_mem_addr[i];
+    assign r_payload[i].wdata = r_mem_wdata[i];
+    assign r_payload[i].strb  = r_mem_strb[i];
+    assign r_payload[i].we    = r_mem_we[i];
+    assign r_payload[i].atop  = r_mem_atop[i];
+
+    assign w_payload[i].addr  = w_mem_addr[i];
+    assign w_payload[i].wdata = w_mem_wdata[i];
+    assign w_payload[i].strb  = w_mem_strb[i];
+    assign w_payload[i].we    = w_mem_we[i];
+    assign w_payload[i].atop  = w_mem_atop[i];
+
+    assign mem_addr_o [i] = payload[i].addr;
+    assign mem_wdata_o[i] = payload[i].wdata;
+    assign mem_strb_o [i] = payload[i].strb;
+    assign mem_we_o   [i] = payload[i].we;
+    assign mem_atop_o [i] = payload[i].atop;
+
+    // route data back to both channels
+    assign w_mem_rdata[i]  = mem_rdata_i[i];
+    assign r_mem_rdata[i]  = mem_rdata_i[i];
+
+    assign w_mem_rvalid[i] = mem_rvalid_i[i] & !arb_outcome_head[i];
+    assign r_mem_rvalid[i] = mem_rvalid_i[i] &  arb_outcome_head[i];
+
+    // fine-grain arbitration
+    rr_arb_tree #(
+      .NumIn     ( 2                 ),
+      .DataType  ( mem_req_payload_t )
+    ) i_rr_arb_tree (
+      .clk_i    ( clk_i                          ),
+      .rst_ni   ( rst_ni                         ),
+      .flush_i  ( 1'b0                           ),
+      .rr_i     (  '0                            ),
+      .req_i    ( { r_mem_req[i], w_mem_req[i] } ),
+      .gnt_o    ( { r_mem_gnt[i], w_mem_gnt[i] } ),
+      .data_i   ( { r_payload[i], w_payload[i] } ),
+      .req_o    ( mem_req_o[i]                   ),
+      .gnt_i    ( mem_gnt_i[i]                   ),
+      .data_o   ( payload[i]                     ),
+      .idx_o    ( arb_outcome[i]                 )
+    );
+
+    // back-routing store
+    fifo_v3 #(
+      .DATA_WIDTH ( 1            ),
+      .DEPTH      ( BufDepth + 1 )
+    ) i_fifo_v3_response_trgt_store (
+      .clk_i      ( clk_i                       ),
+      .rst_ni     ( rst_ni                      ),
+      .flush_i    ( 1'b0                        ),
+      .testmode_i ( 1'b0                        ),
+      .full_o     ( ),
+      .empty_o    ( ),
+      .usage_o    ( ),
+      .data_i     ( arb_outcome[i]              ),
+      .push_i     ( mem_req_o[i] & mem_gnt_i[i] ),
+      .data_o     ( arb_outcome_head[i]         ),
+      .pop_i      ( mem_rvalid_i[i]             )
+    );
+  end
+
+endmodule : axi_to_mem_interleaved

--- a/src/axi_to_mem_split.sv
+++ b/src/axi_to_mem_split.sv
@@ -1,0 +1,251 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author:
+// Michael Rogenmoser <michaero@iis.ee.ethz.ch>
+
+`include "axi/assign.svh"
+/// AXI4+ATOP to memory-protocol interconnect. Completely separates the read and write channel to
+/// individual mem ports. This can only be used when addresses for the same bank are accessible
+/// from different memory ports.
+module axi_to_mem_split #(
+  /// AXI4+ATOP request type. See `include/axi/typedef.svh`.
+  parameter type         axi_req_t    = logic,
+  /// AXI4+ATOP response type. See `include/axi/typedef.svh`.
+  parameter type         axi_resp_t   = logic,
+  /// Address width, has to be less or equal than the width off the AXI address field.
+  /// Determines the width of `mem_addr_o`. Has to be wide enough to emit the memory region
+  /// which should be accessible.
+  parameter int unsigned AddrWidth    = 0,
+  /// AXI4+ATOP data width.
+  parameter int unsigned AxiDataWidth = 0,
+  /// AXI4+ATOP ID width.
+  parameter int unsigned IdWidth      = 0,
+  /// Memory data width, must evenly divide `DataWidth`.
+  parameter int unsigned MemDataWidth = 0, // must divide `AxiDataWidth` without remainder
+  /// Depth of memory response buffer. This should be equal to the memory response latency.
+  parameter int unsigned BufDepth     = 0,
+  /// Hide write requests if the strb == '0
+  parameter bit          HideStrb   = 1'b0,
+  /// Dependent parameters, do not override. Number of memory ports.
+  parameter int unsigned NumMemPorts  = 2*AxiDataWidth/MemDataWidth,
+  /// Dependent parameter, do not override. Memory address type.
+  parameter type         addr_t       = logic [AddrWidth-1:0],
+  /// Dependent parameter, do not override. Memory data type.
+  parameter type         mem_data_t   = logic [MemDataWidth-1:0],
+  /// Dependent parameter, do not override. Memory write strobe type.
+  parameter type         mem_strb_t   = logic [MemDataWidth/8-1:0]
+) (
+  /// Clock input.
+  input logic                              clk_i,
+  /// Asynchronous reset, active low.
+  input logic                              rst_ni,
+  /// The unit is busy handling an AXI4+ATOP request.
+  output logic                             busy_o,
+  /// AXI4+ATOP slave port, request input.
+  input  axi_req_t                         axi_req_i,
+  /// AXI4+ATOP slave port, response output.
+  output axi_resp_t                        axi_resp_o,
+  /// Memory stream master, request is valid for this bank.
+  output logic           [NumMemPorts-1:0] mem_req_o,
+  /// Memory stream master, request can be granted by this bank.
+  input  logic           [NumMemPorts-1:0] mem_gnt_i,
+  /// Memory stream master, byte address of the request.
+  output addr_t          [NumMemPorts-1:0] mem_addr_o,   // byte address
+  /// Memory stream master, write data for this bank. Valid when `mem_req_o`.
+  output mem_data_t      [NumMemPorts-1:0] mem_wdata_o,  // write data
+  /// Memory stream master, byte-wise strobe (byte enable).
+  output mem_strb_t      [NumMemPorts-1:0] mem_strb_o,   // byte-wise strobe
+  /// Memory stream master, `axi_pkg::atop_t` signal associated with this request.
+  output axi_pkg::atop_t [NumMemPorts-1:0] mem_atop_o,   // atomic operation
+  /// Memory stream master, write enable. Then asserted store of `mem_w_data` is requested.
+  output logic           [NumMemPorts-1:0] mem_we_o,     // write enable
+  /// Memory stream master, response is valid. This module expects always a response valid for a
+  /// request regardless if the request was a write or a read.
+  input  logic           [NumMemPorts-1:0] mem_rvalid_i, // response valid
+  /// Memory stream master, read response data.
+  input  mem_data_t      [NumMemPorts-1:0] mem_rdata_i   // read data
+);
+
+  axi_req_t axi_read_req, axi_write_req;
+  axi_resp_t axi_read_resp, axi_write_resp;
+
+  logic read_busy, write_busy;
+
+  always_comb begin: proc_axi_rw_split
+    `AXI_SET_R_STRUCT(axi_resp_o.r, axi_read_resp.r)
+    axi_resp_o.r_valid     = axi_read_resp.r_valid;
+    axi_resp_o.ar_ready    = axi_read_resp.ar_ready;
+    `AXI_SET_B_STRUCT(axi_resp_o.b, axi_write_resp.b)
+    axi_resp_o.b_valid     = axi_write_resp.b_valid;
+    axi_resp_o.aw_ready    = axi_write_resp.aw_ready;
+    axi_resp_o.w_ready     = axi_write_resp.w_ready;
+
+    axi_write_req = '0;
+    `AXI_SET_AW_STRUCT(axi_write_req.aw, axi_req_i.aw)
+    axi_write_req.aw_valid = axi_req_i.aw_valid;
+    `AXI_SET_W_STRUCT(axi_write_req.w, axi_req_i.w)
+    axi_write_req.w_valid = axi_req_i.w_valid;
+    axi_write_req.b_ready = axi_req_i.b_ready;
+
+    axi_read_req = '0;
+    `AXI_SET_AR_STRUCT(axi_read_req.ar, axi_req_i.ar)
+    axi_read_req.ar_valid = axi_req_i.ar_valid;
+    axi_read_req.r_ready  = axi_req_i.r_ready;
+  end
+
+  assign busy_o = read_busy || write_busy;
+
+  axi_to_mem #(
+    .axi_req_t  ( axi_req_t     ),
+    .axi_resp_t ( axi_resp_t    ),
+    .AddrWidth  ( AddrWidth     ),
+    .DataWidth  ( AxiDataWidth  ),
+    .IdWidth    ( IdWidth       ),
+    .NumBanks   ( NumMemPorts/2 ),
+    .BufDepth   ( BufDepth      ),
+    .HideStrb   ( 1'b0          )
+  ) i_axi_to_mem_read (
+    .clk_i,
+    .rst_ni,
+    .busy_o       ( read_busy                        ),
+    .axi_req_i    ( axi_read_req                     ),
+    .axi_resp_o   ( axi_read_resp                    ),
+    .mem_req_o    ( mem_req_o    [NumMemPorts/2-1:0] ),
+    .mem_gnt_i    ( mem_gnt_i    [NumMemPorts/2-1:0] ),
+    .mem_addr_o   ( mem_addr_o   [NumMemPorts/2-1:0] ),
+    .mem_wdata_o  ( mem_wdata_o  [NumMemPorts/2-1:0] ),
+    .mem_strb_o   ( mem_strb_o   [NumMemPorts/2-1:0] ),
+    .mem_atop_o   ( mem_atop_o   [NumMemPorts/2-1:0] ),
+    .mem_we_o     ( mem_we_o     [NumMemPorts/2-1:0] ),
+    .mem_rvalid_i ( mem_rvalid_i [NumMemPorts/2-1:0] ),
+    .mem_rdata_i  ( mem_rdata_i  [NumMemPorts/2-1:0] )
+  );
+
+  axi_to_mem #(
+    .axi_req_t  ( axi_req_t     ),
+    .axi_resp_t ( axi_resp_t    ),
+    .AddrWidth  ( AddrWidth     ),
+    .DataWidth  ( AxiDataWidth  ),
+    .IdWidth    ( IdWidth       ),
+    .NumBanks   ( NumMemPorts/2 ),
+    .BufDepth   ( BufDepth      ),
+    .HideStrb   ( HideStrb      )
+  ) i_axi_to_mem_write (
+    .clk_i,
+    .rst_ni,
+    .busy_o       ( write_busy                                 ),
+    .axi_req_i    ( axi_write_req                              ),
+    .axi_resp_o   ( axi_write_resp                             ),
+    .mem_req_o    ( mem_req_o    [NumMemPorts-1:NumMemPorts/2] ),
+    .mem_gnt_i    ( mem_gnt_i    [NumMemPorts-1:NumMemPorts/2] ),
+    .mem_addr_o   ( mem_addr_o   [NumMemPorts-1:NumMemPorts/2] ),
+    .mem_wdata_o  ( mem_wdata_o  [NumMemPorts-1:NumMemPorts/2] ),
+    .mem_strb_o   ( mem_strb_o   [NumMemPorts-1:NumMemPorts/2] ),
+    .mem_atop_o   ( mem_atop_o   [NumMemPorts-1:NumMemPorts/2] ),
+    .mem_we_o     ( mem_we_o     [NumMemPorts-1:NumMemPorts/2] ),
+    .mem_rvalid_i ( mem_rvalid_i [NumMemPorts-1:NumMemPorts/2] ),
+    .mem_rdata_i  ( mem_rdata_i  [NumMemPorts-1:NumMemPorts/2] )
+  );
+
+endmodule
+
+`include "axi/typedef.svh"
+/// AXI4+ATOP interface wrapper for `axi_to_mem_split`
+module axi_to_mem_split_intf #(
+  /// AXI4+ATOP ID width
+  parameter int unsigned AXI_ID_WIDTH   = 32'b0,
+  /// AXI4+ATOP address width
+  parameter int unsigned AXI_ADDR_WIDTH = 32'b0,
+  /// AXI4+ATOP data width
+  parameter int unsigned AXI_DATA_WIDTH = 32'b0,
+  /// AXI4+ATOP user width
+  parameter int unsigned AXI_USER_WIDTH = 32'b0,
+  /// Memory data width, must evenly divide `DataWidth`.
+  parameter int unsigned MEM_DATA_WIDTH = 32'b0,
+  /// See `axi_to_mem`, parameter `BufDepth`.
+  parameter int unsigned BUF_DEPTH      = 0,
+  /// Hide write requests if the strb == '0
+  parameter bit          HIDE_STRB      = 1'b0,
+  /// Dependent parameters, do not override. Number of memory ports.
+  parameter int unsigned NUM_MEM_PORTS  = 2*AXI_DATA_WIDTH/MEM_DATA_WIDTH,
+  /// Dependent parameter, do not override. See `axi_to_mem`, parameter `addr_t`.
+  parameter type addr_t     = logic [AXI_ADDR_WIDTH-1:0],
+  /// Dependent parameter, do not override. See `axi_to_mem`, parameter `mem_data_t`.
+  parameter type mem_data_t = logic [MEM_DATA_WIDTH-1:0],
+  /// Dependent parameter, do not override. See `axi_to_mem`, parameter `mem_strb_t`.
+  parameter type mem_strb_t = logic [MEM_DATA_WIDTH/8-1:0]
+) (
+  /// Clock input.
+  input  logic                               clk_i,
+  /// Asynchronous reset, active low.
+  input  logic                               rst_ni,
+  /// See `axi_to_mem_split`, port `busy_o`.
+  output logic                               busy_o,
+  /// AXI4+ATOP slave interface port.
+  AXI_BUS.Slave                              axi_bus,
+  /// See `axi_to_mem_split`, port `mem_req_o`.
+  output logic           [NUM_MEM_PORTS-1:0] mem_req_o,
+  /// See `axi_to_mem_split`, port `mem_gnt_i`.
+  input  logic           [NUM_MEM_PORTS-1:0] mem_gnt_i,
+  /// See `axi_to_mem_split`, port `mem_addr_o`.
+  output addr_t          [NUM_MEM_PORTS-1:0] mem_addr_o,
+  /// See `axi_to_mem_split`, port `mem_wdata_o`.
+  output mem_data_t      [NUM_MEM_PORTS-1:0] mem_wdata_o,
+  /// See `axi_to_mem_split`, port `mem_strb_o`.
+  output mem_strb_t      [NUM_MEM_PORTS-1:0] mem_strb_o,
+  /// See `axi_to_mem_split`, port `mem_atop_o`.
+  output axi_pkg::atop_t [NUM_MEM_PORTS-1:0] mem_atop_o,
+  /// See `axi_to_mem_split`, port `mem_we_o`.
+  output logic           [NUM_MEM_PORTS-1:0] mem_we_o,
+  /// See `axi_to_mem_split`, port `mem_rvalid_i`.
+  input  logic           [NUM_MEM_PORTS-1:0] mem_rvalid_i,
+  /// See `axi_to_mem_split`, port `mem_rdata_i`.
+  input  mem_data_t      [NUM_MEM_PORTS-1:0] mem_rdata_i
+);
+
+  typedef logic [AXI_ID_WIDTH-1:0] id_t;
+  typedef logic [AXI_DATA_WIDTH-1:0] data_t;
+  typedef logic [AXI_DATA_WIDTH/8-1:0] strb_t;
+  typedef logic [AXI_USER_WIDTH-1:0] user_t;
+  `AXI_TYPEDEF_ALL(axi, addr_t, id_t, data_t, strb_t, user_t)
+
+  axi_req_t axi_req;
+  axi_resp_t axi_resp;
+  `AXI_ASSIGN_TO_REQ(axi_req, axi_bus)
+  `AXI_ASSIGN_FROM_RESP(axi_bus, axi_resp)
+
+  axi_to_mem_split #(
+    .axi_req_t    ( axi_req_t      ),
+    .axi_resp_t   ( axi_resp_t     ),
+    .AxiDataWidth ( AXI_DATA_WIDTH ),
+    .AddrWidth    ( AXI_ADDR_WIDTH ),
+    .IdWidth      ( AXI_ID_WIDTH   ),
+    .MemDataWidth ( MEM_DATA_WIDTH ), // must divide `AxiDataWidth` without remainder
+    .BufDepth     ( BUF_DEPTH      ),
+    .HideStrb     ( HIDE_STRB      )
+  ) i_axi_to_mem_split (
+    .clk_i,
+    .rst_ni,
+    .busy_o,
+    .axi_req_i (axi_req),
+    .axi_resp_o (axi_resp),
+    .mem_req_o,
+    .mem_gnt_i,
+    .mem_addr_o,
+    .mem_wdata_o,
+    .mem_strb_o,
+    .mem_atop_o,
+    .mem_we_o,
+    .mem_rvalid_i,
+    .mem_rdata_i
+  );
+
+endmodule

--- a/test/axi_synth_bench.sv
+++ b/test/axi_synth_bench.sv
@@ -176,10 +176,10 @@ module axi_synth_bench (
 
   // AXI4+ATOP on chip memory slave banked
   for (genvar i = 0; i < 5; i++) begin : gen_axi_to_mem_banked_data
-    for (genvar j = 0; j < 5; j++) begin : gen_axi_to_mem_banked_bank_num
+    for (genvar j = 0; j < 4; j++) begin : gen_axi_to_mem_banked_bank_num
       for (genvar k = 0; k < 2; k++) begin : gen_axi_to_mem_banked_bank_addr
         localparam int unsigned DATA_WIDTH_AXI[5]   = {32'd32, 32'd64, 32'd128, 32'd256, 32'd512};
-        localparam int unsigned NUM_BANKS[5]        = {32'd2,  32'd4,  32'd6,   32'd8,   32'd16};
+        localparam int unsigned NUM_BANKS[4]        = {32'd2,  32'd4,  32'd6,   32'd8};
         localparam int unsigned ADDR_WIDTH_BANKS[2] = {32'd5,  32'd11};
 
         synth_axi_to_mem_banked #(

--- a/test/tb_axi_to_mem_banked.sv
+++ b/test/tb_axi_to_mem_banked.sv
@@ -177,8 +177,8 @@ module tb_axi_to_mem_banked #(
 
   // Clock generator
   clk_rst_gen #(
-    .CLK_PERIOD     ( CyclTime ),
-    .RST_CLK_CYCLES ( 5        )
+    .ClkPeriod    ( CyclTime ),
+    .RstClkCycles ( 5        )
   ) i_clk_rst_gen (
     .clk_o  ( clk   ),
     .rst_no ( rst_n )

--- a/test/tb_axi_to_mem_banked.sv
+++ b/test/tb_axi_to_mem_banked.sv
@@ -1,0 +1,417 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Authors:
+// - Wolfgang Roenninger <wroennin@iis.ee.ethz.ch>
+
+`include "axi/typedef.svh"
+`include "axi/assign.svh"
+`include "common_cells/registers.svh"
+
+/// Testbench for axi_to_mem_banked. Monitors the performance for random accesses.
+module tb_axi_to_mem_banked #(
+  /// Data Width of the AXI4+ATOP channels.
+  parameter int unsigned TbAxiDataWidth = 32'd256,
+  /// Number of words of an individual memory bank.
+  /// Determines the address width of the request output.
+  parameter int unsigned TbNumWords     = 32'd8192,
+  /// Number of connected memory banks.
+  parameter int unsigned TbNumBanks     = 32'd8,
+  /// Data width of an individual memory bank.
+  parameter int unsigned TbMemDataWidth = 32'd64,
+  /// Latancy in cycles of a memory bank.
+  parameter int unsigned TbMemLatency   = 32'd2,
+  /// Number of writes performed by the testbench.
+  parameter int unsigned NumWrites    = 32'd5000,
+  /// Number of writes performed by the testbench.
+  parameter int unsigned NumReads     = 32'd10000
+);
+  // test bench params
+  localparam time CyclTime = 10ns;
+  localparam time ApplTime = 2ns;
+  localparam time TestTime = 8ns;
+
+  // localparam and typedefs for AXI4+ATOP
+  localparam int unsigned AxiIdWidth   = 32'd6;
+  localparam int unsigned AxiAddrWidth = 32'd64;
+  localparam int unsigned AxiStrbWidth = TbAxiDataWidth / 8;
+  localparam int unsigned AxiUserWidth = 32'd4;
+
+  typedef logic [AxiAddrWidth-1:0] axi_addr_t;
+
+  // AXI test defines
+  typedef axi_test::rand_axi_master #(
+    // AXI interface parameters
+    .AW ( AxiAddrWidth ),
+    .DW ( TbAxiDataWidth ),
+    .IW ( AxiIdWidth   ),
+    .UW ( AxiUserWidth ),
+    // Stimuli application and test time
+    .TA ( ApplTime     ),
+    .TT ( TestTime     ),
+    // Maximum number of read and write transactions in flight
+    .MAX_READ_TXNS        (   20 ),
+    .MAX_WRITE_TXNS       (   20 ),
+    // Upper and lower bounds on wait cycles on Ax, W, and resp (R and B) channels
+    .AX_MIN_WAIT_CYCLES   (    0 ),
+    .AX_MAX_WAIT_CYCLES   (    0 ),
+    .W_MIN_WAIT_CYCLES    (    0 ),
+    .W_MAX_WAIT_CYCLES    (    0 ),
+    .RESP_MIN_WAIT_CYCLES (    0 ),
+    .RESP_MAX_WAIT_CYCLES (    0 ),
+    // AXI feature usage
+    .AXI_MAX_BURST_LEN    (    0 ), // maximum number of beats in burst; 0 = AXI max (256)
+    .TRAFFIC_SHAPING      (    0 ),
+    .AXI_EXCLS            ( 1'b0 ),
+    .AXI_ATOPS            ( 1'b0 ),
+    .AXI_BURST_FIXED      ( 1'b0 ),
+    .AXI_BURST_INCR       ( 1'b1 ),
+    .AXI_BURST_WRAP       ( 1'b0 )
+  ) rand_axi_master_t;
+
+  // memory defines
+  localparam int unsigned MemAddrWidth = $clog2(TbNumWords);
+
+  localparam int unsigned MemBufDepth  = 1;
+  // addresses
+  localparam axi_addr_t StartAddr = axi_addr_t'(64'h0);
+  localparam axi_addr_t EndAddr   = axi_addr_t'(StartAddr + 32'd2 * TbNumWords * TbAxiDataWidth/32'd8);
+
+  typedef logic [MemAddrWidth-1:0]   mem_addr_t;
+  typedef logic [5:0]                mem_atop_t;
+  typedef logic [TbMemDataWidth-1:0]   mem_data_t;
+  typedef logic [TbMemDataWidth/8-1:0] mem_strb_t;
+
+  // sim signals
+  logic end_of_sim;
+
+  // dut signals
+  logic clk, rst_n, one_dut_active;
+
+  logic      [1:0]          dut_busy;
+  logic      [TbNumBanks-1:0] mem_req;
+  logic      [TbNumBanks-1:0] mem_gnt;
+  mem_addr_t [TbNumBanks-1:0] mem_addr;
+  mem_data_t [TbNumBanks-1:0] mem_wdata;
+  mem_strb_t [TbNumBanks-1:0] mem_strb;
+  logic      [TbNumBanks-1:0] mem_we;
+  mem_atop_t [TbNumBanks-1:0] mem_atop;
+  logic      [TbNumBanks-1:0] mem_rvalid;
+  mem_data_t [TbNumBanks-1:0] mem_rdata;
+
+  assign one_dut_active = |dut_busy;
+
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth ),
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_USER_WIDTH ( AxiUserWidth )
+  ) mem_axi_dv (clk);
+
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth ),
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_USER_WIDTH ( AxiUserWidth )
+  ) mem_axi ();
+  `AXI_ASSIGN(mem_axi, mem_axi_dv)
+
+  // stimuli generation
+  initial begin : proc_axi_master
+    static rand_axi_master_t rand_axi_master = new ( mem_axi_dv );
+    end_of_sim <= 1'b0;
+    rand_axi_master.add_memory_region(StartAddr, EndAddr, axi_pkg::DEVICE_NONBUFFERABLE);
+    rand_axi_master.reset();
+    @(posedge rst_n);
+    @(posedge clk);
+    @(posedge clk);
+
+    rand_axi_master.run(NumReads, NumWrites);
+    end_of_sim <= 1'b1;
+  end
+
+  // memory banks
+  for (genvar i = 0; i < TbNumBanks; i++) begin : gen_tc_sram
+    tc_sram #(
+      .NumWords    ( TbNumWords   ),
+      .DataWidth   ( TbMemDataWidth ),
+      .ByteWidth   ( 32'd8        ),
+      .NumPorts    ( 32'd1        ),
+      .Latency     ( TbMemLatency   ),
+      .SimInit     ( "none"       ),
+      .PrintSimCfg ( 1'b1         )
+    ) i_tc_sram_bank (
+      .clk_i   ( clk          ),
+      .rst_ni  ( rst_n        ),
+      .req_i   ( mem_req[i]   ),
+      .we_i    ( mem_we[i]    ),
+      .addr_i  ( mem_addr[i]  ),
+      .wdata_i ( mem_wdata[i] ),
+      .be_i    ( mem_strb[i]  ),
+      .rdata_o ( mem_rdata[i] )
+    );
+    // always be ready
+    assign mem_gnt[i] = 1'b1;
+    // generate mem_rvalid signal
+    if (TbMemLatency == 0) begin : gen_no_mem__lat
+      assign mem_rvalid[i] = mem_req[i];
+    end else begin : gen_mem_lat
+      logic [TbMemLatency-1:0] mem_lat_q, mem_lat_d;
+      `FFARN(mem_lat_q, mem_lat_d, '0, clk, rst_n)
+      assign mem_lat_d[TbMemLatency-1] = mem_req[i];
+      if (TbMemLatency > 1) begin
+        for (genvar lat_i = 0; lat_i < TbMemLatency - 1; lat_i++) begin
+          assign mem_lat_d[lat_i] = mem_lat_q[lat_i+1];
+        end
+      end
+      assign mem_rvalid[i] = mem_lat_q[0];
+    end
+  end
+
+  // Clock generator
+  clk_rst_gen #(
+    .CLK_PERIOD     ( CyclTime ),
+    .RST_CLK_CYCLES ( 5        )
+  ) i_clk_rst_gen (
+    .clk_o  ( clk   ),
+    .rst_no ( rst_n )
+  );
+
+  // Design under test
+  axi_to_mem_banked_intf #(
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth ),
+    .AXI_USER_WIDTH ( AxiUserWidth ),
+    .MEM_NUM_BANKS  ( TbNumBanks     ),
+    .MEM_ADDR_WIDTH ( MemAddrWidth ),
+    .MEM_DATA_WIDTH ( TbMemDataWidth ),
+    .MEM_LATENCY    ( TbMemLatency   )
+  ) i_axi_to_mem_banked_dut (
+    .clk_i             ( clk       ),
+    .rst_ni            ( rst_n     ),
+    .test_i            ( 1'b0      ),
+    .axi_to_mem_busy_o ( dut_busy  ),
+    .slv               ( mem_axi   ),
+    .mem_req_o         ( mem_req   ),
+    .mem_gnt_i         ( mem_gnt   ),
+    .mem_add_o         ( mem_addr  ), // byte address
+    .mem_wdata_o       ( mem_wdata ), // write data
+    .mem_be_o          ( mem_strb  ), // byte-wise strobe
+    .mem_atop_o        ( mem_atop  ), // atomic operation
+    .mem_we_o          ( mem_we    ), // write enable
+    .mem_rdata_i       ( mem_rdata )  // read data
+  );
+
+  // monitoring
+  logic aw_beat, aw_stall, w_beat, b_beat, ar_beat, ar_stall, r_beat;
+  assign aw_beat  = mem_axi.aw_valid & mem_axi.aw_ready;
+  assign aw_stall = mem_axi.aw_valid & !mem_axi.aw_ready;
+  assign  w_beat  = mem_axi.w_valid  & mem_axi.w_ready;
+  assign  b_beat  = mem_axi.b_valid  & mem_axi.b_ready;
+  assign ar_beat  = mem_axi.ar_valid & mem_axi.ar_ready;
+  assign ar_stall = mem_axi.ar_valid & !mem_axi.ar_ready;
+  assign  r_beat  = mem_axi.r_valid  & mem_axi.r_ready;
+
+  int unsigned aw_open;
+  int unsigned ar_open;
+
+  initial begin : proc_monitor
+    automatic bit aw_new = 1;
+    automatic bit w_new  = 1;
+    automatic bit b_new  = 1;
+    automatic bit ar_new = 1;
+    automatic bit r_new  = 1;
+
+
+    automatic longint      wc_cnt     = 0;
+    automatic longint      rc_cnt     = 0;
+    automatic longint      w_cnt      = 0;
+    automatic longint      r_cnt      = 0;
+
+    automatic longint      busy_cnt;
+    automatic longint      dut_busy_cnt [TbNumBanks];
+    automatic real         bank_busy_percent;
+    automatic real         axi_busy_percent;
+    automatic real         tmp;
+
+    aw_open           = 0;
+    ar_open           = 0;
+    bank_busy_percent = 0;
+    axi_busy_percent  = 0;
+    for (int i = 0; i < TbNumBanks; i++) begin
+      dut_busy_cnt[i] = 0;
+    end
+    $display("###############################################################################");
+    $display("Sim Parameter:");
+    $display("###############################################################################");
+    $display("TbAxiDataWidth: %0d", TbAxiDataWidth);
+    $display("TbMemDataWidth: %0d", TbMemDataWidth);
+    $display("TbNumBanks:     %0d", TbNumBanks);
+    $display("TbMemLatency:   %0d", TbMemLatency);
+    $display("###############################################################################");
+
+    @(posedge rst_n);
+    forever begin
+      @(posedge clk);
+
+      #TestTime;
+      // determine the first valid of an AW transaction
+      if (mem_axi.aw_valid) begin
+        if (aw_new) begin
+          aw_open++;
+          if (!mem_axi.aw_ready) begin
+            aw_new = 0;
+          end
+        end else begin
+          if (mem_axi.aw_ready) begin
+            aw_new = 1;
+          end
+        end
+      end
+
+      // determine the first valid of an AR transaction
+      if (mem_axi.ar_valid) begin
+        if (ar_new) begin
+          ar_open++;
+          if (!mem_axi.ar_ready) begin
+            ar_new = 0;
+          end
+        end else begin
+          if (mem_axi.ar_ready) begin
+            ar_new = 1;
+          end
+        end
+      end
+
+      if (b_beat) begin
+        aw_open--;
+      end
+      if (r_beat && mem_axi.r_last) begin
+        ar_open--;
+      end
+
+      if (aw_open > 0) begin
+        wc_cnt++;
+      end
+      if (ar_open > 0) begin
+        rc_cnt++;
+      end
+
+      if (w_beat) begin
+        w_cnt++;
+      end
+      if (r_beat) begin
+        r_cnt++;
+      end
+
+      if ((aw_open > 0) || (ar_open > 0)) begin
+        busy_cnt++;
+      end
+
+      for (int unsigned i = 0; i < TbNumBanks; i++) begin
+        if (mem_req[i]) begin
+          dut_busy_cnt[i]++;
+        end
+      end
+
+
+      if (end_of_sim) begin
+        @(posedge clk);
+        $display("###############################################################################");
+        $display("Statistics:");
+        $display("###############################################################################");
+        $display("Writes:");
+        $display("Cycles Open write tnx: %0d", wc_cnt);
+        $display("Write beat count:      %0d", w_cnt);
+        $display("Write utilization:     %0f", real'(w_cnt) / real'(wc_cnt) * 100);
+        axi_busy_percent += real'(w_cnt) / real'(wc_cnt) * 100;
+                $display("###############################################################################");
+        $display("Reads:");
+        $display("Cycles Open read tnx:  %0d", rc_cnt);
+        $display("Read beat count:       %0d", r_cnt);
+        $display("Read utilization:      %0f", real'(r_cnt) / real'(rc_cnt) * 100);
+        axi_busy_percent += real'(r_cnt) / real'(rc_cnt) * 100;
+        $display("###############################################################################");
+        for (int unsigned i = 0; i < TbNumBanks; i++) begin
+          bank_busy_percent += real'(dut_busy_cnt[i]) / real'(busy_cnt) * 100;
+          $display("Bank %0d utilization: %0f", i, real'(dut_busy_cnt[i]) / real'(busy_cnt) * 100);
+          tmp = dut_busy_cnt[i];
+          $display("Bank %0d requests: %0f", i, tmp);
+          tmp = busy_cnt;
+          $display("Bank %0d busy cycles: %0f", i, tmp);
+        end
+        $display("Sum bank utilization:      %0f", bank_busy_percent);
+        $display("Sum axi utilization:       %0f", axi_busy_percent);
+        $display("###############################################################################");
+        $stop();
+      end
+    end
+  end
+
+  initial begin : proc_sim_progress
+    longint unsigned       ActAwTnx;
+    longint unsigned       ActArTnx;
+    automatic int unsigned PrintInterv = 100;
+
+    ActAwTnx = 0;
+    ActArTnx = 0;
+    $display("Start Addr: %0h", StartAddr);
+    $display("End   addr: %0h", EndAddr);
+
+    @(posedge rst_n);
+    forever begin
+      @(posedge clk);
+      #TestTime;
+
+      if (aw_beat) begin
+        if (ActAwTnx % PrintInterv == 0) begin
+          $display("%t > AW Transaction %d of %d ", $time(), ActAwTnx, NumWrites);
+        end
+        ActAwTnx++;
+      end
+      if (ar_beat) begin
+        if (ActArTnx % PrintInterv == 0) begin
+          $display("%t > AR Transaction %d of %d ", $time(), ActArTnx, NumReads);
+        end
+        ActArTnx++;
+      end
+
+      if (end_of_sim) begin
+        break;
+      end
+    end
+  end
+
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth ),
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_USER_WIDTH ( AxiUserWidth )
+  ) monitor_dv (clk);
+
+  `AXI_ASSIGN_MONITOR(monitor_dv, mem_axi)
+
+  typedef axi_test::axi_scoreboard #(
+    .IW ( AxiIdWidth   ),
+    .AW ( AxiAddrWidth ),
+    .DW ( TbAxiDataWidth ),
+    .UW ( AxiUserWidth ),
+    .TT ( TestTime     )
+  ) axi_scoreboard_t;
+  axi_scoreboard_t axi_scoreboard = new(monitor_dv);
+  initial begin : proc_scoreboard
+    axi_scoreboard.enable_all_checks();
+    @(posedge rst_n);
+    axi_scoreboard.monitor();
+    wait (end_of_sim);
+  end
+
+endmodule

--- a/test/tb_axi_to_mem_banked.sv
+++ b/test/tb_axi_to_mem_banked.sv
@@ -29,9 +29,9 @@ module tb_axi_to_mem_banked #(
   /// Latancy in cycles of a memory bank.
   parameter int unsigned TbMemLatency   = 32'd2,
   /// Number of writes performed by the testbench.
-  parameter int unsigned NumWrites    = 32'd5000,
+  parameter int unsigned NumWrites      = 32'd10000,
   /// Number of writes performed by the testbench.
-  parameter int unsigned NumReads     = 32'd10000
+  parameter int unsigned NumReads       = 32'd10000
 );
   // test bench params
   localparam time CyclTime = 10ns;


### PR DESCRIPTION
Rebase of the relevant changes in #115 on the current master

This adds two modules:
- `axi_to_mem`: Slave module, max throughout simultaneous read/writes 50%, read or write 100%.
- `axi_to_mem_banked`: With enough banks 100% throughput with simultaneous reads/writes.

Notes to Bender:
For the dependencies pulp-platform/tech_cells_generic has been directly added. In there the tc_sram module is used for the testbench to serve a memory model.

Open tasks
- [x] Rework `mem_to_banks` to ensure no writes are issued with `strb='0`. While not illegal, this can cause issues (e.g. when converting back to APB3) and unnecessary contention on an interconnect
- [x] Add an interleaved variant to allow reads and writes to bypass each other
- [x] Add a split variant to completely separate the read and write channel to individual mem ports when connecting to an interconnect