### PR TITLE
axi_sim_mem: Add monitoring interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+- `axi_sim_mem`: Add monitoring interface to observe the point of coherency between the write and
+  the read channel.
 
 ### Changed
 

--- a/src/axi_sim_mem.sv
+++ b/src/axi_sim_mem.sv
@@ -46,7 +46,39 @@ module axi_sim_mem #(
   /// AXI4 request struct
   input  axi_req_t axi_req_i,
   /// AXI4 response struct
-  output axi_rsp_t axi_rsp_o
+  output axi_rsp_t axi_rsp_o,
+  /// Memory monitor write valid.  All `mon_w_*` outputs are only valid if this signal is high.
+  /// A write to the memory is visible on the `mon_w_*` outputs in the clock cycle after it has
+  /// happened.
+  output logic                 mon_w_valid_o,
+  /// Memory monitor write address
+  output logic [AddrWidth-1:0] mon_w_addr_o,
+  /// Memory monitor write data
+  output logic [DataWidth-1:0] mon_w_data_o,
+  /// Memory monitor write ID
+  output logic [IdWidth-1:0]   mon_w_id_o,
+  /// Memory monitor write user
+  output logic [UserWidth-1:0] mon_w_user_o,
+  /// Memory monitor write beat count
+  output axi_pkg::len_t        mon_w_beat_count_o,
+  /// Memory monitor write last
+  output logic                 mon_w_last_o,
+  /// Memory monitor read valid.  All `mon_r_*` outputs are only valid if this signal is high.
+  /// A read from the memory is visible on the `mon_w_*` outputs in the clock cycle after it has
+  /// happened.
+  output logic                 mon_r_valid_o,
+  /// Memory monitor read address
+  output logic [AddrWidth-1:0] mon_r_addr_o,
+  /// Memory monitor read data
+  output logic [DataWidth-1:0] mon_r_data_o,
+  /// Memory monitor read ID
+  output logic [IdWidth-1:0]   mon_r_id_o,
+  /// Memory monitor read user
+  output logic [UserWidth-1:0] mon_r_user_o,
+  /// Memory monitor read beat count
+  output axi_pkg::len_t        mon_r_beat_count_o,
+  /// Memory monitor read last
+  output logic                 mon_r_last_o
 );
 
   localparam int unsigned StrbWidth = DataWidth / 8;
@@ -61,6 +93,17 @@ module axi_sim_mem #(
   `AXI_TYPEDEF_AR_CHAN_T(ar_t, addr_t, id_t, user_t)
   `AXI_TYPEDEF_R_CHAN_T(r_t, data_t, id_t, user_t)
 
+  typedef struct packed {
+    logic                 valid;
+    logic [AddrWidth-1:0] addr;
+    logic [DataWidth-1:0] data;
+    logic [IdWidth-1:0]   id;
+    logic [UserWidth-1:0] user;
+    axi_pkg::len_t        beat_count;
+    logic                 last;
+  } monitor_t;
+
+  monitor_t mon_w, mon_r;
   logic [7:0] mem[addr_t];
 
   initial begin
@@ -69,6 +112,9 @@ module axi_sim_mem #(
     automatic b_t b_queue[$];
     automatic shortint unsigned r_cnt = 0, w_cnt = 0;
     axi_rsp_o = '0;
+    // Monitor interface
+    mon_w = '0;
+    mon_r = '0;
     wait (rst_ni);
     fork
       // AW
@@ -87,6 +133,7 @@ module axi_sim_mem #(
         @(posedge clk_i);
         #(ApplDelay);
         axi_rsp_o.w_ready = 1'b0;
+        mon_w = '0;
         if (aw_queue.size() != 0) begin
           axi_rsp_o.w_ready = 1'b1;
           #(AcqDelay - ApplDelay);
@@ -96,6 +143,12 @@ module axi_sim_mem #(
             automatic axi_pkg::size_t size = aw_queue[0].size;
             automatic addr_t addr = axi_pkg::beat_addr(aw_queue[0].addr, size, len, burst,
                 w_cnt);
+            mon_w.valid = 1'b1;
+            mon_w.addr = addr;
+            mon_w.data = axi_req_i.w.data;
+            mon_w.id = aw_queue[0].id;
+            mon_w.user = aw_queue[0].user;
+            mon_w.beat_count = w_cnt;
             for (shortint unsigned
                 i_byte = axi_pkg::beat_lower_byte(addr, size, len, burst, StrbWidth, w_cnt);
                 i_byte <= axi_pkg::beat_upper_byte(addr, size, len, burst, StrbWidth, w_cnt);
@@ -112,6 +165,7 @@ module axi_sim_mem #(
               b_beat.resp = axi_pkg::RESP_OKAY;
               b_queue.push_back(b_beat);
               w_cnt = 0;
+              mon_w.last = 1'b1;
               void'(aw_queue.pop_front());
             end else begin
               assert (!axi_req_i.w.last) else $error("Did not expect last beat of W burst!");
@@ -150,6 +204,7 @@ module axi_sim_mem #(
         @(posedge clk_i);
         #(ApplDelay);
         axi_rsp_o.r_valid = 1'b0;
+        mon_r = '0;
         if (ar_queue.size() != 0) begin
           automatic axi_pkg::burst_t burst = ar_queue[0].burst;
           automatic axi_pkg::len_t len = ar_queue[0].len;
@@ -176,13 +231,21 @@ module axi_sim_mem #(
           end
           if (r_cnt == ar_queue[0].len) begin
             r_beat.last = 1'b1;
+            mon_r.last = 1'b1;
           end
           axi_rsp_o.r = r_beat;
           axi_rsp_o.r_valid = 1'b1;
+          mon_r.valid = 1'b1;
+          mon_r.addr = addr;
+          mon_r.data = r_beat.data;
+          mon_r.id = r_beat.id;
+          mon_r.user = r_beat.user;
+          mon_r.beat_count = r_cnt;
           #(AcqDelay - ApplDelay);
           while (!axi_req_i.r_ready) begin
             @(posedge clk_i);
             #(AcqDelay);
+            mon_r = '0;
           end
           if (r_beat.last) begin
             r_cnt = 0;
@@ -193,6 +256,46 @@ module axi_sim_mem #(
         end
       end
     join
+  end
+
+  // Assign the monitor output in the next clock cycle.  Rationale: We only know whether we are
+  // writing until after `AcqDelay`.  This means we could only provide the monitoring output for
+  // writes after `AcqDelay` in the same cycle, which is incompatible with ATI timing.  Thus, we
+  // provide the monitoring output for writes (and for uniformity also for reads) in the next clock
+  // cycle.
+  initial begin
+    mon_w_valid_o = '0;
+    mon_w_addr_o = '0;
+    mon_w_data_o = '0;
+    mon_w_id_o = '0;
+    mon_w_user_o = '0;
+    mon_w_beat_count_o = '0;
+    mon_w_last_o = '0;
+    mon_r_valid_o = '0;
+    mon_r_addr_o = '0;
+    mon_r_data_o = '0;
+    mon_r_id_o = '0;
+    mon_r_user_o = '0;
+    mon_r_beat_count_o = '0;
+    mon_r_last_o = '0;
+    wait (rst_ni);
+    forever begin
+      @(posedge clk_i);
+      mon_w_valid_o <= #(ApplDelay) mon_w.valid;
+      mon_w_addr_o <= #(ApplDelay) mon_w.addr;
+      mon_w_data_o <= #(ApplDelay) mon_w.data;
+      mon_w_id_o <= #(ApplDelay) mon_w.id;
+      mon_w_user_o <= #(ApplDelay) mon_w.user;
+      mon_w_beat_count_o <= #(ApplDelay) mon_w.beat_count;
+      mon_w_last_o <= #(ApplDelay) mon_w.last;
+      mon_r_valid_o <= #(ApplDelay) mon_r.valid;
+      mon_r_addr_o <= #(ApplDelay) mon_r.addr;
+      mon_r_data_o <= #(ApplDelay) mon_r.data;
+      mon_r_id_o <= #(ApplDelay) mon_r.id;
+      mon_r_user_o <= #(ApplDelay) mon_r.user;
+      mon_r_beat_count_o <= #(ApplDelay) mon_r.beat_count;
+      mon_r_last_o <= #(ApplDelay) mon_r.last;
+    end
   end
 
   // Parameter Assertions
@@ -220,9 +323,23 @@ module axi_sim_mem_intf #(
   parameter time APPL_DELAY = 0ps,
   parameter time ACQ_DELAY = 0ps
 ) (
-  input  logic  clk_i,
-  input  logic  rst_ni,
-  AXI_BUS.Slave axi_slv
+  input  logic                      clk_i,
+  input  logic                      rst_ni,
+  AXI_BUS.Slave                     axi_slv,
+  output logic                      mon_w_valid_o,
+  output logic [AXI_ADDR_WIDTH-1:0] mon_w_addr_o,
+  output logic [AXI_DATA_WIDTH-1:0] mon_w_data_o,
+  output logic [AXI_ID_WIDTH-1:0]   mon_w_id_o,
+  output logic [AXI_USER_WIDTH-1:0] mon_w_user_o,
+  output axi_pkg::len_t             mon_w_beat_count_o,
+  output logic                      mon_w_last_o,
+  output logic                      mon_r_valid_o,
+  output logic [AXI_ADDR_WIDTH-1:0] mon_r_addr_o,
+  output logic [AXI_DATA_WIDTH-1:0] mon_r_data_o,
+  output logic [AXI_ID_WIDTH-1:0]   mon_r_id_o,
+  output logic [AXI_USER_WIDTH-1:0] mon_r_user_o,
+  output axi_pkg::len_t             mon_r_beat_count_o,
+  output logic                      mon_r_last_o
 );
 
   typedef logic [AXI_ADDR_WIDTH-1:0]   axi_addr_t;
@@ -251,8 +368,22 @@ module axi_sim_mem_intf #(
   ) i_sim_mem (
     .clk_i,
     .rst_ni,
-    .axi_req_i  (axi_req),
-    .axi_rsp_o  (axi_rsp)
+    .axi_req_i (axi_req),
+    .axi_rsp_o (axi_rsp),
+    .mon_w_valid_o,
+    .mon_w_addr_o,
+    .mon_w_data_o,
+    .mon_w_id_o,
+    .mon_w_user_o,
+    .mon_w_beat_count_o,
+    .mon_w_last_o,
+    .mon_r_valid_o,
+    .mon_r_addr_o,
+    .mon_r_data_o,
+    .mon_r_id_o,
+    .mon_r_user_o,
+    .mon_r_beat_count_o,
+    .mon_r_last_o
   );
 
 endmodule


### PR DESCRIPTION
Add a monitoring interface into the `axi_sim_mem` to observe the Point of Coherency between the write and the read channel.

#216 Has to be merged first.