### PR TITLE
VCS and Verilator support

### DIFF
--- a/src/axi_sim_mem.sv
+++ b/src/axi_sim_mem.sv
@@ -116,8 +116,8 @@ module axi_sim_mem #(
 
   monitor_t [NumPorts-1:0] mon_w, mon_r;
   logic [7:0]     mem[addr_t];
-  axi_pkg::resp_t rerr[addr_t] = '{default: axi_pkg::RESP_OKAY};
-  axi_pkg::resp_t werr[addr_t] = '{default: axi_pkg::RESP_OKAY};
+  axi_pkg::resp_t rerr[addr_t] = '{default: 2'b0};
+  axi_pkg::resp_t werr[addr_t] = '{default: 2'b0};
 
   // error happened in write burst
   axi_pkg::resp_t [NumPorts-1:0] error_happened = axi_pkg::RESP_OKAY;

--- a/src/axi_sim_mem.sv
+++ b/src/axi_sim_mem.sv
@@ -118,8 +118,8 @@ module axi_sim_mem #(
   logic [7:0]     mem[addr_t];
   axi_pkg::resp_t rerr[addr_t] = '{default: 2'b0}; // default: 'axi_pkg::RESP_OKAY'
   axi_pkg::resp_t werr[addr_t] = '{default: 2'b0}; // default: 'axi_pkg::RESP_OKAY'
-  // Verilator cannot determine the type of 'axi_pkg::RESP_OKAY' in this context.
-  // The 'axi_pkg::RESP_OKAY' is expanded to 0 for Verilator compatibility.
+  // - Verilator cannot determine the type of 'axi_pkg::RESP_OKAY' in this context.
+  //   The 'axi_pkg::RESP_OKAY' is expanded to 0 for Verilator compatibility.
 
   // error happened in write burst
   axi_pkg::resp_t [NumPorts-1:0] error_happened = axi_pkg::RESP_OKAY;

--- a/src/axi_sim_mem.sv
+++ b/src/axi_sim_mem.sv
@@ -116,8 +116,10 @@ module axi_sim_mem #(
 
   monitor_t [NumPorts-1:0] mon_w, mon_r;
   logic [7:0]     mem[addr_t];
-  axi_pkg::resp_t rerr[addr_t] = '{default: 2'b0};
-  axi_pkg::resp_t werr[addr_t] = '{default: 2'b0};
+  axi_pkg::resp_t rerr[addr_t] = '{default: 2'b0}; // default: 'axi_pkg::RESP_OKAY'
+  axi_pkg::resp_t werr[addr_t] = '{default: 2'b0}; // default: 'axi_pkg::RESP_OKAY'
+  // Verilator cannot determine the type of 'axi_pkg::RESP_OKAY' in this context.
+  // The 'axi_pkg::RESP_OKAY' is expanded to 0 for Verilator compatibility.
 
   // error happened in write burst
   axi_pkg::resp_t [NumPorts-1:0] error_happened = axi_pkg::RESP_OKAY;

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -226,9 +226,9 @@ package axi_test;
 
   /// The data transferred on a beat on the AW/AR channels.
   class axi_ax_beat #(
-    parameter int AW = 32,
-    parameter int IW = 8 ,
-    parameter int UW = 1
+    parameter int unsigned AW = 32,
+    parameter int unsigned IW = 8 ,
+    parameter int unsigned UW = 1
   );
     rand logic [IW-1:0] ax_id     = '0;
     rand logic [AW-1:0] ax_addr   = '0;
@@ -246,8 +246,8 @@ package axi_test;
 
   /// The data transferred on a beat on the W channel.
   class axi_w_beat #(
-    parameter int DW = 32,
-    parameter int UW = 1
+    parameter int unsigned DW = 32,
+    parameter int unsigned UW = 1
   );
     rand logic [DW-1:0]   w_data = '0;
     rand logic [DW/8-1:0] w_strb = '0;
@@ -257,8 +257,8 @@ package axi_test;
 
   /// The data transferred on a beat on the B channel.
   class axi_b_beat #(
-    parameter int IW = 8,
-    parameter int UW = 1
+    parameter int unsigned IW = 8,
+    parameter int unsigned UW = 1
   );
     rand logic [IW-1:0] b_id   = '0;
     axi_pkg::resp_t     b_resp = '0;
@@ -267,9 +267,9 @@ package axi_test;
 
   /// The data transferred on a beat on the R channel.
   class axi_r_beat #(
-    parameter int DW = 32,
-    parameter int IW = 8 ,
-    parameter int UW = 1
+    parameter int unsigned DW = 32,
+    parameter int unsigned IW = 8 ,
+    parameter int unsigned UW = 1
   );
     rand logic [IW-1:0] r_id   = '0;
     rand logic [DW-1:0] r_data = '0;
@@ -281,12 +281,12 @@ package axi_test;
 
   /// A driver for AXI4 interface.
   class axi_driver #(
-    parameter int  AW = 32  ,
-    parameter int  DW = 32  ,
-    parameter int  IW = 8   ,
-    parameter int  UW = 1   ,
-    parameter time TA = 0ns , // stimuli application time
-    parameter time TT = 0ns   // stimuli test time
+    parameter int unsigned AW = 32  ,
+    parameter int unsigned DW = 32  ,
+    parameter int unsigned IW = 8   ,
+    parameter int unsigned UW = 1   ,
+    parameter time         TA = 0ns , // stimuli application time
+    parameter time         TT = 0ns   // stimuli test time
   );
     virtual AXI_BUS_DV #(
       .AXI_ADDR_WIDTH(AW),

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -226,9 +226,9 @@ package axi_test;
 
   /// The data transferred on a beat on the AW/AR channels.
   class axi_ax_beat #(
-    parameter AW = 32,
-    parameter IW = 8 ,
-    parameter UW = 1
+    parameter int AW = 32,
+    parameter int IW = 8 ,
+    parameter int UW = 1
   );
     rand logic [IW-1:0] ax_id     = '0;
     rand logic [AW-1:0] ax_addr   = '0;
@@ -246,8 +246,8 @@ package axi_test;
 
   /// The data transferred on a beat on the W channel.
   class axi_w_beat #(
-    parameter DW = 32,
-    parameter UW = 1
+    parameter int DW = 32,
+    parameter int UW = 1
   );
     rand logic [DW-1:0]   w_data = '0;
     rand logic [DW/8-1:0] w_strb = '0;
@@ -257,8 +257,8 @@ package axi_test;
 
   /// The data transferred on a beat on the B channel.
   class axi_b_beat #(
-    parameter IW = 8,
-    parameter UW = 1
+    parameter int IW = 8,
+    parameter int UW = 1
   );
     rand logic [IW-1:0] b_id   = '0;
     axi_pkg::resp_t     b_resp = '0;
@@ -267,9 +267,9 @@ package axi_test;
 
   /// The data transferred on a beat on the R channel.
   class axi_r_beat #(
-    parameter DW = 32,
-    parameter IW = 8 ,
-    parameter UW = 1
+    parameter int DW = 32,
+    parameter int IW = 8 ,
+    parameter int UW = 1
   );
     rand logic [IW-1:0] r_id   = '0;
     rand logic [DW-1:0] r_data = '0;
@@ -747,7 +747,7 @@ package axi_test;
     len_t                 max_len;
     burst_t               allowed_bursts[$];
 
-    semaphore cnt_sem;
+    std::semaphore cnt_sem;
 
     ax_beat_t aw_queue[$],
               w_queue[$],
@@ -1037,7 +1037,7 @@ package axi_test;
           automatic addr_t addr_mask;
           // In an exclusive burst, the number of bytes to be transferred must be a power of 2, i.e.,
           // 1, 2, 4, 8, 16, 32, 64, or 128 bytes, and the burst length must not exceed 16 transfers.
-          static int unsigned ul = (AXI_STRB_WIDTH < 8) ? 4 + $clog2(AXI_STRB_WIDTH) : 7;
+          int unsigned ul = (AXI_STRB_WIDTH < 8) ? 4 + $clog2(AXI_STRB_WIDTH) : 7;
           rand_success = std::randomize(n_bytes) with {
             n_bytes >= 1;
             n_bytes <= ul;
@@ -1848,8 +1848,8 @@ package axi_test;
     typedef axi_driver_t::r_beat_t r_beat_t;
 
     axi_driver_t          drv;
-    mailbox aw_mbx = new, w_mbx = new, b_mbx = new,
-            ar_mbx = new, r_mbx = new;
+    std::mailbox aw_mbx = new, w_mbx = new, b_mbx = new,
+                 ar_mbx = new, r_mbx = new;
 
     function new(
       virtual AXI_BUS_DV #(

--- a/test/tb_axi_dw_pkg.sv
+++ b/test/tb_axi_dw_pkg.sv
@@ -134,7 +134,7 @@ package tb_axi_dw_pkg       ;
     longint unsigned tests_expected;
     longint unsigned tests_conducted;
     longint unsigned tests_failed;
-    semaphore        cnt_sem;
+    std::semaphore   cnt_sem;
 
     // Queues and FIFOs to hold the expected AXIDs
 

--- a/test/tb_axi_xbar_pkg.sv
+++ b/test/tb_axi_xbar_pkg.sv
@@ -101,7 +101,7 @@ package tb_axi_xbar_pkg;
     longint unsigned tests_expected;
     longint unsigned tests_conducted;
     longint unsigned tests_failed;
-    semaphore        cnt_sem;
+    std::semaphore   cnt_sem;
 
     //-----------------------------------------
     // Constructor


### PR DESCRIPTION
Minimal changes required to compile sources and simulation targets for VCS (version W-2024.09-1) and Verilator (v5.028-44-g1d79f5c59):
- Verilator requires the `std::` prefix when using built-in classes like `std::semaphore` and `std::mailbox`.
- Verilator cannot compute static variables at compile time when conditional operator is used.
- Verilator cannot determine the default type for Associative Arrays if a parameter is used.
- VCS requires parameter types to match when calling a function with a class object. If any of the axi_??_beat classes are instantiated directly and not from the typedefs in axi_driver, they cannot be passed to a function of a axi_driver object, as `parameter` and `parameter int` are not the same.