### PR TITLE
axi_dw_downsizer: Fix `i_forward_b_beats_queue` underflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `axi_bus_compare`: Fix mismatch detection.
 - `axi_to_detailed_mem`: Only respond with `exokay` if `lock` was set on the request.
   Bump `common_cells` for `mem_to_banks` fix.
+- `axi_dw_downsizer`: Fix `i_forward_b_beats_queue` underflow.
 
 ## 0.39.3 - 2024-05-08
 ### Added

--- a/scripts/run_vsim.sh
+++ b/scripts/run_vsim.sh
@@ -49,6 +49,14 @@ exec_test() {
             call_vsim tb_$1
             ;;
         axi_dw_downsizer)
+            call_vsim tb_axi_dw_downsizer \
+                    -gTbAxiSlvPortDataWidth=32 \
+                    -gTbAxiMstPortDataWidth=16 \
+                    -gTbInitialBStallCycles=100000 -t 1ps
+            call_vsim tb_axi_dw_downsizer \
+                    -gTbAxiSlvPortDataWidth=32 \
+                    -gTbAxiMstPortDataWidth=16 \
+                    -gTbInitialRStallCycles=100000 -t 1ps
             for AxiSlvPortDataWidth in 8 16 32 64 128 256 512 1024; do
                 for (( AxiMstPortDataWidth = 8; \
                         AxiMstPortDataWidth < $AxiSlvPortDataWidth; \

--- a/src/axi_dw_downsizer.sv
+++ b/src/axi_dw_downsizer.sv
@@ -733,7 +733,7 @@ module axi_dw_downsizer #(
             automatic addr_t slv_port_offset = AxiSlvPortStrbWidth == 1 ? '0 : w_req_q.aw.addr[idx_width(AxiSlvPortStrbWidth)-1:0];
 
             // Valid output
-            mst_req.w_valid = 1'b1               ;
+            mst_req.w_valid = !forward_b_beat_full;
             mst_req.w.last  = w_req_q.aw.len == 0;
             mst_req.w.user  = slv_req_i.w.user   ;
 
@@ -774,7 +774,7 @@ module axi_dw_downsizer #(
           // Trigger another burst request, if needed
           if (w_state_q == W_SPLIT_INCR_DOWNSIZE)
             // Finished current burst, but whole transaction hasn't finished
-            if (w_req_q.aw.len == '0 && w_req_q.burst_len != '0 && !forward_b_beat_full) begin
+            if (w_req_q.aw.len == '0 && w_req_q.burst_len != '0) begin
               w_req_d.aw_valid = 1'b1;
               w_req_d.aw.len   = (w_req_d.burst_len <= 255) ? w_req_d.burst_len : 255;
 
@@ -783,7 +783,7 @@ module axi_dw_downsizer #(
               forward_b_beat_push = 1'b1;
             end
 
-          if (w_req_q.burst_len == 0 && !forward_b_beat_full) begin
+          if (w_req_q.burst_len == 0) begin
             w_state_d = W_IDLE;
 
             forward_b_beat_push = 1'b1;

--- a/src/axi_dw_downsizer.sv
+++ b/src/axi_dw_downsizer.sv
@@ -746,7 +746,7 @@ module axi_dw_downsizer #(
             automatic addr_t slv_port_offset = AxiSlvPortStrbWidth == 1 ? '0 : w_req_q.aw.addr[idx_width(AxiSlvPortStrbWidth)-1:0];
 
             // Valid output
-            mst_req.w_valid = !forward_b_beat_full;
+            mst_req.w_valid = !(forward_b_beat_full && w_req_q.aw.len == 0);
             mst_req.w.last  = w_req_q.aw.len == 0;
             mst_req.w.user  = slv_req_i.w.user   ;
 

--- a/test/tb_axi_dw_downsizer.sv
+++ b/test/tb_axi_dw_downsizer.sv
@@ -21,8 +21,8 @@ module tb_axi_dw_downsizer #(
     parameter int unsigned TbAxiSlvPortDataWidth = 64  ,
     parameter int unsigned TbAxiMstPortDataWidth = 32  ,
     parameter int unsigned TbAxiUserWidth        = 8   ,
-    parameter int unsigned TbInitialBStallCycles = 1000,
-    parameter int unsigned TbInitialRStallCycles = 1000,
+    parameter int unsigned TbInitialBStallCycles = 0,
+    parameter int unsigned TbInitialRStallCycles = 0,
     // TB Parameters
     parameter time TbCyclTime                    = 10ns,
     parameter time TbApplTime                    = 2ns ,


### PR DESCRIPTION
The `forward_b_beat_push` signal should be asserted every time the last `W` handshake in a burst occurs on the master port. However, pushing to the FIFO should also be conditional on `forward_b_beat_full` not being asserted.

The way this second condition was ensured allowed the `W` handshake to occur, without tracking it through a push to the queue. The corresponding `B` handshake would then trigger a pop, causing an underflow in the FIFO counter.

This PR corrects this behaviour, by stalling the `W` handshake until the FIFO is no longer full, so it is ensured that pushing to the FIFO is possible.

- [x] Revert first commit after review and wait for CI to pass (see comment below)