### PR TITLE
axi_pkg: keep hardcoded value in typedef for vivado ip packager

### DIFF
--- a/src/axi_pkg.sv
+++ b/src/axi_pkg.sv
@@ -19,49 +19,50 @@
 //! AXI Package
 /// Contains all necessary type definitions, constants, and generally useful functions.
 package axi_pkg;
-    /// AXI Transaction Burst Width.
-  parameter int unsigned BurstWidth  = 32'd2;
+
+  /// AXI Transaction Burst Width.
+  typedef logic [1:0]  burst_t;
+  /// AXI Transaction Response Type.
+  typedef logic [1:0]   resp_t;
+  /// AXI Transaction Cacheability Type.
+  typedef logic [3:0]  cache_t;
+  /// AXI Transaction Protection Type.
+  typedef logic [2:0]   prot_t;
+  /// AXI Transaction Quality of Service Type.
+  typedef logic [3:0]    qos_t;
+  /// AXI Transaction Region Type.
+  typedef logic [3:0] region_t;
+  /// AXI Transaction Length Type.
+  typedef logic [7:0]    len_t;
+  /// AXI Transaction Size Type.
+  typedef logic [2:0]   size_t;
+  /// AXI5 Atomic Operation Type.
+  typedef logic [5:0]   atop_t; // atomic operations
+  /// AXI5 Non-Secure Address Identifier.
+  typedef logic [3:0]  nsaid_t;
+
+  /// AXI Transaction Burst Width.
+  parameter int unsigned BurstWidth  = $size(burst_t);
   /// AXI Transaction Response Width.
-  parameter int unsigned RespWidth   = 32'd2;
+  parameter int unsigned RespWidth   = $size(resp_t);
   /// AXI Transaction Cacheability Width.
-  parameter int unsigned CacheWidth  = 32'd4;
+  parameter int unsigned CacheWidth  = $size(cache_t);
   /// AXI Transaction Protection Width.
-  parameter int unsigned ProtWidth   = 32'd3;
+  parameter int unsigned ProtWidth   = $size(prot_t);
   /// AXI Transaction Quality of Service Width.
-  parameter int unsigned QosWidth    = 32'd4;
+  parameter int unsigned QosWidth    = $size(qos_t);
   /// AXI Transaction Region Width.
-  parameter int unsigned RegionWidth = 32'd4;
+  parameter int unsigned RegionWidth = $size(region_t);
   /// AXI Transaction Length Width.
-  parameter int unsigned LenWidth    = 32'd8;
+  parameter int unsigned LenWidth    = $size(len_t);
   /// AXI Transaction Size Width.
-  parameter int unsigned SizeWidth   = 32'd3;
+  parameter int unsigned SizeWidth   = $size(size_t);
   /// AXI Lock Width.
   parameter int unsigned LockWidth   = 32'd1;
   /// AXI5 Atomic Operation Width.
-  parameter int unsigned AtopWidth   = 32'd6;
+  parameter int unsigned AtopWidth   = $size(atop_t);
   /// AXI5 Non-Secure Address Identifier.
-  parameter int unsigned NsaidWidth  = 32'd4;
-
-  /// AXI Transaction Burst Width.
-  typedef logic [BurstWidth-1:0]  burst_t;
-  /// AXI Transaction Response Type.
-  typedef logic [RespWidth-1:0]   resp_t;
-  /// AXI Transaction Cacheability Type.
-  typedef logic [CacheWidth-1:0]  cache_t;
-  /// AXI Transaction Protection Type.
-  typedef logic [ProtWidth-1:0]   prot_t;
-  /// AXI Transaction Quality of Service Type.
-  typedef logic [QosWidth-1:0]    qos_t;
-  /// AXI Transaction Region Type.
-  typedef logic [RegionWidth-1:0] region_t;
-  /// AXI Transaction Length Type.
-  typedef logic [LenWidth-1:0]    len_t;
-  /// AXI Transaction Size Type.
-  typedef logic [SizeWidth-1:0]   size_t;
-  /// AXI5 Atomic Operation Type.
-  typedef logic [AtopWidth-1:0]   atop_t; // atomic operations
-  /// AXI5 Non-Secure Address Identifier.
-  typedef logic [NsaidWidth-1:0]  nsaid_t;
+  parameter int unsigned NsaidWidth  = $size(nsaid_t);
 
   /// In a fixed burst:
   /// - The address is the same for every transfer in the burst.

--- a/src/axi_pkg.sv
+++ b/src/axi_pkg.sv
@@ -19,6 +19,28 @@
 //! AXI Package
 /// Contains all necessary type definitions, constants, and generally useful functions.
 package axi_pkg;
+    /// AXI Transaction Burst Width.
+  parameter int unsigned BurstWidth  = 32'd2;
+  /// AXI Transaction Response Width.
+  parameter int unsigned RespWidth   = 32'd2;
+  /// AXI Transaction Cacheability Width.
+  parameter int unsigned CacheWidth  = 32'd4;
+  /// AXI Transaction Protection Width.
+  parameter int unsigned ProtWidth   = 32'd3;
+  /// AXI Transaction Quality of Service Width.
+  parameter int unsigned QosWidth    = 32'd4;
+  /// AXI Transaction Region Width.
+  parameter int unsigned RegionWidth = 32'd4;
+  /// AXI Transaction Length Width.
+  parameter int unsigned LenWidth    = 32'd8;
+  /// AXI Transaction Size Width.
+  parameter int unsigned SizeWidth   = 32'd3;
+  /// AXI Lock Width.
+  parameter int unsigned LockWidth   = 32'd1;
+  /// AXI5 Atomic Operation Width.
+  parameter int unsigned AtopWidth   = 32'd6;
+  /// AXI5 Non-Secure Address Identifier.
+  parameter int unsigned NsaidWidth  = 32'd4;
 
   /// AXI Transaction Burst Width.
   typedef logic [1:0]  burst_t;
@@ -40,29 +62,6 @@ package axi_pkg;
   typedef logic [5:0]   atop_t; // atomic operations
   /// AXI5 Non-Secure Address Identifier.
   typedef logic [3:0]  nsaid_t;
-
-  /// AXI Transaction Burst Width.
-  parameter int unsigned BurstWidth  = $size(burst_t);
-  /// AXI Transaction Response Width.
-  parameter int unsigned RespWidth   = $size(resp_t);
-  /// AXI Transaction Cacheability Width.
-  parameter int unsigned CacheWidth  = $size(cache_t);
-  /// AXI Transaction Protection Width.
-  parameter int unsigned ProtWidth   = $size(prot_t);
-  /// AXI Transaction Quality of Service Width.
-  parameter int unsigned QosWidth    = $size(qos_t);
-  /// AXI Transaction Region Width.
-  parameter int unsigned RegionWidth = $size(region_t);
-  /// AXI Transaction Length Width.
-  parameter int unsigned LenWidth    = $size(len_t);
-  /// AXI Transaction Size Width.
-  parameter int unsigned SizeWidth   = $size(size_t);
-  /// AXI Lock Width.
-  parameter int unsigned LockWidth   = 32'd1;
-  /// AXI5 Atomic Operation Width.
-  parameter int unsigned AtopWidth   = $size(atop_t);
-  /// AXI5 Non-Secure Address Identifier.
-  parameter int unsigned NsaidWidth  = $size(nsaid_t);
 
   /// In a fixed burst:
   /// - The address is the same for every transfer in the burst.


### PR DESCRIPTION
\[ From issue https://github.com/pulp-platform/axi/issues/292 \]

Since commit [fe4e020](https://github.com/pulp-platform/axi/commit/fe4e020f2c06a242d4901b23cedbf2eeab22bfe6) the typedef`axi_pkg::burst_t` now relies on a Verilog parameter `BurstWidth`.
https://github.com/pulp-platform/axi/blob/fd60be8b51a4fa7476856be162ce3334474592ba/src/axi_pkg.sv#L46
In [Occamy emulation](https://github.com/pulp-platform/snitch/blob/master/hw/system/occamy/src/occamy_xilinx.sv) we use these typedefs at the ports of a custom packaged Vivado IP.

But Vivado requires that "the IP ports are contained within the port description of the HDL file" (c.f. [doc](https://www.xilinx.com/support/documents/sw_manuals/xilinx2022_1/ug1118-vivado-creating-packaging-custom-ip.pdf) page 14).
So custom Vivado IPs can't use `axi_pkg::burst_t` at their top anymore (similar issue on this [support thread](https://support.xilinx.com/s/question/0D52E00006hpfh5SAA/ipflow-19627-hdl-parameter-fpgamanu-fpga-manu-xpath-expression-failed-undefined-parameter-xilinx-used-in-expression-xilinx?language=en_US))

We could maybe define the typdef with a numerical value and then the parameter based on the `$size` of this typedef.
See proposition in  https://github.com/pulp-platform/axi/commit/d2f98d691594c1a8dd1af5bedd5d37d965027535
