### PR TITLE
axi_pkg: Add iomsb to avoid underflow in array lengths

### DIFF
--- a/src/axi_id_serialize.sv
+++ b/src/axi_id_serialize.sv
@@ -66,7 +66,7 @@ module axi_id_serialize #(
   /// Number of Entries in the explicit ID map (default: None)
   parameter int unsigned IdMapNumEntries = 32'd0,
   /// Explicit ID map; index [0] in each entry is the input ID to match, index [1] the output ID.
-  parameter int unsigned IdMap [IdMapNumEntries-1:0][0:1] = '{default: {32'b0, 32'b0}}
+  parameter int unsigned IdMap [axi_pkg::iomsb(IdMapNumEntries):0][0:1] = '{default: {32'b0, 32'b0}}
 ) (
   /// Rising-edge clock of both ports
   input  logic      clk_i,

--- a/src/axi_pkg.sv
+++ b/src/axi_pkg.sv
@@ -532,4 +532,9 @@ package axi_pkg;
     logic [31:0] end_addr;
   } xbar_rule_32_t;
 
+  // Return either the argument minus 1 or 0 if 0; useful for IO vector width declaration
+  function automatic integer unsigned iomsb (input integer unsigned width);
+      return (width != 32'd0) ? unsigned'(width-1) : 32'd0;
+  endfunction
+
 endpackage


### PR DESCRIPTION
`axi_id_serialize_intf` such as used [here](https://github.com/pulp-platform/cheshire/blob/main/target/sim/src/vip_cheshire_soc.sv#L686) calls `axi_id_serialize` without setting IdMapNumEntries. This causes VCS to complain about an array bound greater than 2^31-1.
Thus, iomsb function may be useful in axi.
