### PR TITLE
Fix byte calculation in axi_sim_mem R and W forks

### DIFF
--- a/src/axi_sim_mem.sv
+++ b/src/axi_sim_mem.sv
@@ -162,8 +162,8 @@ module axi_sim_mem #(
             mon_w.user = aw_queue[0].user;
             mon_w.beat_count = w_cnt;
             for (shortint unsigned
-                i_byte = axi_pkg::beat_lower_byte(addr, size, len, burst, StrbWidth, w_cnt);
-                i_byte <= axi_pkg::beat_upper_byte(addr, size, len, burst, StrbWidth, w_cnt);
+                i_byte = axi_pkg::beat_lower_byte(aw_queue[0].addr, size, len, burst, StrbWidth, w_cnt);
+                i_byte <= axi_pkg::beat_upper_byte(aw_queue[0].addr, size, len, burst, StrbWidth, w_cnt);
                 i_byte++) begin
               if (axi_req_i.w.strb[i_byte]) begin
                 automatic addr_t byte_addr = (addr / StrbWidth) * StrbWidth + i_byte;
@@ -232,8 +232,8 @@ module axi_sim_mem #(
           r_beat.id = ar_queue[0].id;
           r_beat.resp = axi_pkg::RESP_OKAY;
           for (shortint unsigned
-              i_byte = axi_pkg::beat_lower_byte(addr, size, len, burst, StrbWidth, r_cnt);
-              i_byte <= axi_pkg::beat_upper_byte(addr, size, len, burst, StrbWidth, r_cnt);
+              i_byte = axi_pkg::beat_lower_byte(ar_queue[0].addr, size, len, burst, StrbWidth, r_cnt);
+              i_byte <= axi_pkg::beat_upper_byte(ar_queue[0].addr, size, len, burst, StrbWidth, r_cnt);
               i_byte++) begin
             automatic addr_t byte_addr = (addr / StrbWidth) * StrbWidth + i_byte;
             if (!mem.exists(byte_addr)) begin


### PR DESCRIPTION
Hi all!

I found this bug when accessing the simulation RAM with `ax.size = 0` and 32-bit data bus.
During an increment access to the memory, when `r_cnt % strb_width != 0`, the address of the location accessed (`addr`) is calculated with `ax_queue[0].addr` (e.g. 2nd beat of an INCR burst at location 0x10 has an address of 0x11), but then `addr` is used to determine the byte in the 32-bit word, causing it to make the offset with 0x11 instead of 0x10.
In particular, for `r_cnt = 1`, the byte calculated was 2 instead of 1.