### PR TITLE
axi_sim_mem: Propagate the ar_user signal correctly to the monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- `axi_sim_mem`: Propagate the AR channel's user signal correctly to the monitor.
 
 
 ## 0.35.0 - 2022-03-11

--- a/src/axi_sim_mem.sv
+++ b/src/axi_sim_mem.sv
@@ -239,7 +239,7 @@ module axi_sim_mem #(
           mon_r.addr = addr;
           mon_r.data = r_beat.data;
           mon_r.id = r_beat.id;
-          mon_r.user = r_beat.user;
+          mon_r.user = ar_queue[0].user;
           mon_r.beat_count = r_cnt;
           #(AcqDelay - ApplDelay);
           while (!axi_req_i.r_ready) begin


### PR DESCRIPTION
The AR channel's user signal was not correctly propagated to the monitor interface since we do not reflect the user signal. As the R and AR channels do not have the same user signals, it makes sense to use the AR's signal for the monitoring interface since this is the one the user has control over and might want to observe.