### PR TITLE
src/axi_dw_upsizer.sv: avoid unnecessarily wide indices into r_data

### DIFF
--- a/src/axi_dw_upsizer.sv
+++ b/src/axi_dw_upsizer.sv
@@ -482,8 +482,8 @@ module axi_dw_upsizer #(
           // Request was accepted
           if (!r_req_q.ar_valid)
             if (mst_resp.r_valid && (idx_r_upsizer == t) && r_upsizer_valid) begin
-              automatic addr_t mst_port_offset = AxiMstPortStrbWidth == 1 ? '0 : r_req_q.ar.addr[idx_width(AxiMstPortStrbWidth)-1:0];
-              automatic addr_t slv_port_offset = AxiSlvPortStrbWidth == 1 ? '0 : r_req_q.ar.addr[idx_width(AxiSlvPortStrbWidth)-1:0];
+              automatic logic [idx_width(AxiMstPortStrbWidth)-1:0] mst_port_offset = AxiMstPortStrbWidth == 1 ? '0 : r_req_q.ar.addr[idx_width(AxiMstPortStrbWidth)-1:0];
+              automatic logic [idx_width(AxiSlvPortStrbWidth)-1:0] slv_port_offset = AxiSlvPortStrbWidth == 1 ? '0 : r_req_q.ar.addr[idx_width(AxiSlvPortStrbWidth)-1:0];
 
               // Valid output
               slv_r_valid_tran[t] = 1'b1                                       ;


### PR DESCRIPTION
As detailed in #361, Verilator versions v5.028+ have issues with a statement in `axi_dw_upsizer.sv`. Contrary to my initial assumption, it seems that the root cause of the problem is actually the width of the data type of `mst_port_offset` and `slv_port_offset` and not its sign. Hence, this PR reduces the width of these signals to the width that is actually used and assigned on lines 485 and 486.

While this is actually a bug in Verilator, I would be very grateful if the maintainers of this repository are willing to accept this workaround.