### PR TITLE
`axi_tb`: add option for aligned accesses of given `ax_size`

### DIFF
--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -698,6 +698,7 @@ package axi_test;
     parameter int   RESP_MIN_WAIT_CYCLES = 0,
     parameter int   RESP_MAX_WAIT_CYCLES = 20,
     // AXI feature usage
+    parameter int   SIZE_ALIGN        = 0,
     parameter int   AXI_MAX_BURST_LEN = 0, // maximum number of beats in burst; 0 = AXI max (256)
     parameter int   TRAFFIC_SHAPING   = 0,
     parameter bit   AXI_EXCLS         = 1'b0,
@@ -926,7 +927,7 @@ package axi_test;
         end
       end
 
-      ax_beat.ax_addr = addr;
+      ax_beat.ax_addr =  axi_pkg::aligned_addr(addr, axi_pkg::size_t'(SIZE_ALIGN) );
       rand_success = std::randomize(id); assert(rand_success);
       rand_success = std::randomize(qos); assert(rand_success);
       // The random ID *must* be legalized with `legalize_id()` before the beat is sent!  This is


### PR DESCRIPTION
Having a parameter to only have aligned accesses could be useful in certain stages of development.
If you agree it is a feature worth mentioning, we could then also discuss the proper way to implement it.