### PR TITLE
First batch of fixes and improvements originating from the `axi_llc` branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `axi_to_mem`: AXI4+ATOP slave to control on chip memory.
+- `axi_test`: Add `mapped` mode to the random classes as well as additional functionality to the
+  scoreboard class.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - `axi_lite_mux`: Reduce complexity of W channel at master port by removing an unnecessary
   multiplexer.
+- `axi_lite_demux`: Improve compatibility with vsim version 10.7b.
 
 
 ## 0.36.0 - 2022-07-07

--- a/src/axi_lite_demux.sv
+++ b/src/axi_lite_demux.sv
@@ -426,8 +426,15 @@ module axi_lite_demux #(
     );
 
     // connect the response if the FIFO has valid data in it
-    assign slv_r_chan      = (!r_fifo_empty) ? mst_resps_i[r_select].r : '0;
-    assign slv_r_valid     =  ~r_fifo_empty  & mst_resps_i[r_select].r_valid;
+    always_comb begin
+       slv_r_chan  = '0;
+       slv_r_valid = '0;
+       if (!r_fifo_empty) begin
+          slv_r_chan  = mst_resps_i[r_select].r;
+          slv_r_valid = mst_resps_i[r_select].r_valid;
+       end
+    end
+
     for (genvar i = 0; i < NoMstPorts; i++) begin : gen_mst_r
       assign mst_reqs_o[i].r_ready = ~r_fifo_empty & slv_r_ready & (r_select == select_t'(i));
     end

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -1190,11 +1190,12 @@ package axi_test;
         static logic rand_success;
         wait (w_queue.size() > 0 || (aw_done && w_queue.size() == 0));
         aw_beat = w_queue.pop_front();
-        addr = aw_beat.ax_addr;
         for (int unsigned i = 0; i < aw_beat.ax_len + 1; i++) begin
           automatic w_beat_t w_beat = new;
           automatic int unsigned begin_byte, end_byte, n_bytes;
           automatic logic [AXI_STRB_WIDTH-1:0] rand_strb, strb_mask;
+          addr = axi_pkg::beat_addr(aw_beat.ax_addr, aw_beat.ax_size, aw_beat.ax_len,
+                                    aw_beat.ax_burst, i);
           rand_success = w_beat.randomize(); assert (rand_success);
           // Determine strobe.
           w_beat.w_strb = '0;
@@ -1210,8 +1211,6 @@ package axi_test;
           w_beat.w_last = (i == aw_beat.ax_len);
           rand_wait(W_MIN_WAIT_CYCLES, W_MAX_WAIT_CYCLES);
           drv.send_w(w_beat);
-          if (aw_beat.ax_burst == axi_pkg::BURST_INCR)
-            addr += n_bytes;
         end
       end
     endtask
@@ -1269,7 +1268,11 @@ package axi_test;
     parameter int   R_MIN_WAIT_CYCLES = 0,
     parameter int   R_MAX_WAIT_CYCLES = 5,
     parameter int   RESP_MIN_WAIT_CYCLES = 0,
-    parameter int   RESP_MAX_WAIT_CYCLES = 20
+    parameter int   RESP_MAX_WAIT_CYCLES = 20,
+    /// This parameter eneables an internal memory, which gets randomly initialized, if it is read
+    /// and retains written data. This mode does currently not support `axi_pkg::BURST_WRAP`!
+    /// All responses are `axi_pkg::RESP_OKAY` when in this mode.
+    parameter bit   MAPPED = 1'b0
   );
     typedef axi_test::axi_driver #(
       .AW(AW), .DW(DW), .IW(IW), .UW(UW), .TA(TA), .TT(TT)
@@ -1283,10 +1286,16 @@ package axi_test;
     typedef axi_driver_t::r_beat_t r_beat_t;
     typedef axi_driver_t::w_beat_t w_beat_t;
 
+    typedef logic [AW-1:0] addr_t;
+    typedef logic [7:0]    byte_t;
+
     axi_driver_t          drv;
     rand_ax_beat_queue_t  ar_queue;
     ax_beat_t             aw_queue[$];
     int unsigned          b_wait_cnt;
+
+    // Memory array for when the `MAPPED` parameter is set.
+    byte_t memory_q[addr_t];
 
     function new(
       virtual AXI_BUS_DV #(
@@ -1303,7 +1312,8 @@ package axi_test;
     endfunction
 
     function void reset();
-      drv.reset_slave();
+      this.drv.reset_slave();
+      this.memory_q.delete();
     endfunction
 
     // TODO: The `rand_wait` task exists in `rand_verif_pkg`, but that task cannot be called with
@@ -1323,6 +1333,10 @@ package axi_test;
         automatic ax_beat_t ar_beat;
         rand_wait(AX_MIN_WAIT_CYCLES, AX_MAX_WAIT_CYCLES);
         drv.recv_ar(ar_beat);
+        if (MAPPED) begin
+          assert (ar_beat.ax_burst != axi_pkg::BURST_WRAP) else
+            $error("axi_pkg::BURST_WRAP not supported in MAPPED mode.");
+        end
         ar_queue.push(ar_beat.ax_id, ar_beat);
       end
     endtask
@@ -1331,10 +1345,25 @@ package axi_test;
       forever begin
         automatic logic rand_success;
         automatic ax_beat_t ar_beat;
-        automatic r_beat_t r_beat = new;
+        automatic r_beat_t  r_beat = new;
+        automatic addr_t    byte_addr;
         wait (ar_queue.size > 0);
-        ar_beat = ar_queue.peek();
+        ar_beat      = ar_queue.peek();
+        byte_addr    = axi_pkg::aligned_addr(ar_beat.ax_addr, axi_pkg::size_t'($clog2(DW/8)));
+        rand_success = std::randomize(r_beat); assert(rand_success);
         rand_success = r_beat.randomize(); assert(rand_success);
+        if (MAPPED) begin
+          // Either use the actual data, or save the random generated.
+          for (int unsigned i = 0; i < (DW/8); i++) begin
+            if (this.memory_q.exists(byte_addr)) begin
+              r_beat.r_data[i*8+:8] = this.memory_q[byte_addr];
+            end else begin
+              this.memory_q[byte_addr] = r_beat.r_data[i*8+:8];
+            end
+            byte_addr++;
+          end
+          r_beat.r_resp = axi_pkg::RESP_OKAY;
+        end
         r_beat.r_id = ar_beat.ax_id;
         if (RAND_RESP && !ar_beat.ax_atop[axi_pkg::ATOP_R_RESP])
           r_beat.r_resp[1] = $random();
@@ -1345,6 +1374,10 @@ package axi_test;
           r_beat.r_last = 1'b1;
           void'(ar_queue.pop_id(ar_beat.ax_id));
         end else begin
+          if ((ar_beat.ax_burst == axi_pkg::BURST_INCR) && MAPPED) begin
+            ar_beat.ax_addr = axi_pkg::aligned_addr(ar_beat.ax_addr, ar_beat.ax_size) +
+                                  2**ar_beat.ax_size;
+          end
           ar_beat.ax_len--;
           ar_queue.set(ar_beat.ax_id, ar_beat);
         end
@@ -1357,6 +1390,12 @@ package axi_test;
         automatic ax_beat_t aw_beat;
         rand_wait(AX_MIN_WAIT_CYCLES, AX_MAX_WAIT_CYCLES);
         drv.recv_aw(aw_beat);
+        if (MAPPED) begin
+          assert (aw_beat.ax_atop == '0) else
+            $error("ATOP not supported in MAPPED mode.");
+          assert (aw_beat.ax_burst != axi_pkg::BURST_WRAP) else
+            $error("axi_pkg::BURST_WRAP not supported in MAPPED mode.");
+        end
         aw_queue.push_back(aw_beat);
         // Atomic{Load,Swap,Compare}s require an R response.
         if (aw_beat.ax_atop[axi_pkg::ATOP_R_RESP]) begin
@@ -1368,10 +1407,30 @@ package axi_test;
     task recv_ws();
       forever begin
         automatic ax_beat_t aw_beat;
+        automatic addr_t    byte_addr;
         forever begin
           automatic w_beat_t w_beat;
           rand_wait(RESP_MIN_WAIT_CYCLES, RESP_MAX_WAIT_CYCLES);
           drv.recv_w(w_beat);
+          if (MAPPED) begin
+            wait (aw_queue.size() > 0);
+            aw_beat = aw_queue[0];
+            byte_addr    = axi_pkg::aligned_addr(aw_beat.ax_addr, $clog2(DW/8));
+
+            // Write Data if the strobe is defined
+            for (int unsigned i = 0; i < (DW/8); i++) begin
+              if (w_beat.w_strb[i]) begin
+                this.memory_q[byte_addr] = w_beat.w_data[i*8+:8];
+              end
+              byte_addr++;
+            end
+            // Update address in beat
+            if (aw_beat.ax_burst == axi_pkg::BURST_INCR) begin
+              aw_beat.ax_addr = axi_pkg::aligned_addr(aw_beat.ax_addr, aw_beat.ax_size) +
+                                    2**aw_beat.ax_size;
+            end
+            aw_queue[0] = aw_beat;
+          end
           if (w_beat.w_last)
             break;
         end
@@ -1394,6 +1453,9 @@ package axi_test;
           b_beat.b_resp[0]= $random();
         end
         rand_wait(RESP_MIN_WAIT_CYCLES, RESP_MAX_WAIT_CYCLES);
+        if (MAPPED) begin
+          b_beat.b_resp = axi_pkg::RESP_OKAY;
+        end
         drv.send_b(b_beat);
         b_wait_cnt--;
       end
@@ -1939,8 +2001,6 @@ package axi_test;
         b_beat  = b_sample[id].pop_front();
         if (check_en[BRespCheck]) begin
           assert (b_beat.b_id   == id);
-          assert (b_beat.b_resp == axi_pkg::RESP_OKAY) else
-              $warning("Behavior for b_resp != axi_pkg::RESP_OKAY not modeled.");
         end
         // pop all accessed memory locations by this beat
         for (int unsigned i = 0; i <= aw_beat.ax_len; i++) begin
@@ -1948,7 +2008,11 @@ package axi_test;
               axi_pkg::beat_addr(aw_beat.ax_addr, aw_beat.ax_size, aw_beat.ax_len, aw_beat.ax_burst,
                   i), BUS_SIZE);
           for (int j = 0; j < axi_pkg::num_bytes(BUS_SIZE); j++) begin
-            memory_q[bus_address+j].delete(0);
+            if (b_beat.b_resp inside {axi_pkg::RESP_OKAY, axi_pkg::RESP_EXOKAY}) begin
+              memory_q[bus_address+j].delete(0);
+            end else begin
+              memory_q[bus_address+j].delete(memory_q[bus_address+j].size() - 1);
+            end
           end
         end
       end
@@ -1982,22 +2046,29 @@ package axi_test;
             end
           end
           // Assert that the correct data is read.
-          if (this.check_en[ReadCheck]) begin
+          if (this.check_en[ReadCheck] &&
+              (r_beat.r_resp inside {axi_pkg::RESP_OKAY, axi_pkg::RESP_EXOKAY})) begin
             for (int unsigned j = 0; j < axi_pkg::num_bytes(ar_beat.ax_size); j++) begin
               idx_data  = 8*BUS_SIZE'(beat_address+j);
               act_data  = r_beat.r_data[idx_data+:8];
               exp_data  = this.memory_q[beat_address+j];
-              tst_data  = exp_data.find with (item === 8'hxx || item === act_data);
-              assert (tst_data.size() > 0) else begin
-                $warning("Unexpected RData ID: %0h Addr: %0h Byte Idx: %0h Exp Data : %0h Data: %h",
-                r_beat.r_id, beat_address+j, idx_data, exp_data, act_data);
+              if (exp_data.size() > 0) begin
+                tst_data  = exp_data.find with (item === 8'hxx || item === act_data);
+                assert (tst_data.size() > 0) else begin
+                  $warning("Unexpected RData ID: %0h \n \
+                            Addr:     %h \n \
+                            Byte Idx: %h \n \
+                            Exp Data: %h \n \
+                            Act Data: %h \n \
+                            BeatData: %h",
+                  r_beat.r_id, beat_address+j, idx_data, exp_data, act_data, r_beat.r_data);
+                end
               end
             end
           end
         end
         if (this.check_en[RRespCheck]) begin
           assert (r_beat.r_id   == id);
-          assert (r_beat.r_resp == axi_pkg::RESP_OKAY);
           assert (r_beat.r_last);
         end
       end
@@ -2182,6 +2253,40 @@ package axi_test;
         assert(this.b_queue[i].size()   == 0);
       end
     endtask : reset
+
+    /// Check that the byte in memory_q is the same as check_data.
+    task automatic check_byte(axi_addr_t check_addr, byte_t check_data);
+      assert(this.memory_q[check_addr][0] === check_data) else
+        $warning("Byte at ADDR: %h does not match: memory_q: %h check_data: %h",
+            check_addr, this.memory_q[check_addr][0], check_data);
+    endtask : check_byte
+
+    /// Clear a byte from memoy. Can be used to partially delete mem space.
+    task clear_byte(axi_addr_t clear_addr);
+      if (this.memory_q.exists(clear_addr)) begin
+        this.memory_q.delete(clear_addr);
+      end
+    endtask : clear_byte
+
+    /// Clear a memory range.
+    /// The end address alo gets cleared.
+    task automatic clear_range(axi_addr_t clear_start_addr, clear_end_addr);
+      axi_addr_t curr_addr = clear_start_addr;
+      while (curr_addr <= clear_end_addr) begin
+        this.clear_byte(curr_addr);
+        curr_addr++;
+      end
+    endtask : clear_range
+
+    /// Get a byte from the modeled memory.
+    task automatic get_byte(input axi_addr_t byte_addr, output byte_t byte_data);
+      if (this.memory_q.exists(byte_addr)) begin
+        byte_data = this.memory_q[byte_addr][0];
+      end else begin
+        byte_data = 8'hxx;
+      end
+    endtask : get_byte
+
   endclass : axi_scoreboard
 
 endpackage


### PR DESCRIPTION
Included are the following changes:
- axi_test:
  - axi_test: Use `beat_addr` function
  - axi_test: Add mapped mode to random classes
  - axi_test: Additions to scoreboard class
- axi_lite_demux: 
  - axi_lite_demux: Increase VSIM compatibility
- axi_demux (***amended***): 
  - axi_demux: Replace w_fifo with a write counter