### PR TITLE
Propagation of the cdc gray SYNC_STAGES parameter to the interfaces

### DIFF
--- a/src/axi_cdc.sv
+++ b/src/axi_cdc.sv
@@ -30,7 +30,9 @@ module axi_cdc #(
   parameter type axi_req_t  = logic, // encapsulates request channels
   parameter type axi_resp_t = logic, // encapsulates request channels
   /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
-  parameter int unsigned  LogDepth  = 1
+  parameter int unsigned  LogDepth   = 1,
+  /// Number of synchronization registers to insert on the async pointers
+  parameter int unsigned  SyncStages = 2
 ) (
   // slave side - clocked by `src_clk_i`
   input  logic      src_clk_i,
@@ -63,7 +65,8 @@ module axi_cdc #(
     .r_chan_t   ( r_chan_t    ),
     .axi_req_t  ( axi_req_t   ),
     .axi_resp_t ( axi_resp_t  ),
-    .LogDepth   ( LogDepth    )
+    .LogDepth   ( LogDepth    ),
+    .SyncStages ( SyncStages  )
   ) i_axi_cdc_src (
                 .src_clk_i,
                 .src_rst_ni,
@@ -94,7 +97,8 @@ module axi_cdc #(
     .r_chan_t   ( r_chan_t    ),
     .axi_req_t  ( axi_req_t   ),
     .axi_resp_t ( axi_resp_t  ),
-    .LogDepth   ( LogDepth    )
+    .LogDepth   ( LogDepth    ),
+    .SyncStages ( SyncStages  )
   ) i_axi_cdc_dst (
                 .dst_clk_i,
                 .dst_rst_ni,
@@ -129,7 +133,9 @@ module axi_cdc_intf #(
   parameter int unsigned AXI_DATA_WIDTH = 0,
   parameter int unsigned AXI_USER_WIDTH = 0,
   /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
-  parameter int unsigned LOG_DEPTH = 1
+  parameter int unsigned LOG_DEPTH = 1,
+  /// Number of synchronization registers to insert on the async pointers
+  parameter int unsigned SYNC_STAGES = 2
 ) (
    // slave side - clocked by `src_clk_i`
   input  logic      src_clk_i,
@@ -171,7 +177,8 @@ module axi_cdc_intf #(
     .r_chan_t   ( r_chan_t  ),
     .axi_req_t  ( req_t     ),
     .axi_resp_t ( resp_t    ),
-    .LogDepth   ( LOG_DEPTH )
+    .LogDepth   ( LOG_DEPTH ),
+    .SyncStages ( SYNC_STAGES )
   ) i_axi_cdc (
     .src_clk_i,
     .src_rst_ni,
@@ -189,7 +196,9 @@ module axi_lite_cdc_intf #(
   parameter int unsigned AXI_ADDR_WIDTH = 0,
   parameter int unsigned AXI_DATA_WIDTH = 0,
   /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
-  parameter int unsigned LOG_DEPTH = 1
+  parameter int unsigned LOG_DEPTH = 1,
+  /// Number of synchronization registers to insert on the async pointers
+  parameter int unsigned SYNC_STAGES = 2
 ) (
    // slave side - clocked by `src_clk_i`
   input  logic      src_clk_i,
@@ -229,7 +238,8 @@ module axi_lite_cdc_intf #(
     .r_chan_t   ( r_chan_t  ),
     .axi_req_t  ( req_t     ),
     .axi_resp_t ( resp_t    ),
-    .LogDepth   ( LOG_DEPTH )
+    .LogDepth   ( LOG_DEPTH ),
+    .SyncStages ( SYNC_STAGES )
   ) i_axi_cdc (
     .src_clk_i,
     .src_rst_ni,

--- a/src/axi_cdc_dst.sv
+++ b/src/axi_cdc_dst.sv
@@ -24,6 +24,8 @@
 module axi_cdc_dst #(
   /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
   parameter int unsigned LogDepth = 1,
+  /// Number of synchronization registers to insert on the async pointers
+  parameter int unsigned SyncStages = 2,
   parameter type aw_chan_t = logic,
   parameter type w_chan_t = logic,
   parameter type b_chan_t = logic,
@@ -63,7 +65,8 @@ module axi_cdc_dst #(
     // Other tools, such as VCS, have problems with type parameters constructed through `$bits()`.
     .T          ( aw_chan_t                     ),
 `endif
-    .LOG_DEPTH  ( LogDepth                      )
+    .LOG_DEPTH   ( LogDepth                     ),
+    .SYNC_STAGES ( SyncStages                   )
   ) i_cdc_fifo_gray_dst_aw (
     .async_data_i ( async_data_slave_aw_data_i  ),
     .async_wptr_i ( async_data_slave_aw_wptr_i  ),
@@ -81,7 +84,8 @@ module axi_cdc_dst #(
 `else
     .T          ( w_chan_t                    ),
 `endif
-    .LOG_DEPTH  ( LogDepth                    )
+    .LOG_DEPTH   ( LogDepth                    ),
+    .SYNC_STAGES ( SyncStages                  )
   ) i_cdc_fifo_gray_dst_w (
     .async_data_i ( async_data_slave_w_data_i ),
     .async_wptr_i ( async_data_slave_w_wptr_i ),
@@ -99,7 +103,8 @@ module axi_cdc_dst #(
 `else
     .T          ( b_chan_t                    ),
 `endif
-    .LOG_DEPTH  ( LogDepth                    )
+    .LOG_DEPTH   ( LogDepth                    ),
+    .SYNC_STAGES ( SyncStages                  )
   ) i_cdc_fifo_gray_src_b (
     .src_clk_i    ( dst_clk_i                 ),
     .src_rst_ni   ( dst_rst_ni                ),
@@ -117,7 +122,8 @@ module axi_cdc_dst #(
 `else
     .T          ( ar_chan_t                     ),
 `endif
-    .LOG_DEPTH  ( LogDepth                      )
+    .LOG_DEPTH   ( LogDepth                     ),
+    .SYNC_STAGES ( SyncStages                   )
   ) i_cdc_fifo_gray_dst_ar (
     .dst_clk_i,
     .dst_rst_ni,
@@ -135,7 +141,8 @@ module axi_cdc_dst #(
 `else
     .T          ( r_chan_t                    ),
 `endif
-    .LOG_DEPTH  ( LogDepth                    )
+    .LOG_DEPTH   ( LogDepth                    ),
+    .SYNC_STAGES ( SyncStages                  )
   ) i_cdc_fifo_gray_src_r (
     .src_clk_i    ( dst_clk_i                 ),
     .src_rst_ni   ( dst_rst_ni                ),
@@ -156,7 +163,9 @@ module axi_cdc_dst_intf #(
   parameter int unsigned AXI_DATA_WIDTH = 0,
   parameter int unsigned AXI_USER_WIDTH = 0,
   /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
-  parameter int unsigned LOG_DEPTH = 1
+  parameter int unsigned LOG_DEPTH = 1,
+  /// Number of synchronization registers to insert on the async pointers
+  parameter int unsigned SYNC_STAGES = 2
 ) (
   // asynchronous slave port
   AXI_BUS_ASYNC_GRAY.Slave  src,
@@ -183,14 +192,15 @@ module axi_cdc_dst_intf #(
   resp_t dst_resp;
 
   axi_cdc_dst #(
-    .aw_chan_t  ( aw_chan_t ),
-    .w_chan_t   ( w_chan_t  ),
-    .b_chan_t   ( b_chan_t  ),
-    .ar_chan_t  ( ar_chan_t ),
-    .r_chan_t   ( r_chan_t  ),
-    .axi_req_t  ( req_t     ),
-    .axi_resp_t ( resp_t    ),
-    .LogDepth   ( LOG_DEPTH )
+    .aw_chan_t  ( aw_chan_t   ),
+    .w_chan_t   ( w_chan_t    ),
+    .b_chan_t   ( b_chan_t    ),
+    .ar_chan_t  ( ar_chan_t   ),
+    .r_chan_t   ( r_chan_t    ),
+    .axi_req_t  ( req_t       ),
+    .axi_resp_t ( resp_t      ),
+    .LogDepth   ( LOG_DEPTH   ),
+    .SyncStages ( SYNC_STAGES )
   ) i_axi_cdc_dst (
     .async_data_slave_aw_data_i ( src.aw_data ),
     .async_data_slave_aw_wptr_i ( src.aw_wptr ),
@@ -223,7 +233,9 @@ module axi_lite_cdc_dst_intf #(
   parameter int unsigned AXI_ADDR_WIDTH = 0,
   parameter int unsigned AXI_DATA_WIDTH = 0,
   /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
-  parameter int unsigned LOG_DEPTH = 1
+  parameter int unsigned LOG_DEPTH = 1,
+  /// Number of synchronization registers to insert on the async pointers
+  parameter int unsigned SYNC_STAGES = 2
 ) (
   // asynchronous slave port
   AXI_LITE_ASYNC_GRAY.Slave   src,
@@ -248,14 +260,15 @@ module axi_lite_cdc_dst_intf #(
   resp_t  dst_resp;
 
   axi_cdc_dst #(
-    .aw_chan_t  ( aw_chan_t ),
-    .w_chan_t   ( w_chan_t  ),
-    .b_chan_t   ( b_chan_t  ),
-    .ar_chan_t  ( ar_chan_t ),
-    .r_chan_t   ( r_chan_t  ),
-    .axi_req_t  ( req_t     ),
-    .axi_resp_t ( resp_t    ),
-    .LogDepth   ( LOG_DEPTH )
+    .aw_chan_t  ( aw_chan_t   ),
+    .w_chan_t   ( w_chan_t    ),
+    .b_chan_t   ( b_chan_t    ),
+    .ar_chan_t  ( ar_chan_t   ),
+    .r_chan_t   ( r_chan_t    ),
+    .axi_req_t  ( req_t       ),
+    .axi_resp_t ( resp_t      ),
+    .LogDepth   ( LOG_DEPTH   ),
+    .SyncStages ( SYNC_STAGES )
   ) i_axi_cdc_dst (
     .async_data_slave_aw_data_i ( src.aw_data ),
     .async_data_slave_aw_wptr_i ( src.aw_wptr ),

--- a/src/axi_cdc_src.sv
+++ b/src/axi_cdc_src.sv
@@ -23,7 +23,9 @@
 /// the FIFO; see the header of `cdc_fifo_gray` for instructions.
 module axi_cdc_src #(
   /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
-  parameter int unsigned LogDepth = 1,
+  parameter int unsigned LogDepth   = 1,
+  /// Number of synchronization registers to insert on the async pointers
+  parameter int unsigned SyncStages = 2,
   parameter type aw_chan_t = logic,
   parameter type w_chan_t = logic,
   parameter type b_chan_t = logic,
@@ -62,7 +64,8 @@ module axi_cdc_src #(
 `else
     .T         ( aw_chan_t                    ),
 `endif
-    .LOG_DEPTH ( LogDepth                     )
+    .LOG_DEPTH   ( LogDepth                     ),
+    .SYNC_STAGES ( SyncStages                   )
   ) i_cdc_fifo_gray_src_aw (
     .src_clk_i,
     .src_rst_ni,
@@ -80,7 +83,8 @@ module axi_cdc_src #(
 `else
     .T         ( w_chan_t                     ),
 `endif
-    .LOG_DEPTH ( LogDepth                     )
+    .LOG_DEPTH   ( LogDepth                     ),
+    .SYNC_STAGES ( SyncStages                   )
   ) i_cdc_fifo_gray_src_w (
     .src_clk_i,
     .src_rst_ni,
@@ -98,7 +102,8 @@ module axi_cdc_src #(
 `else
     .T         ( b_chan_t                     ),
 `endif
-    .LOG_DEPTH ( LogDepth                     )
+    .LOG_DEPTH   ( LogDepth                     ),
+    .SYNC_STAGES ( SyncStages                   )
   ) i_cdc_fifo_gray_dst_b (
     .dst_clk_i    ( src_clk_i                   ),
     .dst_rst_ni   ( src_rst_ni                  ),
@@ -116,7 +121,8 @@ module axi_cdc_src #(
 `else
     .T         ( ar_chan_t                    ),
 `endif
-    .LOG_DEPTH ( LogDepth                     )
+    .LOG_DEPTH   ( LogDepth                     ),
+    .SYNC_STAGES ( SyncStages                   )
   ) i_cdc_fifo_gray_src_ar (
     .src_clk_i,
     .src_rst_ni,
@@ -134,7 +140,8 @@ module axi_cdc_src #(
 `else
     .T         ( r_chan_t                     ),
 `endif
-    .LOG_DEPTH ( LogDepth                     )
+    .LOG_DEPTH   ( LogDepth                     ),
+    .SYNC_STAGES ( SyncStages                   )
   ) i_cdc_fifo_gray_dst_r (
     .dst_clk_i    ( src_clk_i                   ),
     .dst_rst_ni   ( src_rst_ni                  ),
@@ -155,7 +162,9 @@ module axi_cdc_src_intf #(
   parameter int unsigned AXI_DATA_WIDTH = 0,
   parameter int unsigned AXI_USER_WIDTH = 0,
   /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
-  parameter int unsigned LOG_DEPTH = 1
+  parameter int unsigned LOG_DEPTH   = 1,
+  /// Number of synchronization registers to insert on the async pointers
+  parameter int unsigned SYNC_STAGES = 2
 ) (
   // synchronous slave port - clocked by `src_clk_i`
   input  logic                src_clk_i,
@@ -185,14 +194,15 @@ module axi_cdc_src_intf #(
   `AXI_ASSIGN_FROM_RESP(src, src_resp)
 
   axi_cdc_src #(
-    .aw_chan_t  ( aw_chan_t ),
-    .w_chan_t   ( w_chan_t  ),
-    .b_chan_t   ( b_chan_t  ),
-    .ar_chan_t  ( ar_chan_t ),
-    .r_chan_t   ( r_chan_t  ),
-    .axi_req_t  ( req_t     ),
-    .axi_resp_t ( resp_t    ),
-    .LogDepth   ( LOG_DEPTH )
+    .aw_chan_t  ( aw_chan_t   ),
+    .w_chan_t   ( w_chan_t    ),
+    .b_chan_t   ( b_chan_t    ),
+    .ar_chan_t  ( ar_chan_t   ),
+    .r_chan_t   ( r_chan_t    ),
+    .axi_req_t  ( req_t       ),
+    .axi_resp_t ( resp_t      ),
+    .LogDepth   ( LOG_DEPTH   ),
+    .SyncStages ( SYNC_STAGES )
   ) i_axi_cdc_src (
     .src_clk_i,
     .src_rst_ni,
@@ -222,7 +232,9 @@ module axi_lite_cdc_src_intf #(
   parameter int unsigned AXI_ADDR_WIDTH = 0,
   parameter int unsigned AXI_DATA_WIDTH = 0,
   /// Depth of the FIFO crossing the clock domain, given as 2**LOG_DEPTH.
-  parameter int unsigned LOG_DEPTH = 1
+  parameter int unsigned LOG_DEPTH = 1,
+  /// Number of synchronization registers to insert on the async pointers
+  parameter int unsigned SYNC_STAGES = 2
 ) (
   // synchronous slave port - clocked by `src_clk_i`
   input  logic                src_clk_i,
@@ -250,14 +262,15 @@ module axi_lite_cdc_src_intf #(
   `AXI_LITE_ASSIGN_FROM_RESP(src, src_resp)
 
   axi_cdc_src #(
-    .aw_chan_t  ( aw_chan_t ),
-    .w_chan_t   ( w_chan_t  ),
-    .b_chan_t   ( b_chan_t  ),
-    .ar_chan_t  ( ar_chan_t ),
-    .r_chan_t   ( r_chan_t  ),
-    .axi_req_t  ( req_t     ),
-    .axi_resp_t ( resp_t    ),
-    .LogDepth   ( LOG_DEPTH )
+    .aw_chan_t  ( aw_chan_t   ),
+    .w_chan_t   ( w_chan_t    ),
+    .b_chan_t   ( b_chan_t    ),
+    .ar_chan_t  ( ar_chan_t   ),
+    .r_chan_t   ( r_chan_t    ),
+    .axi_req_t  ( req_t       ),
+    .axi_resp_t ( resp_t      ),
+    .LogDepth   ( LOG_DEPTH   ),
+    .SyncStages ( SYNC_STAGES )
   ) i_axi_cdc_src (
     .src_clk_i,
     .src_rst_ni,


### PR DESCRIPTION
Here is a minor update to the CDCs.
The only changes are related to the propagation of the sync_stages parameter to the internal cdc_gray.
It is useful to set a different number of synchronization registers.