### PR TITLE
AXI4 banked on chip memory slave

### DIFF
--- a/.ci/Memora.yml
+++ b/.ci/Memora.yml
@@ -258,6 +258,21 @@ artifacts:
     outputs:
       - build/axi_to_axi_lite-%.tested
 
+  axi_to_mem_banked-%:
+    inputs:
+      - Bender.yml
+      - include
+      - scripts/run_vsim.sh
+      - src/axi_pkg.sv
+      - src/axi_intf.sv
+      - src/axi_test.sv
+      - src/axi_demux.sv
+      - src/axi_to_mem.sv
+      - src/axi_to_mem_banked.sv
+      - test/tb_axi_to_mem_banked.sv
+    outputs:
+      - build/axi_to_mem_banked-%.tested
+
   axi_xbar-%:
     inputs:
       - Bender.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ vsim:
       fi
   parallel:
     matrix:
-      - VSIM_VER: ['10.7b', '10.7e', '2020.1', '2021.1']
+      - VSIM_VER: ['10.7b', '10.7e', '2021.3']
 
 synopsys_dc:
   stage: build
@@ -61,7 +61,7 @@ synopsys_dc:
       fi
   parallel:
     matrix:
-      - VSIM_VER: ['10.7b', '10.7e', '2020.1', '2021.1']
+      - VSIM_VER: ['10.7b', '10.7e', '2021.3']
 
 axi_addr_test:
   <<: *run_vsim
@@ -147,6 +147,11 @@ axi_to_axi_lite:
   <<: *run_vsim
   variables:
     TEST_MODULE: axi_to_axi_lite
+
+axi_to_mem_banked:
+  <<: *run_vsim
+  variables:
+    TEST_MODULE: axi_to_mem_banked
 
 axi_xbar:
   <<: *run_vsim

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,6 +10,7 @@ package:
 dependencies:
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.26.0 }
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.0 }
+  tech_cells_generic:  { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.2 }
 
 export_include_dirs:
   - include
@@ -55,6 +56,7 @@ sources:
   - src/axi_id_serialize.sv
   - src/axi_multicut.sv
   - src/axi_to_axi_lite.sv
+  - src/axi_to_mem_banked.sv
   # Level 4
   - src/axi_iw_converter.sv
   - src/axi_lite_xbar.sv
@@ -92,4 +94,5 @@ sources:
       - test/tb_axi_serializer.sv
       - test/tb_axi_sim_mem.sv
       - test/tb_axi_to_axi_lite.sv
+      - test/tb_axi_to_mem_banked.sv
       - test/tb_axi_xbar.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   scoreboard class.
 - `axi_throttle`: Add a module that limits the maximum number of outstanding transfers sent to the
   downstream logic.
+- `axi_to_mem_banked`:  AXI4+ATOP slave to control on chip memory, with banking support, higher
+                        throughput than `axi_to_mem`.
+- `Bender`: Add dependency `tech_cells_generic` `v0.2.2` for generic SRAM macro for simulation.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In addition to the documents linked in the following table, we are setting up [d
 | [`axi_throttle`](src/axi_throttle.sv)                | Limits the maximum number of outstanding transfers sent to the downstream logic.                  |                                |
 | [`axi_test`](src/axi_test.sv)                        | A set of testbench utilities for AXI interfaces.                                                  |                                |
 | [`axi_to_axi_lite`](src/axi_to_axi_lite.sv)          | AXI4 to AXI4-Lite protocol converter.                                                             |                                |
-| [`axi_to_mem`](src/axi_to_mem.sv)                    | AXI4 to memory protocol (req, gnt, rvalid) converter.                                             |                                |
+| [`axi_to_mem`](src/axi_to_mem.sv)                    | AXI4 to memory protocol (req, gnt, rvalid) converter. Additional banked variant.                  |                                |
 | [`axi_xbar`](src/axi_xbar.sv)                        | Fully-connected AXI4+ATOP crossbar with an arbitrary number of slave and master ports.            | [Doc](doc/axi_xbar.md)         |
 
 ### Simulation-Only Modules

--- a/axi.core
+++ b/axi.core
@@ -47,6 +47,7 @@ filesets:
       - src/axi_id_serialize.sv
       - src/axi_multicut.sv
       - src/axi_to_axi_lite.sv
+      - src/axi_to_mem_banked.sv
       # Level 4
       - src/axi_iw_converter.sv
       - src/axi_lite_xbar.sv

--- a/scripts/compile_vsim.sh
+++ b/scripts/compile_vsim.sh
@@ -18,7 +18,7 @@ set -e
 
 [ ! -z "$VSIM" ] || VSIM=vsim
 
-bender script vsim -t test \
+bender script vsim -t test -t rtl \
     --vlog-arg="-svinputport=compat" \
     --vlog-arg="-override_timescale 1ns/1ps" \
     --vlog-arg="-suppress 2583" \

--- a/scripts/run_vsim.sh
+++ b/scripts/run_vsim.sh
@@ -174,6 +174,27 @@ exec_test() {
                 done
             done
             ;;
+        axi_to_mem_banked)
+            for MEM_LAT in 1 2; do
+                for BANK_FACTOR in 1 2; do
+                    for NUM_BANKS in 1 2 ; do
+                        for AXI_DATA_WIDTH in 64 256 ; do
+                            ACT_BANKS=$((2*$BANK_FACTOR*$NUM_BANKS))
+                            MEM_DATA_WIDTH=$(($AXI_DATA_WIDTH/$NUM_BANKS))
+                            call_vsim tb_axi_to_mem_banked \
+                                -voptargs="+acc +cover=bcesfx" \
+                                -gTbAxiDataWidth=$AXI_DATA_WIDTH \
+                                -gTbNumWords=2048 \
+                                -gTbNumBanks=$ACT_BANKS \
+                                -gTbMemDataWidth=$MEM_DATA_WIDTH \
+                                -gTbMemLatency=$MEM_LAT \
+                                -gTbNumWrites=2000 \
+                                -gTbNumReads=2000
+                        done
+                    done
+                done
+            done
+            ;;
         *)
             call_vsim tb_$1 -t 1ns -coverage -voptargs="+acc +cover=bcesfx"
             ;;

--- a/src/axi_to_mem_banked.sv
+++ b/src/axi_to_mem_banked.sv
@@ -107,7 +107,6 @@ module axi_to_mem_banked #(
     WriteAccess = 1'b1
   } access_type_e;
   typedef logic [AxiAddrWidth-1:0] axi_addr_t;
-  // typedef logic [TcdmDataWidth-1:0] tcdm_data_t;
 
   /// Payload definition which is sent over the xbar between the macros and the read/write unit.
   typedef struct packed {
@@ -146,7 +145,7 @@ module axi_to_mem_banked #(
     .axi_req_t   ( axi_req_t     ),
     .axi_resp_t  ( axi_resp_t    ),
     .NoMstPorts  ( 32'd2         ),
-    .MaxTrans    ( 32'd4         ), // allow multiple Ax vectors to not starve W channel
+    .MaxTrans    ( MemLatency+2  ), // allow multiple Ax vectors to not starve W channel
     .AxiLookBits ( 32'd1         ), // select is fixed, do not need it
     .UniqueIds   ( 1'b0          ),
     .FallThrough ( 1'b1          ),

--- a/src/axi_to_mem_banked.sv
+++ b/src/axi_to_mem_banked.sv
@@ -1,0 +1,430 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Authors:
+// - Wolfgang Rönninger <wroennin@iis.ee.ethz.ch>
+
+/// AXI4+ATOP to banked SRAM memory slave. Allows for parallel read and write transactions.
+/// Has higher throughput than `axi_to_mem`, however needs more hardware.
+///
+/// The used address space starts at 0x0 and ends at the capacity of all memory banks combined.
+/// The higher address bits are ignored for accesses.
+module axi_to_mem_banked #(
+  /// AXI4+ATOP ID width
+  parameter int unsigned                  AxiIdWidth    = 32'd0,
+  /// AXI4+ATOP address width
+  parameter int unsigned                  AxiAddrWidth  = 32'd0,
+  /// AXI4+ATOP data width
+  parameter int unsigned                  AxiDataWidth  = 32'd0,
+  /// AXI4+ATOP AW channel struct
+  parameter type                          axi_aw_chan_t = logic,
+  /// AXI4+ATOP  W channel struct
+  parameter type                          axi_w_chan_t  = logic,
+  /// AXI4+ATOP  B channel struct
+  parameter type                          axi_b_chan_t  = logic,
+  /// AXI4+ATOP AR channel struct
+  parameter type                          axi_ar_chan_t = logic,
+  /// AXI4+ATOP  R channel struct
+  parameter type                          axi_r_chan_t  = logic,
+  /// AXI4+ATOP request struct
+  parameter type                          axi_req_t     = logic,
+  /// AXI4+ATOP response struct
+  parameter type                          axi_resp_t    = logic,
+  /// Number of memory banks / macros
+  /// Has to satisfy:
+  /// - MemNumBanks >= 2 * AxiDataWidth / MemDataWidth
+  /// - MemNumBanks is a power of 2.
+  parameter int unsigned                  MemNumBanks   = 32'd4,
+  /// Address width of an individual memory bank. This is treated as a word address.
+  parameter int unsigned                  MemAddrWidth  = 32'd11,
+  /// Data width of the memory macros.
+  /// Has to satisfy:
+  /// - AxiDataWidth % MemDataWidth = 0
+  parameter int unsigned                  MemDataWidth  = 32'd32,
+  /// Read latency of the connected memory in cycles
+  parameter int unsigned                  MemLatency    = 32'd1,
+  /// Hide write requests if the strb == '0
+  parameter bit                           HideStrb      = 1'b0,
+  /// DEPENDENT PARAMETER, DO NOT OVERWRITE! Address type of the memory request.
+  parameter type mem_addr_t = logic [MemAddrWidth-1:0],
+  /// DEPENDENT PARAMETER, DO NOT OVERWRITE! Atomic operation type for the memory request.
+  parameter type mem_atop_t = axi_pkg::atop_t,
+  /// DEPENDENT PARAMETER, DO NOT OVERWRITE! Data type for the memory request.
+  parameter type mem_data_t = logic [MemDataWidth-1:0],
+  /// DEPENDENT PARAMETER, DO NOT OVERWRITE! Byte strobe/enable signal for the memory request.
+  parameter type mem_strb_t = logic [MemDataWidth/8-1:0]
+) (
+  /// Clock
+  input  logic                        clk_i,
+  /// Asynchronous reset, active low
+  input  logic                        rst_ni,
+  /// Testmode enable
+  input  logic                        test_i,
+  /// AXI4+ATOP slave port, request struct
+  input  axi_req_t                    axi_req_i,
+  /// AXI4+ATOP slave port, response struct
+  output axi_resp_t                   axi_resp_o,
+  /// Memory bank request
+  output logic      [MemNumBanks-1:0] mem_req_o,
+  /// Memory request grant
+  input  logic      [MemNumBanks-1:0] mem_gnt_i,
+  /// Request address
+  output mem_addr_t [MemNumBanks-1:0] mem_add_o,
+  /// Write request enable, active high
+  output logic      [MemNumBanks-1:0] mem_we_o,
+  /// Write data
+  output mem_data_t [MemNumBanks-1:0] mem_wdata_o,
+  /// Write data byte enable, active high
+  output mem_strb_t [MemNumBanks-1:0] mem_be_o,
+  /// Atomic operation
+  output mem_atop_t [MemNumBanks-1:0] mem_atop_o,
+  /// Read data response
+  input  mem_data_t [MemNumBanks-1:0] mem_rdata_i,
+  /// Status output, busy flag of `axi_to_mem`
+  output logic      [1:0]             axi_to_mem_busy_o
+);
+  /// This specifies the number of banks needed to have the full data bandwidth of one
+  /// AXI data channel.
+  localparam int unsigned BanksPerAxiChannel = AxiDataWidth / MemDataWidth;
+  /// Offset of the byte address from AXI to determine, where the selection signal for the
+  /// memory bank should start.
+  localparam int unsigned BankSelOffset = $clog2(MemDataWidth / 32'd8);
+  /// Selection signal width of the xbar. This is the reason for power of two banks, otherwise
+  /// There are holes in the address mapping.
+  localparam int unsigned BankSelWidth  = cf_math_pkg::idx_width(MemNumBanks);
+  typedef logic [BankSelWidth-1:0] xbar_sel_t;
+
+  // Typedef for defining the channels
+  typedef enum logic {
+    ReadAccess  = 1'b0,
+    WriteAccess = 1'b1
+  } access_type_e;
+  typedef logic [AxiAddrWidth-1:0] axi_addr_t;
+  // typedef logic [TcdmDataWidth-1:0] tcdm_data_t;
+
+  /// Payload definition which is sent over the xbar between the macros and the read/write unit.
+  typedef struct packed {
+    /// Address for the memory access
+    mem_addr_t addr;
+    /// Write enable, active high
+    logic      we;
+    /// Write data
+    mem_data_t wdata;
+    /// Strobe signal, byte enable
+    mem_strb_t wstrb;
+    /// Atomic operation, from AXI
+    mem_atop_t atop;
+  } xbar_payload_t;
+
+  /// Read data definition for the shift register, which samples the read response data
+  typedef struct packed {
+    /// Selection signal for response routing
+    xbar_sel_t sel;
+    /// Selection is valid
+    logic      valid;
+  } read_sel_t;
+
+  axi_req_t  [1:0] mem_axi_reqs;
+  axi_resp_t [1:0] mem_axi_resps;
+
+  // Fixed select `axi_demux` to split reads and writes to the two `axi_to_mem`
+  axi_demux #(
+    .AxiIdWidth  ( AxiIdWidth    ),
+    .AtopSupport ( 1'b1          ),
+    .aw_chan_t   ( axi_aw_chan_t ),
+    .w_chan_t    ( axi_w_chan_t  ),
+    .b_chan_t    ( axi_b_chan_t  ),
+    .ar_chan_t   ( axi_ar_chan_t ),
+    .r_chan_t    ( axi_r_chan_t  ),
+    .axi_req_t   ( axi_req_t     ),
+    .axi_resp_t  ( axi_resp_t    ),
+    .NoMstPorts  ( 32'd2         ),
+    .MaxTrans    ( 32'd4         ), // allow multiple Ax vectors to not starve W channel
+    .AxiLookBits ( 32'd1         ), // select is fixed, do not need it
+    .UniqueIds   ( 1'b0          ),
+    .FallThrough ( 1'b1          ),
+    .SpillAw     ( 1'b1          ),
+    .SpillW      ( 1'b1          ),
+    .SpillB      ( 1'b1          ),
+    .SpillAr     ( 1'b1          ),
+    .SpillR      ( 1'b1          )
+  ) i_axi_demux (
+    .clk_i,
+    .rst_ni,
+    .test_i,
+    .slv_req_i       ( axi_req_i     ),
+    .slv_aw_select_i ( WriteAccess   ),
+    .slv_ar_select_i ( ReadAccess    ),
+    .slv_resp_o      ( axi_resp_o    ),
+    .mst_reqs_o      ( mem_axi_reqs  ),
+    .mst_resps_i     ( mem_axi_resps )
+  );
+
+  xbar_payload_t [1:0][BanksPerAxiChannel-1:0] inter_payload;
+  xbar_sel_t     [1:0][BanksPerAxiChannel-1:0] inter_sel;
+  logic          [1:0][BanksPerAxiChannel-1:0] inter_valid,   inter_ready;
+
+  // axi_to_mem protocol converter
+  for (genvar i = 0; i < 2; i++) begin : gen_axi_to_mem
+    axi_addr_t [BanksPerAxiChannel-1:0] req_addr;  // This is a byte address
+    mem_data_t [BanksPerAxiChannel-1:0] req_wdata, res_rdata;
+    mem_strb_t [BanksPerAxiChannel-1:0] req_wstrb;
+    mem_atop_t [BanksPerAxiChannel-1:0] req_atop;
+
+    logic      [BanksPerAxiChannel-1:0] req_we,    res_valid;
+
+    // Careful, request / grant
+    // Only assert grant, if there is a ready
+    axi_to_mem #(
+      .axi_req_t ( axi_req_t          ),
+      .axi_resp_t( axi_resp_t         ),
+      .AddrWidth ( AxiAddrWidth       ),
+      .DataWidth ( AxiDataWidth       ),
+      .IdWidth   ( AxiIdWidth         ),
+      .NumBanks  ( BanksPerAxiChannel ),
+      .BufDepth  ( MemLatency         ),
+      .HideStrb  ( HideStrb           )
+    ) i_axi_to_mem (
+      .clk_i,
+      .rst_ni,
+      .busy_o       ( axi_to_mem_busy_o[i]            ),
+      .axi_req_i    ( mem_axi_reqs[i]                 ),
+      .axi_resp_o   ( mem_axi_resps[i]                ),
+      .mem_req_o    ( inter_valid[i]                  ),
+      .mem_gnt_i    ( inter_ready[i] & inter_valid[i] ), // convert valid/ready to req/gnt
+      .mem_addr_o   ( req_addr                        ),
+      .mem_wdata_o  ( req_wdata                       ),
+      .mem_strb_o   ( req_wstrb                       ),
+      .mem_atop_o   ( req_atop                        ),
+      .mem_we_o     ( req_we                          ),
+      .mem_rvalid_i ( res_valid                       ),
+      .mem_rdata_i  ( res_rdata                       )
+    );
+    // Pack the payload data together
+    for (genvar j = 0; unsigned'(j) < BanksPerAxiChannel; j++) begin : gen_response_mux
+      // Cut out the bank selection signal.
+      assign inter_sel[i][j] = req_addr[j][BankSelOffset+:BankSelWidth];
+
+      // Assign the xbar payload.
+      assign inter_payload[i][j] = xbar_payload_t'{
+        // Cut out the word address for the banks.
+        addr:    req_addr[j][(BankSelOffset+BankSelWidth)+:MemAddrWidth],
+        we:      req_we[j],
+        wdata:   req_wdata[j],
+        wstrb:   req_wstrb[j],
+        atop:    req_atop[j],
+        default: '0
+      };
+
+      // Cut out the portion of the address for the bank selection, each bank is word addressed!
+      read_sel_t r_shift_inp, r_shift_oup;
+      // Pack the selection into the shift register
+      assign r_shift_inp = read_sel_t'{
+        sel:     inter_sel[i][j],                       // Selection for response multiplexer
+        valid:   inter_valid[i][j] & inter_ready[i][j], // Valid when req to SRAM
+        default: '0
+      };
+
+      // Select the right read response data.
+      // Writes should also generate a `response`.
+      assign res_valid[j] = r_shift_oup.valid;
+      assign res_rdata[j] = mem_rdata_i[r_shift_oup.sel];
+
+      // Connect for the response data `MemLatency` cycles after a request was made to the xbar.
+      shift_reg #(
+        .dtype ( read_sel_t ),
+        .Depth ( MemLatency )
+      ) i_shift_reg_rdata_mux (
+        .clk_i,
+        .rst_ni,
+        .d_i    ( r_shift_inp ),
+        .d_o    ( r_shift_oup )
+      );
+    end
+  end
+
+  // Xbar to arbitrate data over the different memory banks
+  xbar_payload_t [MemNumBanks-1:0] mem_payload;
+
+  stream_xbar #(
+    .NumInp      ( 32'd2 * BanksPerAxiChannel ),
+    .NumOut      ( MemNumBanks                ),
+    .payload_t   ( xbar_payload_t             ),
+    .OutSpillReg ( 1'b0                       ),
+    .ExtPrio     ( 1'b0                       ),
+    .AxiVldRdy   ( 1'b1                       ),
+    .LockIn      ( 1'b1                       )
+  ) i_stream_xbar (
+    .clk_i,
+    .rst_ni,
+    .flush_i ( 1'b0          ),
+    .rr_i    ( '0            ),
+    .data_i  ( inter_payload ),
+    .sel_i   ( inter_sel     ),
+    .valid_i ( inter_valid   ),
+    .ready_o ( inter_ready   ),
+    .data_o  ( mem_payload   ),
+    .idx_o   ( /*not used*/  ),
+    .valid_o ( mem_req_o     ),
+    .ready_i ( mem_gnt_i     )
+  );
+
+  // Memory request output assignment
+  for (genvar i = 0; unsigned'(i) < MemNumBanks; i++) begin : gen_mem_outp
+    assign mem_add_o[i]   = mem_payload[i].addr;
+    assign mem_we_o[i]    = mem_payload[i].we;
+    assign mem_wdata_o[i] = mem_payload[i].wdata;
+    assign mem_be_o[i]    = mem_payload[i].wstrb;
+    assign mem_atop_o[i]  = mem_payload[i].atop;
+  end
+
+// pragma translate_off
+`ifndef VERILATOR
+  initial begin: p_assertions
+    assert (AxiIdWidth   >= 32'd1) else $fatal(1, "AxiIdWidth must be at least 1!");
+    assert (AxiAddrWidth >= 32'd1) else $fatal(1, "AxiAddrWidth must be at least 1!");
+    assert (AxiDataWidth >= 32'd1) else $fatal(1, "AxiDataWidth must be at least 1!");
+    assert (MemNumBanks  >= 32'd2 * AxiDataWidth / MemDataWidth) else
+        $fatal(1, "MemNumBanks has to be >= 2 * AxiDataWidth / MemDataWidth");
+    assert (MemLatency   >= 32'd1) else $fatal(1, "MemLatency has to be at least 1!");
+    assert ($onehot(MemNumBanks))  else $fatal(1, "MemNumBanks has to be a power of 2.");
+    assert (MemAddrWidth >= 32'd1) else $fatal(1, "MemAddrWidth must be at least 1!");
+    assert (MemDataWidth >= 32'd1) else $fatal(1, "MemDataWidth must be at least 1!");
+    assert (AxiDataWidth % MemDataWidth == 0) else
+        $fatal(1, "MemDataWidth has to be a divisor of AxiDataWidth.");
+  end
+`endif
+// pragma translate_on
+endmodule
+
+`include "axi/typedef.svh"
+`include "axi/assign.svh"
+/// AXI4+ATOP interface wrapper for `axi_to_mem`
+module axi_to_mem_banked_intf #(
+  /// AXI4+ATOP ID width
+  parameter int unsigned                  AXI_ID_WIDTH   = 32'd0,
+  /// AXI4+ATOP address width
+  parameter int unsigned                  AXI_ADDR_WIDTH = 32'd0,
+  /// AXI4+ATOP data width
+  parameter int unsigned                  AXI_DATA_WIDTH = 32'd0,
+  /// AXI4+ATOP user width
+  parameter int unsigned                  AXI_USER_WIDTH = 32'd0,
+  /// Number of memory banks / macros
+  /// Has to satisfy:
+  /// - MemNumBanks >= 2 * AxiDataWidth / MemDataWidth
+  /// - MemNumBanks is a power of 2.
+  parameter int unsigned                  MEM_NUM_BANKS  = 32'd4,
+  /// Address width of an individual memory bank.
+  parameter int unsigned                  MEM_ADDR_WIDTH = 32'd11,
+  /// Data width of the memory macros.
+  /// Has to satisfy:
+  /// - AxiDataWidth % MemDataWidth = 0
+  parameter int unsigned                  MEM_DATA_WIDTH = 32'd32,
+  /// Read latency of the connected memory in cycles
+  parameter int unsigned                  MEM_LATENCY    = 32'd1,
+  /// Hide write requests if the strb == '0
+  parameter bit                           HIDE_STRB      = 1'b0,
+  // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
+  parameter type mem_addr_t = logic [MEM_ADDR_WIDTH-1:0],
+  parameter type mem_atop_t = logic [5:0],
+  parameter type mem_data_t = logic [MEM_DATA_WIDTH-1:0],
+  parameter type mem_strb_t = logic [MEM_DATA_WIDTH/8-1:0]
+) (
+  /// Clock
+  input  logic                          clk_i,
+  /// Asynchronous reset, active low
+  input  logic                          rst_ni,
+  /// Testmode enable
+  input  logic                          test_i,
+  /// AXI4+ATOP slave port
+  AXI_BUS.Slave                         slv,
+  /// Memory bank request
+  output logic      [MEM_NUM_BANKS-1:0] mem_req_o,
+  /// Memory request grant
+  input  logic      [MEM_NUM_BANKS-1:0] mem_gnt_i,
+  /// Request address
+  output mem_addr_t [MEM_NUM_BANKS-1:0] mem_add_o,
+  /// Write request enable, active high
+  output logic      [MEM_NUM_BANKS-1:0] mem_we_o,
+  /// Write data
+  output mem_data_t [MEM_NUM_BANKS-1:0] mem_wdata_o,
+  /// Write data byte enable, active high
+  output mem_strb_t [MEM_NUM_BANKS-1:0] mem_be_o,
+  /// Atomic operation
+  output mem_atop_t [MEM_NUM_BANKS-1:0] mem_atop_o,
+  /// Read data response
+  input  mem_data_t [MEM_NUM_BANKS-1:0] mem_rdata_i,
+  /// Status output, busy flag of `axi_to_mem`
+  output logic      [1:0]               axi_to_mem_busy_o
+);
+  typedef logic [AXI_ID_WIDTH-1:0]     id_t;
+  typedef logic [AXI_ADDR_WIDTH-1:0]   addr_t;
+  typedef logic [AXI_DATA_WIDTH-1:0]   data_t;
+  typedef logic [AXI_DATA_WIDTH/8-1:0] strb_t;
+  typedef logic [AXI_USER_WIDTH-1:0]   user_t;
+  `AXI_TYPEDEF_AW_CHAN_T(aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(w_chan_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(b_chan_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(ar_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(r_chan_t, data_t, id_t, user_t)
+  `AXI_TYPEDEF_REQ_T(axi_req_t, aw_chan_t, w_chan_t, ar_chan_t)
+  `AXI_TYPEDEF_RESP_T(axi_resp_t, b_chan_t, r_chan_t)
+
+  axi_req_t  mem_axi_req;
+  axi_resp_t mem_axi_resp;
+
+  `AXI_ASSIGN_TO_REQ(mem_axi_req, slv)
+  `AXI_ASSIGN_FROM_RESP(slv, mem_axi_resp)
+
+  axi_to_mem_banked #(
+    .AxiIdWidth    ( AXI_ID_WIDTH               ),
+    .AxiAddrWidth  ( AXI_ADDR_WIDTH             ),
+    .AxiDataWidth  ( AXI_DATA_WIDTH             ),
+    .axi_aw_chan_t ( aw_chan_t                  ),
+    .axi_w_chan_t  (  w_chan_t                  ),
+    .axi_b_chan_t  (  b_chan_t                  ),
+    .axi_ar_chan_t ( ar_chan_t                  ),
+    .axi_r_chan_t  (  r_chan_t                  ),
+    .axi_req_t     ( axi_req_t                  ),
+    .axi_resp_t    ( axi_resp_t                 ),
+    .MemNumBanks   ( MEM_NUM_BANKS              ),
+    .MemAddrWidth  ( MEM_ADDR_WIDTH             ),
+    .MemDataWidth  ( MEM_DATA_WIDTH             ),
+    .MemLatency    ( MEM_LATENCY                ),
+    .HideStrb      ( HIDE_STRB                  )
+  ) i_axi_to_mem_banked (
+    .clk_i,
+    .rst_ni,
+    .test_i,
+    .axi_to_mem_busy_o,
+    .axi_req_i      ( mem_axi_req  ),
+    .axi_resp_o     ( mem_axi_resp ),
+    .mem_req_o,
+    .mem_gnt_i,
+    .mem_add_o,
+    .mem_wdata_o,
+    .mem_be_o,
+    .mem_atop_o,
+    .mem_we_o,
+    .mem_rdata_i
+  );
+
+// pragma translate_off
+`ifndef VERILATOR
+  initial begin: p_assertions
+    assert (AXI_ADDR_WIDTH  >= 1) else $fatal(1, "AXI address width must be at least 1!");
+    assert (AXI_DATA_WIDTH  >= 1) else $fatal(1, "AXI data width must be at least 1!");
+    assert (AXI_ID_WIDTH    >= 1) else $fatal(1, "AXI ID   width must be at least 1!");
+    assert (AXI_USER_WIDTH  >= 1) else $fatal(1, "AXI user width must be at least 1!");
+  end
+`endif
+// pragma translate_on
+endmodule
+

--- a/src_files.yml
+++ b/src_files.yml
@@ -46,6 +46,7 @@ axi:
     - src/axi_id_serialize.sv
     - src/axi_multicut.sv
     - src/axi_to_axi_lite.sv
+    - src/axi_to_mem_banked.sv
     # Level 4
     - src/axi_iw_converter.sv
     - src/axi_lite_xbar.sv

--- a/test/axi_synth_bench.sv
+++ b/test/axi_synth_bench.sv
@@ -174,6 +174,25 @@ module axi_synth_bench (
     end
   end
 
+  // AXI4+ATOP on chip memory slave banked
+  for (genvar i = 0; i < 5; i++) begin : gen_axi_to_mem_banked_data
+    for (genvar j = 0; j < 4; j++) begin : gen_axi_to_mem_banked_bank_num
+      for (genvar k = 0; k < 2; k++) begin : gen_axi_to_mem_banked_bank_addr
+        localparam int unsigned DATA_WIDTH_AXI[5]   = {32'd32, 32'd64, 32'd128, 32'd256, 32'd512};
+        localparam int unsigned NUM_BANKS[4]        = {32'd2,  32'd4,  32'd6,   32'd8};
+        localparam int unsigned ADDR_WIDTH_BANKS[2] = {32'd5,  32'd11};
+
+        synth_axi_to_mem_banked #(
+          .AxiDataWidth  ( DATA_WIDTH_AXI[i]   ),
+          .BankNum       ( NUM_BANKS[j]        ),
+          .BankAddrWidth ( ADDR_WIDTH_BANKS[k] )
+        ) i_axi_to_mem_banked (.*);
+      end
+    end
+  end
+
+
+
 endmodule
 
 
@@ -658,4 +677,72 @@ module synth_axi_iw_converter # (
     .slv     ( upstream   ),
     .mst     ( downstream )
   );
+endmodule
+
+module synth_axi_to_mem_banked #(
+  parameter int unsigned AxiDataWidth  = 32'd0,
+  parameter int unsigned BankNum       = 32'd0,
+  parameter int unsigned BankAddrWidth = 32'd0
+) (
+  input logic clk_i,
+  input logic rst_ni
+);
+  localparam int unsigned AxiIdWidth    = 32'd10;
+  localparam int unsigned AxiAddrWidth  = 32'd64;
+  localparam int unsigned AxiStrbWidth  = AxiDataWidth / 32'd8;
+  localparam int unsigned AxiUserWidth  = 32'd8;
+  localparam int unsigned BankDataWidth = 32'd2 * AxiDataWidth / BankNum;
+  localparam int unsigned BankStrbWidth = BankDataWidth / 32'd8;
+  localparam int unsigned BankLatency   = 32'd1;
+
+  typedef logic [BankAddrWidth-1:0] mem_addr_t;
+  typedef logic [BankDataWidth-1:0] mem_data_t;
+  typedef logic [BankStrbWidth-1:0] mem_strb_t;
+
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH ( AxiIdWidth   ),
+    .AXI_DATA_WIDTH ( AxiAddrWidth ),
+    .AXI_ID_WIDTH   ( AxiDataWidth ),
+    .AXI_USER_WIDTH ( AxiUserWidth )
+  ) axi ();
+
+  // Misc signals
+  logic                             test;
+  logic           [1:0]             axi_to_mem_busy;
+  // Signals for mem macros
+  logic           [BankNum-1:0] mem_req;
+  logic           [BankNum-1:0] mem_gnt;
+  mem_addr_t      [BankNum-1:0] mem_addr;
+  logic           [BankNum-1:0] mem_we;
+  mem_data_t      [BankNum-1:0] mem_wdata;
+  mem_strb_t      [BankNum-1:0] mem_be;
+  axi_pkg::atop_t [BankNum-1:0] mem_atop;
+  mem_data_t      [BankNum-1:0] mem_rdata;
+
+
+  axi_to_mem_banked_intf #(
+    .AXI_ID_WIDTH    ( AxiIdWidth    ),
+    .AXI_ADDR_WIDTH  ( AxiAddrWidth  ),
+    .AXI_DATA_WIDTH  ( AxiDataWidth  ),
+    .AXI_USER_WIDTH  ( AxiUserWidth  ),
+    .MEM_NUM_BANKS   ( BankNum       ),
+    .MEM_ADDR_WIDTH  ( BankAddrWidth ),
+    .MEM_DATA_WIDTH  ( BankDataWidth ),
+    .MEM_LATENCY     ( BankLatency   )
+  ) i_axi_to_mem_banked_intf (
+    .clk_i,
+    .rst_ni,
+    .test_i            ( test            ),
+    .slv               ( axi             ),
+    .mem_req_o         ( mem_req         ),
+    .mem_gnt_i         ( mem_gnt         ),
+    .mem_add_o         ( mem_addr        ),
+    .mem_we_o          ( mem_we          ),
+    .mem_wdata_o       ( mem_wdata       ),
+    .mem_be_o          ( mem_be          ),
+    .mem_atop_o        ( mem_atop        ),
+    .mem_rdata_i       ( mem_rdata       ),
+    .axi_to_mem_busy_o ( axi_to_mem_busy )
+  );
+
 endmodule

--- a/test/tb_axi_to_mem_banked.sv
+++ b/test/tb_axi_to_mem_banked.sv
@@ -1,0 +1,417 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Authors:
+// - Wolfgang Roenninger <wroennin@iis.ee.ethz.ch>
+
+`include "axi/typedef.svh"
+`include "axi/assign.svh"
+`include "common_cells/registers.svh"
+
+/// Testbench for axi_to_mem_banked. Monitors the performance for random accesses.
+module tb_axi_to_mem_banked #(
+  /// Data Width of the AXI4+ATOP channels.
+  parameter int unsigned TbAxiDataWidth = 32'd256,
+  /// Number of words of an individual memory bank.
+  /// Determines the address width of the request output.
+  parameter int unsigned TbNumWords     = 32'd8192,
+  /// Number of connected memory banks.
+  parameter int unsigned TbNumBanks     = 32'd8,
+  /// Data width of an individual memory bank.
+  parameter int unsigned TbMemDataWidth = 32'd64,
+  /// Latancy in cycles of a memory bank.
+  parameter int unsigned TbMemLatency   = 32'd2,
+  /// Number of writes performed by the testbench.
+  parameter int unsigned TbNumWrites    = 32'd10000,
+  /// Number of writes performed by the testbench.
+  parameter int unsigned TbNumReads     = 32'd10000
+);
+  // test bench params
+  localparam time CyclTime = 10ns;
+  localparam time ApplTime = 2ns;
+  localparam time TestTime = 8ns;
+
+  // localparam and typedefs for AXI4+ATOP
+  localparam int unsigned AxiIdWidth   = 32'd6;
+  localparam int unsigned AxiAddrWidth = 32'd64;
+  localparam int unsigned AxiStrbWidth = TbAxiDataWidth / 8;
+  localparam int unsigned AxiUserWidth = 32'd4;
+
+  typedef logic [AxiAddrWidth-1:0] axi_addr_t;
+
+  // AXI test defines
+  typedef axi_test::axi_rand_master #(
+    // AXI interface parameters
+    .AW ( AxiAddrWidth ),
+    .DW ( TbAxiDataWidth ),
+    .IW ( AxiIdWidth   ),
+    .UW ( AxiUserWidth ),
+    // Stimuli application and test time
+    .TA ( ApplTime     ),
+    .TT ( TestTime     ),
+    // Maximum number of read and write transactions in flight
+    .MAX_READ_TXNS        (   20 ),
+    .MAX_WRITE_TXNS       (   20 ),
+    // Upper and lower bounds on wait cycles on Ax, W, and resp (R and B) channels
+    .AX_MIN_WAIT_CYCLES   (    0 ),
+    .AX_MAX_WAIT_CYCLES   (    0 ),
+    .W_MIN_WAIT_CYCLES    (    0 ),
+    .W_MAX_WAIT_CYCLES    (    0 ),
+    .RESP_MIN_WAIT_CYCLES (    0 ),
+    .RESP_MAX_WAIT_CYCLES (    0 ),
+    // AXI feature usage
+    .AXI_MAX_BURST_LEN    (    0 ), // maximum number of beats in burst; 0 = AXI max (256)
+    .TRAFFIC_SHAPING      (    0 ),
+    .AXI_EXCLS            ( 1'b0 ),
+    .AXI_ATOPS            ( 1'b0 ),
+    .AXI_BURST_FIXED      ( 1'b0 ),
+    .AXI_BURST_INCR       ( 1'b1 ),
+    .AXI_BURST_WRAP       ( 1'b0 )
+  ) axi_rand_master_t;
+
+  // memory defines
+  localparam int unsigned MemAddrWidth = $clog2(TbNumWords);
+
+  localparam int unsigned MemBufDepth  = 1;
+  // addresses
+  localparam axi_addr_t StartAddr = axi_addr_t'(64'h0);
+  localparam axi_addr_t EndAddr   = axi_addr_t'(StartAddr + 32'd2 * TbNumWords * TbAxiDataWidth/32'd8);
+
+  typedef logic [MemAddrWidth-1:0]     mem_addr_t;
+  typedef logic [5:0]                  mem_atop_t;
+  typedef logic [TbMemDataWidth-1:0]   mem_data_t;
+  typedef logic [TbMemDataWidth/8-1:0] mem_strb_t;
+
+  // sim signals
+  logic end_of_sim;
+
+  // dut signals
+  logic clk, rst_n, one_dut_active;
+
+  logic      [1:0]            dut_busy;
+  logic      [TbNumBanks-1:0] mem_req;
+  logic      [TbNumBanks-1:0] mem_gnt;
+  mem_addr_t [TbNumBanks-1:0] mem_addr;
+  mem_data_t [TbNumBanks-1:0] mem_wdata;
+  mem_strb_t [TbNumBanks-1:0] mem_strb;
+  logic      [TbNumBanks-1:0] mem_we;
+  mem_atop_t [TbNumBanks-1:0] mem_atop;
+  logic      [TbNumBanks-1:0] mem_rvalid;
+  mem_data_t [TbNumBanks-1:0] mem_rdata;
+
+  assign one_dut_active = |dut_busy;
+
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth   ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth ),
+    .AXI_ID_WIDTH   ( AxiIdWidth     ),
+    .AXI_USER_WIDTH ( AxiUserWidth   )
+  ) mem_axi_dv (clk);
+
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth   ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth ),
+    .AXI_ID_WIDTH   ( AxiIdWidth     ),
+    .AXI_USER_WIDTH ( AxiUserWidth   )
+  ) mem_axi ();
+  `AXI_ASSIGN(mem_axi, mem_axi_dv)
+
+  // stimuli generation
+  initial begin : proc_axi_master
+    static axi_rand_master_t axi_rand_master = new ( mem_axi_dv );
+    end_of_sim <= 1'b0;
+    axi_rand_master.add_memory_region(StartAddr, EndAddr, axi_pkg::DEVICE_NONBUFFERABLE);
+    axi_rand_master.reset();
+    @(posedge rst_n);
+    @(posedge clk);
+    @(posedge clk);
+
+    axi_rand_master.run(TbNumReads, TbNumWrites);
+    end_of_sim <= 1'b1;
+  end
+
+  // memory banks
+  for (genvar i = 0; i < TbNumBanks; i++) begin : gen_tc_sram
+    tc_sram #(
+      .NumWords    ( TbNumWords   ),
+      .DataWidth   ( TbMemDataWidth ),
+      .ByteWidth   ( 32'd8        ),
+      .NumPorts    ( 32'd1        ),
+      .Latency     ( TbMemLatency   ),
+      .SimInit     ( "none"       ),
+      .PrintSimCfg ( 1'b1         )
+    ) i_tc_sram_bank (
+      .clk_i   ( clk          ),
+      .rst_ni  ( rst_n        ),
+      .req_i   ( mem_req[i]   ),
+      .we_i    ( mem_we[i]    ),
+      .addr_i  ( mem_addr[i]  ),
+      .wdata_i ( mem_wdata[i] ),
+      .be_i    ( mem_strb[i]  ),
+      .rdata_o ( mem_rdata[i] )
+    );
+    // always be ready
+    assign mem_gnt[i] = 1'b1;
+    // generate mem_rvalid signal
+    if (TbMemLatency == 0) begin : gen_no_mem__lat
+      assign mem_rvalid[i] = mem_req[i];
+    end else begin : gen_mem_lat
+      logic [TbMemLatency-1:0] mem_lat_q, mem_lat_d;
+      `FFARN(mem_lat_q, mem_lat_d, '0, clk, rst_n)
+      assign mem_lat_d[TbMemLatency-1] = mem_req[i];
+      if (TbMemLatency > 1) begin
+        for (genvar lat_i = 0; lat_i < TbMemLatency - 1; lat_i++) begin
+          assign mem_lat_d[lat_i] = mem_lat_q[lat_i+1];
+        end
+      end
+      assign mem_rvalid[i] = mem_lat_q[0];
+    end
+  end
+
+  // Clock generator
+  clk_rst_gen #(
+    .ClkPeriod    ( CyclTime ),
+    .RstClkCycles ( 5        )
+  ) i_clk_rst_gen (
+    .clk_o  ( clk   ),
+    .rst_no ( rst_n )
+  );
+
+  // Design under test
+  axi_to_mem_banked_intf #(
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth ),
+    .AXI_USER_WIDTH ( AxiUserWidth ),
+    .MEM_NUM_BANKS  ( TbNumBanks     ),
+    .MEM_ADDR_WIDTH ( MemAddrWidth ),
+    .MEM_DATA_WIDTH ( TbMemDataWidth ),
+    .MEM_LATENCY    ( TbMemLatency   )
+  ) i_axi_to_mem_banked_dut (
+    .clk_i             ( clk       ),
+    .rst_ni            ( rst_n     ),
+    .test_i            ( 1'b0      ),
+    .axi_to_mem_busy_o ( dut_busy  ),
+    .slv               ( mem_axi   ),
+    .mem_req_o         ( mem_req   ),
+    .mem_gnt_i         ( mem_gnt   ),
+    .mem_add_o         ( mem_addr  ), // byte address
+    .mem_wdata_o       ( mem_wdata ), // write data
+    .mem_be_o          ( mem_strb  ), // byte-wise strobe
+    .mem_atop_o        ( mem_atop  ), // atomic operation
+    .mem_we_o          ( mem_we    ), // write enable
+    .mem_rdata_i       ( mem_rdata )  // read data
+  );
+
+  // monitoring
+  logic aw_beat, aw_stall, w_beat, b_beat, ar_beat, ar_stall, r_beat;
+  assign aw_beat  = mem_axi.aw_valid & mem_axi.aw_ready;
+  assign aw_stall = mem_axi.aw_valid & !mem_axi.aw_ready;
+  assign  w_beat  = mem_axi.w_valid  & mem_axi.w_ready;
+  assign  b_beat  = mem_axi.b_valid  & mem_axi.b_ready;
+  assign ar_beat  = mem_axi.ar_valid & mem_axi.ar_ready;
+  assign ar_stall = mem_axi.ar_valid & !mem_axi.ar_ready;
+  assign  r_beat  = mem_axi.r_valid  & mem_axi.r_ready;
+
+  int unsigned aw_open;
+  int unsigned ar_open;
+
+  initial begin : proc_monitor
+    automatic bit aw_new = 1;
+    automatic bit w_new  = 1;
+    automatic bit b_new  = 1;
+    automatic bit ar_new = 1;
+    automatic bit r_new  = 1;
+
+
+    automatic longint      wc_cnt     = 0;
+    automatic longint      rc_cnt     = 0;
+    automatic longint      w_cnt      = 0;
+    automatic longint      r_cnt      = 0;
+
+    automatic longint      busy_cnt;
+    automatic longint      dut_busy_cnt [TbNumBanks];
+    automatic real         bank_busy_percent;
+    automatic real         axi_busy_percent;
+    automatic real         tmp;
+
+    aw_open           = 0;
+    ar_open           = 0;
+    bank_busy_percent = 0;
+    axi_busy_percent  = 0;
+    for (int i = 0; i < TbNumBanks; i++) begin
+      dut_busy_cnt[i] = 0;
+    end
+    $display("###############################################################################");
+    $display("Sim Parameter:");
+    $display("###############################################################################");
+    $display("TbAxiDataWidth: %0d", TbAxiDataWidth);
+    $display("TbMemDataWidth: %0d", TbMemDataWidth);
+    $display("TbNumBanks:     %0d", TbNumBanks);
+    $display("TbMemLatency:   %0d", TbMemLatency);
+    $display("###############################################################################");
+
+    @(posedge rst_n);
+    forever begin
+      @(posedge clk);
+
+      #TestTime;
+      // determine the first valid of an AW transaction
+      if (mem_axi.aw_valid) begin
+        if (aw_new) begin
+          aw_open++;
+          if (!mem_axi.aw_ready) begin
+            aw_new = 0;
+          end
+        end else begin
+          if (mem_axi.aw_ready) begin
+            aw_new = 1;
+          end
+        end
+      end
+
+      // determine the first valid of an AR transaction
+      if (mem_axi.ar_valid) begin
+        if (ar_new) begin
+          ar_open++;
+          if (!mem_axi.ar_ready) begin
+            ar_new = 0;
+          end
+        end else begin
+          if (mem_axi.ar_ready) begin
+            ar_new = 1;
+          end
+        end
+      end
+
+      if (b_beat) begin
+        aw_open--;
+      end
+      if (r_beat && mem_axi.r_last) begin
+        ar_open--;
+      end
+
+      if (aw_open > 0) begin
+        wc_cnt++;
+      end
+      if (ar_open > 0) begin
+        rc_cnt++;
+      end
+
+      if (w_beat) begin
+        w_cnt++;
+      end
+      if (r_beat) begin
+        r_cnt++;
+      end
+
+      if ((aw_open > 0) || (ar_open > 0)) begin
+        busy_cnt++;
+      end
+
+      for (int unsigned i = 0; i < TbNumBanks; i++) begin
+        if (mem_req[i]) begin
+          dut_busy_cnt[i]++;
+        end
+      end
+
+
+      if (end_of_sim) begin
+        @(posedge clk);
+        $display("###############################################################################");
+        $display("Statistics:");
+        $display("###############################################################################");
+        $display("Writes:");
+        $display("Cycles Open write tnx: %0d", wc_cnt);
+        $display("Write beat count:      %0d", w_cnt);
+        $display("Write utilization:     %0f", real'(w_cnt) / real'(wc_cnt) * 100);
+        axi_busy_percent += real'(w_cnt) / real'(wc_cnt) * 100;
+                $display("###############################################################################");
+        $display("Reads:");
+        $display("Cycles Open read tnx:  %0d", rc_cnt);
+        $display("Read beat count:       %0d", r_cnt);
+        $display("Read utilization:      %0f", real'(r_cnt) / real'(rc_cnt) * 100);
+        axi_busy_percent += real'(r_cnt) / real'(rc_cnt) * 100;
+        $display("###############################################################################");
+        for (int unsigned i = 0; i < TbNumBanks; i++) begin
+          bank_busy_percent += real'(dut_busy_cnt[i]) / real'(busy_cnt) * 100;
+          $display("Bank %0d utilization: %0f", i, real'(dut_busy_cnt[i]) / real'(busy_cnt) * 100);
+          tmp = dut_busy_cnt[i];
+          $display("Bank %0d requests: %0f", i, tmp);
+          tmp = busy_cnt;
+          $display("Bank %0d busy cycles: %0f", i, tmp);
+        end
+        $display("Sum bank utilization:      %0f", bank_busy_percent);
+        $display("Sum axi utilization:       %0f", axi_busy_percent);
+        $display("###############################################################################");
+        $stop();
+      end
+    end
+  end
+
+  initial begin : proc_sim_progress
+    longint unsigned       ActAwTnx;
+    longint unsigned       ActArTnx;
+    automatic int unsigned PrintInterv = 100;
+
+    ActAwTnx = 0;
+    ActArTnx = 0;
+    $display("Start Addr: %0h", StartAddr);
+    $display("End   addr: %0h", EndAddr);
+
+    @(posedge rst_n);
+    forever begin
+      @(posedge clk);
+      #TestTime;
+
+      if (aw_beat) begin
+        if (ActAwTnx % PrintInterv == 0) begin
+          $display("%t > AW Transaction %d of %d ", $time(), ActAwTnx, TbNumWrites);
+        end
+        ActAwTnx++;
+      end
+      if (ar_beat) begin
+        if (ActArTnx % PrintInterv == 0) begin
+          $display("%t > AR Transaction %d of %d ", $time(), ActArTnx, TbNumReads);
+        end
+        ActArTnx++;
+      end
+
+      if (end_of_sim) begin
+        break;
+      end
+    end
+  end
+
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidth ),
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_USER_WIDTH ( AxiUserWidth )
+  ) monitor_dv (clk);
+
+  `AXI_ASSIGN_MONITOR(monitor_dv, mem_axi)
+
+  typedef axi_test::axi_scoreboard #(
+    .IW ( AxiIdWidth   ),
+    .AW ( AxiAddrWidth ),
+    .DW ( TbAxiDataWidth ),
+    .UW ( AxiUserWidth ),
+    .TT ( TestTime     )
+  ) axi_scoreboard_t;
+  axi_scoreboard_t axi_scoreboard = new(monitor_dv);
+  initial begin : proc_scoreboard
+    axi_scoreboard.enable_all_checks();
+    @(posedge rst_n);
+    axi_scoreboard.monitor();
+    wait (end_of_sim);
+  end
+
+endmodule


### PR DESCRIPTION
This PR adds a banked variant of `axi_to_mem` for higher throughput. This PR also adds a test for `axi_to_mem_banked`, which also tests `axi_to_mem` as it is called within the new module. This PR partially replaces #115 and #213 and depends on #244.