### PR TITLE
axi_lite_lfsr: Add missing signal declaration

### DIFF
--- a/src/axi_lite_lfsr.sv
+++ b/src/axi_lite_lfsr.sv
@@ -54,6 +54,7 @@ module axi_lite_lfsr #(
     logic r_lfsr_en;
 
     logic w_b_fifo_ready;
+    logic w_b_fifo_valid;
 
     // LFSR outputs
     logic [DataWidth-1:0] w_data_in, w_data_out;


### PR DESCRIPTION
Explicitly declare `w_b_fifo_valid` to avoid inferred nets.