### PR TITLE
axi_burst_splitter: Expose id_queue module's FULL_BW parameter

### DIFF
--- a/src/axi_burst_splitter.sv
+++ b/src/axi_burst_splitter.sv
@@ -30,6 +30,8 @@ module axi_burst_splitter #(
   parameter int unsigned MaxReadTxns  = 32'd0,
   // Maximum number of AXI write bursts outstanding at the same time
   parameter int unsigned MaxWriteTxns = 32'd0,
+  // Internal ID queue can work in two bandwidth modes: see id_queue.sv for details
+  parameter bit          FullBW       = 0,
   // AXI Bus Types
   parameter int unsigned AddrWidth    = 32'd0,
   parameter int unsigned DataWidth    = 32'd0,
@@ -139,7 +141,8 @@ module axi_burst_splitter #(
   axi_burst_splitter_ax_chan #(
     .chan_t   ( aw_chan_t    ),
     .IdWidth  ( IdWidth      ),
-    .MaxTxns  ( MaxWriteTxns )
+    .MaxTxns  ( MaxWriteTxns ),
+    .FullBW   ( FullBW       )
   ) i_axi_burst_splitter_aw_chan (
     .clk_i,
     .rst_ni,
@@ -233,7 +236,8 @@ module axi_burst_splitter #(
   axi_burst_splitter_ax_chan #(
     .chan_t   ( ar_chan_t   ),
     .IdWidth  ( IdWidth     ),
-    .MaxTxns  ( MaxReadTxns )
+    .MaxTxns  ( MaxReadTxns ),
+    .FullBW   ( FullBW      )
   ) i_axi_burst_splitter_ar_chan (
     .clk_i,
     .rst_ni,
@@ -346,6 +350,7 @@ module axi_burst_splitter_ax_chan #(
   parameter type         chan_t  = logic,
   parameter int unsigned IdWidth = 0,
   parameter int unsigned MaxTxns = 0,
+  parameter bit          FullBW  = 0,
   parameter type         id_t    = logic[IdWidth-1:0]
 ) (
   input  logic          clk_i,
@@ -371,6 +376,7 @@ module axi_burst_splitter_ax_chan #(
   logic cnt_alloc_req, cnt_alloc_gnt;
   axi_burst_splitter_counters #(
     .MaxTxns ( MaxTxns  ),
+    .FullBW  ( FullBW   ),
     .IdWidth ( IdWidth  )
   ) i_axi_burst_splitter_counters (
     .clk_i,
@@ -459,6 +465,7 @@ endmodule
 /// Internal module of [`axi_burst_splitter`](module.axi_burst_splitter) to order transactions.
 module axi_burst_splitter_counters #(
   parameter int unsigned MaxTxns = 0,
+  parameter bit          FullBW  = 0,
   parameter int unsigned IdWidth = 0,
   parameter type         id_t    = logic [IdWidth-1:0]
 ) (
@@ -517,7 +524,8 @@ module axi_burst_splitter_counters #(
   id_queue #(
     .ID_WIDTH ( $bits(id_t) ),
     .CAPACITY ( MaxTxns     ),
-    .data_t   ( cnt_idx_t   )
+    .data_t   ( cnt_idx_t   ),
+    .FULL_BW  ( FullBW      )
   ) i_idq (
     .clk_i,
     .rst_ni,

--- a/src/axi_to_axi_lite.sv
+++ b/src/axi_to_axi_lite.sv
@@ -22,6 +22,7 @@ module axi_to_axi_lite #(
   parameter int unsigned AxiUserWidth    = 32'd0,
   parameter int unsigned AxiMaxWriteTxns = 32'd0,
   parameter int unsigned AxiMaxReadTxns  = 32'd0,
+  parameter bit          FullBW          = 0,     // ID Queue in Full BW mode in axi_burst_splitter
   parameter bit          FallThrough     = 1'b1,  // FIFOs in Fall through mode in ID reflect
   parameter type         full_req_t      = logic,
   parameter type         full_resp_t     = logic,
@@ -61,6 +62,7 @@ module axi_to_axi_lite #(
   axi_burst_splitter #(
     .MaxReadTxns  ( AxiMaxReadTxns  ),
     .MaxWriteTxns ( AxiMaxWriteTxns ),
+    .FullBW       ( FullBW          ),
     .AddrWidth    ( AxiAddrWidth    ),
     .DataWidth    ( AxiDataWidth    ),
     .IdWidth      ( AxiIdWidth      ),
@@ -255,7 +257,8 @@ module axi_to_axi_lite_intf #(
   parameter int unsigned AXI_MAX_WRITE_TXNS = 32'd1,
   /// Maximum number of outstanding reads.
   parameter int unsigned AXI_MAX_READ_TXNS  = 32'd1,
-  parameter bit          FALL_THROUGH       = 1'b1
+  parameter bit          FALL_THROUGH       = 1'b1,
+  parameter bit          FULL_BW            = 0
 ) (
   input logic     clk_i,
   input logic     rst_ni,
@@ -304,6 +307,7 @@ module axi_to_axi_lite_intf #(
     .AxiMaxWriteTxns ( AXI_MAX_WRITE_TXNS ),
     .AxiMaxReadTxns  ( AXI_MAX_READ_TXNS  ),
     .FallThrough     ( FALL_THROUGH       ),  // FIFOs in Fall through mode in ID reflect
+    .FullBW          ( FULL_BW            ),
     .full_req_t      ( full_req_t         ),
     .full_resp_t     ( full_resp_t        ),
     .lite_req_t      ( lite_req_t         ),


### PR DESCRIPTION
This PR exposes the `FULL_BW` parameter of the `id_queue` module in the `axi_burst_splitter` and `axi_to_axi_lite` IPs. This enables AXI testbench memories built with these components to have full bandwidth, i.e. respond with a maximum throughput of one R beat every cycle.