### PR TITLE
axi_dw_downsizer: initialize the write response buffer with EXOKAY

### DIFF
--- a/src/axi_dw_downsizer.sv
+++ b/src/axi_dw_downsizer.sv
@@ -397,11 +397,12 @@ module axi_dw_downsizer #(
               r_state_d = R_PASSTHROUGH;
 
               // Save beat
-              r_req_d.ar           = slv_req_i.ar     ;
-              r_req_d.ar_valid     = 1'b1             ;
-              r_req_d.burst_len    = slv_req_i.ar.len ;
-              r_req_d.orig_ar_size = slv_req_i.ar.size;
-              r_req_d.injected_aw  = 1'b0             ;
+              r_req_d.ar           = slv_req_i.ar        ;
+              r_req_d.ar_valid     = 1'b1                ;
+              r_req_d.burst_len    = slv_req_i.ar.len    ;
+              r_req_d.orig_ar_size = slv_req_i.ar.size   ;
+              r_req_d.injected_aw  = 1'b0                ;
+              r_req_d.r.resp       = axi_pkg::RESP_EXOKAY;
 
               case (r_req_d.ar.burst)
                 axi_pkg::BURST_INCR : begin
@@ -476,6 +477,7 @@ module axi_dw_downsizer #(
           r_req_d.burst_len    = w_req_q.orig_aw_len  ;
           r_req_d.orig_ar_size = w_req_q.orig_aw_size ;
           r_req_d.injected_aw  = 1'b1                 ;
+          r_req_d.r.resp       = axi_pkg::RESP_EXOKAY ;
 
           // Default state
           r_state_d = R_PASSTHROUGH;
@@ -794,10 +796,10 @@ module axi_dw_downsizer #(
     // Can start a new request as soon as w_state_d is W_IDLE
     if (w_state_d == W_IDLE) begin
       // Reset channels
-      w_req_d.aw             = '0                ;
-      w_req_d.aw_valid       = 1'b0              ;
-      w_req_d.aw_throw_error = 1'b0              ;
-      w_req_d.burst_resp     = axi_pkg::RESP_OKAY;
+      w_req_d.aw             = '0                  ;
+      w_req_d.aw_valid       = 1'b0                ;
+      w_req_d.aw_throw_error = 1'b0                ;
+      w_req_d.burst_resp     = axi_pkg::RESP_EXOKAY;
 
       if (!forward_b_beat_full) begin
         if (slv_req_i.aw_valid && slv_req_i.aw.atop[axi_pkg::ATOP_R_RESP]) begin // ATOP with an R response


### PR DESCRIPTION
This modification allows to correctly forward the response status of multi-beat exclusive write operations.

This RESP_EXOKAY response code has the lowest priority (as defined by the axi_pkg::resp_precedence function) when merging the response code from a multi-beat write response. Without this modification, a successful exclusive access can never get the corresponding RESP_EXOKAY code.