### PR TITLE
axi_demux: Eliminate unnecessary AW channel stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- `axi_demux`: Eliminate unnecessary stalls of AW channel when the AR channel has reached its
+  maximum number of transactions.  Prior to this fix, `axi_demux` would always stall AWs while read
+  transactions were at their maximum (that is, while `MaxTrans` read transactions were outstanding).
+  However, this stall is only required when the AW that is being handled by `axi_demux` is an atomic
+  operation (ATOP) that entails an R response.  This fix therefore removes unnecessary stalls as
+  well as an unnecessary dependency between reads and writes.  The integrity of data or transactions
+  was not affected by this problem.
 
 
 ## 0.35.2 - 2022-04-14

--- a/src/axi_demux.sv
+++ b/src/axi_demux.sv
@@ -275,10 +275,12 @@ module axi_demux #(
           atop_inject     = slv_aw_chan_select.aw_chan.atop[axi_pkg::ATOP_R_RESP] & AtopSupport;
         end
       end else begin
-        // Process can start handling a transaction if its `i_aw_id_counter` and `w_fifo` have
-        // space in them. Further check if we could inject something on the AR channel (only if
-        // ATOPs are supported).
-        if (!aw_id_cnt_full && !w_fifo_full && (!ar_id_cnt_full || !AtopSupport)) begin
+        // An AW can be handled if `i_aw_id_counter` and `i_w_fifo` are not full.  An ATOP that
+        // requires an R response can be handled if additionally `i_ar_id_counter` is not full (this
+        // only applies if ATOPs are supported at all).
+        if (!aw_id_cnt_full && !w_fifo_full &&
+            (!(ar_id_cnt_full && slv_aw_chan_select.aw_chan.atop[axi_pkg::ATOP_R_RESP]) ||
+             !AtopSupport)) begin
           // there is a valid AW vector make the id lookup and go further, if it passes
           if (slv_aw_valid && (!aw_select_occupied ||
              (slv_aw_chan_select.aw_select == lookup_aw_select))) begin


### PR DESCRIPTION
Eliminate unnecessary stalls of AW channel when the AR channel has
reached its maximum number of transactions.  Prior to this fix,
`axi_demux` would always stall AWs while read transactions were at their
maximum (that is, while `MaxTrans` read transactions were outstanding).
However, this stall is only required when the AW that is being handled
by `axi_demux` is an atomic operation (ATOP) that entails an R response.
This fix therefore removes unnecessary stalls as well as an unnecessary
dependency between reads and writes.  The integrity of data or
transactions was not affected by this problem.