### PR TITLE
vivado xsim : add XILINX_SIMULATOR ifdefs replace XSIM ifdef

### DIFF
--- a/src/axi_demux.sv
+++ b/src/axi_demux.sv
@@ -625,7 +625,7 @@ module axi_demux #(
 // Validate parameters.
 // pragma translate_off
 `ifndef VERILATOR
-`ifndef XSIM
+`ifndef XILINX_SIMULATOR
     initial begin: validate_params
       no_mst_ports: assume (NoMstPorts > 0) else
         $fatal(1, "The Number of slaves (NoMstPorts) has to be at least 1");
@@ -774,7 +774,7 @@ module axi_demux_id_counters #(
 
 // pragma translate_off
 `ifndef VERILATOR
-`ifndef XSIM
+`ifndef XILINX_SIMULATOR
     // Validate parameters.
     cnt_underflow: assert property(
       @(posedge clk_i) disable iff (~rst_ni) (pop_en[i] |=> !overflow)) else

--- a/src/axi_err_slv.sv
+++ b/src/axi_err_slv.sv
@@ -244,7 +244,7 @@ module axi_err_slv #(
 
   // pragma translate_off
   `ifndef VERILATOR
-  `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   initial begin
     assert (Resp == axi_pkg::RESP_DECERR || Resp == axi_pkg::RESP_SLVERR) else
       $fatal(1, "This module may only generate RESP_DECERR or RESP_SLVERR responses!");

--- a/src/axi_isolate.sv
+++ b/src/axi_isolate.sv
@@ -387,10 +387,12 @@ module axi_isolate_inner #(
 
 // pragma translate_off
 `ifndef VERILATOR
+`ifndef XILINX_SIMULATOR
   initial begin
     assume (NumPending > 0) else $fatal(1, "At least one pending transaction required.");
   end
   default disable iff (!rst_ni);
+`endif
   aw_overflow: assert property (@(posedge clk_i)
       (pending_aw_q == '1) |=> (pending_aw_q != '0)) else
       $fatal(1, "pending_aw_q overflowed");

--- a/src/axi_lite_demux.sv
+++ b/src/axi_lite_demux.sv
@@ -442,7 +442,9 @@ module axi_lite_demux #(
 
     // pragma translate_off
     `ifndef VERILATOR
+    `ifndef XILINX_SIMULATOR
     default disable iff (!rst_ni);
+    `endif
     aw_select: assume property( @(posedge clk_i) (slv_req_i.aw_valid |->
                                                  (slv_aw_select_i < NoMstPorts))) else
       $fatal(1, "slv_aw_select_i is %d: AW has selected a slave that is not defined.\

--- a/src/axi_lite_regs.sv
+++ b/src/axi_lite_regs.sv
@@ -396,7 +396,9 @@ module axi_lite_regs #(
       assert (RegNumBytes == $bits(AxiReadOnly)) else
           $fatal(1, "Each register needs a `ReadOnly` flag!");
     end
+    `ifndef XILINX_SIMULATOR
     default disable iff (~rst_ni);
+    `endif
     for (genvar i = 0; i < RegNumBytes; i++) begin
       assert property (@(posedge clk_i) (!reg_load_i[i] && AxiReadOnly[i] |=> $stable(reg_q_o[i])))
           else $fatal(1, "Read-only register at `byte_index: %0d` was changed by AXI!", i);

--- a/src/axi_lite_xbar.sv
+++ b/src/axi_lite_xbar.sv
@@ -114,7 +114,9 @@ module axi_lite_xbar #(
     // make sure that the default slave does not get changed, if there is an unserved Ax
     // pragma translate_off
     `ifndef VERILATOR
+    `ifndef XILINX_SIMULATOR
     default disable iff (~rst_ni);
+    `endif
     default_aw_mst_port_en: assert property(
       @(posedge clk_i) (slv_ports_req_i[i].aw_valid && !slv_ports_resp_o[i].aw_ready)
           |=> $stable(en_default_mst_port_i[i]))

--- a/src/axi_serializer.sv
+++ b/src/axi_serializer.sv
@@ -197,7 +197,9 @@ module axi_serializer #(
     assert (MaxWriteTxns  >= 1)
       else $fatal(1, "Maximum number of write transactions must be >= 1!");
   end
+  `ifndef XILINX_SIMULATOR
   default disable iff (~rst_ni);
+  `endif
   aw_lost : assert property( @(posedge clk_i)
       (slv_req_i.aw_valid & slv_resp_o.aw_ready |-> mst_req_o.aw_valid & mst_resp_i.aw_ready))
     else $error("AW beat lost.");

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -1196,7 +1196,7 @@ package axi_test;
           automatic logic [AXI_STRB_WIDTH-1:0] rand_strb, strb_mask;
           addr = axi_pkg::beat_addr(aw_beat.ax_addr, aw_beat.ax_size, aw_beat.ax_len,
                                     aw_beat.ax_burst, i);
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
           // std::randomize(w_beat) may behave differently to w_beat.randomize() wrt. limited ranges
           // Keeping alternate implementation for XSIM only
           rand_success = std::randomize(w_beat); assert (rand_success);
@@ -1356,7 +1356,7 @@ package axi_test;
         wait (ar_queue.size > 0);
         ar_beat      = ar_queue.peek();
         byte_addr    = axi_pkg::aligned_addr(ar_beat.ax_addr, axi_pkg::size_t'($clog2(DW/8)));
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
         // std::randomize(r_beat) may behave differently to r_beat.randomize() wrt. limited ranges
         // Keeping alternate implementation for XSIM only
         rand_success = std::randomize(r_beat); assert(rand_success);
@@ -1456,7 +1456,7 @@ package axi_test;
         automatic logic rand_success;
         wait (b_wait_cnt > 0 && (aw_queue.size() != 0));
         aw_beat = aw_queue.pop_front();
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
         // std::randomize(b_beat) may behave differently to b_beat.randomize() wrt. limited ranges
         // Keeping alternate implementation for XSIM only
         rand_success = std::randomize(b_beat); assert (rand_success);

--- a/src/axi_xbar.sv
+++ b/src/axi_xbar.sv
@@ -125,7 +125,7 @@ import cf_math_pkg::idx_width;
     // make sure that the default slave does not get changed, if there is an unserved Ax
     // pragma translate_off
     `ifndef VERILATOR
-    `ifndef XSIM
+    `ifndef XILINX_SIMULATOR
     default disable iff (~rst_ni);
     default_aw_mst_port_en: assert property(
       @(posedge clk_i) (slv_ports_req_i[i].aw_valid && !slv_ports_resp_o[i].aw_ready)
@@ -265,7 +265,7 @@ import cf_math_pkg::idx_width;
 
   // pragma translate_off
   `ifndef VERILATOR
-  `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   initial begin : check_params
     id_slv_req_ports: assert ($bits(slv_ports_req_i[0].aw.id ) == Cfg.AxiIdWidthSlvPorts) else
       $fatal(1, $sformatf("Slv_req and aw_chan id width not equal."));

--- a/test/tb_axi_delayer.sv
+++ b/test/tb_axi_delayer.sv
@@ -83,7 +83,7 @@ module tb_axi_delayer;
     @(posedge clk);
     repeat (200) begin
         @(posedge clk);
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
         // std::randomize(ax_beat) may behave differently to ax_beat.randomize() wrt. limited ranges
         // Keeping alternate implementation for XSIM only
         rand_success = std::randomize(ax_beat); assert(rand_success);

--- a/test/tb_axi_isolate.sv
+++ b/test/tb_axi_isolate.sv
@@ -202,7 +202,9 @@ module tb_axi_isolate #(
   end
 
 
+`ifndef XILINX_SIMULATOR
   default disable iff (!rst_n);
+`endif
   aw_unstable: assert property (@(posedge clk)
       (slave.aw_valid && !slave.aw_ready) |=> $stable(slave.aw_addr)) else
       $fatal(1, "AW is unstable.");

--- a/test/tb_axi_lite_regs.sv
+++ b/test/tb_axi_lite_regs.sv
@@ -299,7 +299,9 @@ module tb_axi_lite_regs #(
   endtask : check_q
 
   // Some assertions for additional checking.
+  `ifndef XILINX_SIMULATOR
   default disable iff (~rst_n);
+  `endif
   for (genvar i = 0; i < TbRegNumBytes; i++) begin : gen_check_ro_bytes
     if (TbAxiReadOnly[i]) begin : gen_check_ro
       ro_assert_no_load: assert property (@(posedge clk)

--- a/test/tb_axi_lite_to_apb.sv
+++ b/test/tb_axi_lite_to_apb.sv
@@ -169,8 +169,10 @@ module tb_axi_lite_to_apb #(
 
   // pragma translate_off
   `ifndef VERILATOR
+  `ifndef XILINX_SIMULATOR
   // Assertions to determine correct APB protocol sequencing
   default disable iff (!rst_n);
+  `endif
   for (genvar i = 0; i < NoApbSlaves; i++) begin : gen_apb_assertions
     // when psel is not asserted, the bus is in the idle state
     sequence APB_IDLE;

--- a/test/tb_axi_sim_mem.sv
+++ b/test/tb_axi_sim_mem.sv
@@ -84,7 +84,7 @@ module tb_axi_sim_mem #(
     drv.reset_master();
     wait (rst_n);
     // AW
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
     // std::randomize(aw_beat) may behave differently to aw_beat.randomize() wrt. limited ranges
     // Keeping alternate implementation for XSIM only
     rand_success = std::randomize(aw_beat); assert (rand_success);
@@ -99,7 +99,7 @@ module tb_axi_sim_mem #(
     drv.send_aw(aw_beat);
     // W beats
     for (int unsigned i = 0; i <= aw_beat.ax_len; i++) begin
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
       // std::randomize(w_beat) may behave differently to w_beat.randomize() wrt. limited ranges
       // Keeping alternate implementation for XSIM only
       rand_success = std::randomize(w_beat); assert (rand_success);


### PR DESCRIPTION
replace XSIM ifdef by XILINX_SIMULATOR  as described in https://docs.xilinx.com/r/en-US/ug900-vivado-logic-simulation/Predefined-Macros
depends on https://github.com/pulp-platform/common_cells/pull/139

Some more benchs are working

However there are segfaults on a lot of them.