### PR TITLE
axi_rw_split: Fix write channel assertions

### DIFF
--- a/src/axi_rw_split.sv
+++ b/src/axi_rw_split.sv
@@ -94,7 +94,7 @@ module axi_rw_split #(
   assign mst_write_req_o.r_ready  = 1'b0;
 
   // check for R never to be valid
-  `ASSERT_NEVER(mst_read_resp_r_valid, mst_read_resp_i.r_valid, clk_i, !rst_ni)
+  `ASSERT_NEVER(mst_write_resp_r_valid, mst_write_resp_i.r_valid, clk_i, !rst_ni)
 
   // Write AW channel handshake
   assign mst_write_req_o.aw_valid = slv_req_i.aw_valid;


### PR DESCRIPTION
Hello,

I believe there is a simple typo in the assertions of axi_rw_split. Currently, it is checking that the read channel's read valid signal should not go high. I believe that it should be checking the write channel instead.

Best regards