### PR TITLE
axi_xbar_unmuxed: Disable for VCS compilation

### DIFF
--- a/.ci/Memora.yml
+++ b/.ci/Memora.yml
@@ -83,6 +83,9 @@ artifacts:
       - src/axi_pkg.sv
       - src/axi_intf.sv
       - src/axi_test.sv
+      - src/axi_err_slv.sv
+      - src/axi_demux.sv
+      - src/axi_demux_simple.sv
       - src/axi_dw_downsizer.sv
       - src/axi_dw_converter.sv
       - test/tb_axi_dw_downsizer.sv
@@ -97,6 +100,9 @@ artifacts:
       - src/axi_pkg.sv
       - src/axi_intf.sv
       - src/axi_test.sv
+      - src/axi_err_slv.sv
+      - src/axi_demux.sv
+      - src/axi_demux_simple.sv
       - src/axi_dw_upsizer.sv
       - src/axi_dw_converter.sv
       - test/tb_axi_dw_upsizer.sv
@@ -125,6 +131,9 @@ artifacts:
       - src/axi_pkg.sv
       - src/axi_intf.sv
       - src/axi_test.sv
+      - src/axi_demux.sv
+      - src/axi_demux_simple.sv
+      - src/axi_err_slv.sv
       - src/axi_isolate.sv
       - test/tb_axi_isolate.sv
     outputs:
@@ -141,6 +150,7 @@ artifacts:
       - src/axi_id_prepend.sv
       - src/axi_id_remap.sv
       - src/axi_demux.sv
+      - src/axi_demux_simple.sv
       - src/axi_serializer.sv
       - src/axi_mux.sv
       - src/axi_id_serialize.sv
@@ -294,6 +304,7 @@ artifacts:
       - src/axi_intf.sv
       - src/axi_test.sv
       - src/axi_demux.sv
+      - src/axi_demux_simple.sv
       - src/axi_to_detailed_mem.sv
       - src/axi_to_mem.sv
       - src/axi_to_mem_banked.sv
@@ -310,8 +321,11 @@ artifacts:
       - src/axi_intf.sv
       - src/axi_test.sv
       - src/axi_demux.sv
+      - src/axi_demux_simple.sv
       - src/axi_err_slv.sv
       - src/axi_mux.sv
+      - src/axi_multicut.sv
+      - src/axi_xbar_unmuxed.sv
       - src/axi_xbar.sv
       - test/tb_axi_xbar.sv
     outputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Disabled the interface variant of `axi_xbar_unmuxed` for VCS, as VCS does not support multi-dimensional arrays of interfaces yet.
+
 ## 0.39.4 - 2024-07-25
 ### Added
 - `axi_sim_mem`: Increase number of request ports, add multiport interface variant.

--- a/src/axi_xbar_unmuxed.sv
+++ b/src/axi_xbar_unmuxed.sv
@@ -30,9 +30,9 @@ import cf_math_pkg::idx_width;
   parameter type w_chan_t                                             = logic,
   /// AXI4+ATOP B channel struct type for the slave ports.
   parameter type b_chan_t                                             = logic,
-  /// AXI4+ATOP AR channel struct type for the slave ports.  
+  /// AXI4+ATOP AR channel struct type for the slave ports.
   parameter type ar_chan_t                                            = logic,
-  /// AXI4+ATOP R channel struct type for the slave ports.  
+  /// AXI4+ATOP R channel struct type for the slave ports.
   parameter type r_chan_t                                             = logic,
   /// AXI4+ATOP request struct type for the slave ports.
   parameter type req_t                                                = logic,
@@ -56,17 +56,17 @@ import cf_math_pkg::idx_width;
 ) (
   /// Clock, positive edge triggered.
   input  logic                                                          clk_i,
-  /// Asynchronous reset, active low.  
+  /// Asynchronous reset, active low.
   input  logic                                                          rst_ni,
   /// Testmode enable, active high.
   input  logic                                                          test_i,
-  /// AXI4+ATOP requests to the slave ports.  
+  /// AXI4+ATOP requests to the slave ports.
   input  req_t  [Cfg.NoSlvPorts-1:0]                                    slv_ports_req_i,
-  /// AXI4+ATOP responses of the slave ports.  
+  /// AXI4+ATOP responses of the slave ports.
   output resp_t [Cfg.NoSlvPorts-1:0]                                    slv_ports_resp_o,
-  /// AXI4+ATOP requests of the master ports.  
+  /// AXI4+ATOP requests of the master ports.
   output req_t  [Cfg.NoMstPorts-1:0][Cfg.NoSlvPorts-1:0]                mst_ports_req_o,
-  /// AXI4+ATOP responses to the master ports.  
+  /// AXI4+ATOP responses to the master ports.
   input  resp_t [Cfg.NoMstPorts-1:0][Cfg.NoSlvPorts-1:0]                mst_ports_resp_i,
   /// Address map array input for the crossbar. This map is global for the whole module.
   /// It is used for routing the transactions to the respective master ports.
@@ -77,12 +77,12 @@ import cf_math_pkg::idx_width;
 `ifdef VCS
   /// Enables a default master port for each slave port. When this is enabled unmapped
   /// transactions get issued at the master port given by `default_mst_port_i`.
-  /// When not used, tie to `'0`.  
+  /// When not used, tie to `'0`.
   input  logic      [Cfg.NoSlvPorts-1:0][MstPortsIdxWidth-1:0]          default_mst_port_i
 `else
   /// Enables a default master port for each slave port. When this is enabled unmapped
   /// transactions get issued at the master port given by `default_mst_port_i`.
-  /// When not used, tie to `'0`.  
+  /// When not used, tie to `'0`.
   input  logic      [Cfg.NoSlvPorts-1:0][idx_width(Cfg.NoMstPorts)-1:0] default_mst_port_i
 `endif
 );

--- a/src/axi_xbar_unmuxed.sv
+++ b/src/axi_xbar_unmuxed.sv
@@ -284,6 +284,8 @@ import cf_math_pkg::idx_width;
   // pragma translate_on
 endmodule
 
+`ifndef VCS
+// As of now, VCS does not support multi-dimensional array of interfaces.
 `include "axi/assign.svh"
 `include "axi/typedef.svh"
 
@@ -295,10 +297,6 @@ import cf_math_pkg::idx_width;
   parameter bit ATOPS                   = 1'b1,
   parameter bit [Cfg.NoSlvPorts-1:0][Cfg.NoMstPorts-1:0] CONNECTIVITY = '1,
   parameter type rule_t                 = axi_pkg::xbar_rule_64_t
-`ifdef VCS
-  , localparam int unsigned MstPortsIdxWidth =
-        (Cfg.NoMstPorts == 32'd1) ? 32'd1 : unsigned'($clog2(Cfg.NoMstPorts))
-`endif
 ) (
   input  logic                                                      clk_i,
   input  logic                                                      rst_ni,
@@ -307,11 +305,7 @@ import cf_math_pkg::idx_width;
   AXI_BUS.Master                                                    mst_ports [Cfg.NoMstPorts-1:0][Cfg.NoSlvPorts-1:0],
   input  rule_t [Cfg.NoAddrRules-1:0]                               addr_map_i,
   input  logic  [Cfg.NoSlvPorts-1:0]                                en_default_mst_port_i,
-`ifdef VCS
-  input  logic  [Cfg.NoSlvPorts-1:0][MstPortsIdxWidth-1:0]          default_mst_port_i
-`else
   input  logic  [Cfg.NoSlvPorts-1:0][idx_width(Cfg.NoMstPorts)-1:0] default_mst_port_i
-`endif
 );
 
   typedef logic [Cfg.AxiIdWidthSlvPorts -1:0] id_t;
@@ -371,3 +365,5 @@ import cf_math_pkg::idx_width;
   );
 
 endmodule
+
+`endif


### PR DESCRIPTION
multi-dimensional array interfaces are not yet supported in VCS