### PR TITLE
[test] Remove begin/end from constructors to fix morty ci err

### DIFF
--- a/test/tb_axi_dw_pkg.sv
+++ b/test/tb_axi_dw_pkg.sv
@@ -612,16 +612,14 @@ package tb_axi_dw_pkg       ;
           .AXI_USER_WIDTH(AxiUserWidth       )
         ) mst_port_vif
       );
-      begin
-        super.new(slv_port_vif, mst_port_vif);
-        slv_port_w_cnt = '0;
-        mst_port_w_cnt = '0;
-        mst_port_w_pnt = '1;
-        mst_port_w     = '0;
-        for (int unsigned id = 0; id < 2**AxiIdWidth; id++) begin
-          slv_port_r_cnt[id] = '0;
-          mst_port_r_cnt[id] = '0;
-        end
+      super.new(slv_port_vif, mst_port_vif);
+      slv_port_w_cnt = '0;
+      mst_port_w_cnt = '0;
+      mst_port_w_pnt = '1;
+      mst_port_w     = '0;
+      for (int unsigned id = 0; id < 2**AxiIdWidth; id++) begin
+        slv_port_r_cnt[id] = '0;
+        mst_port_r_cnt[id] = '0;
       end
     endfunction
 
@@ -956,17 +954,15 @@ package tb_axi_dw_pkg       ;
           .AXI_USER_WIDTH(AxiUserWidth       )
         ) mst_port_vif
       );
-      begin
-        super.new(slv_port_vif, mst_port_vif);
+      super.new(slv_port_vif, mst_port_vif);
 
-        slv_port_w_cnt = 0;
-        mst_port_w_cnt = 0;
-        for (int unsigned id = 0; id < 2**AxiIdWidth; id++) begin
-          slv_port_r_cnt[id] = '0;
-          mst_port_r_cnt[id] = '0;
-          slv_port_r[id]     = '0;
-          slv_port_r_pnt[id] = '1;
-        end
+      slv_port_w_cnt = 0;
+      mst_port_w_cnt = 0;
+      for (int unsigned id = 0; id < 2**AxiIdWidth; id++) begin
+        slv_port_r_cnt[id] = '0;
+        mst_port_r_cnt[id] = '0;
+        slv_port_r[id]     = '0;
+        slv_port_r_pnt[id] = '1;
       end
     endfunction
 


### PR DESCRIPTION
This PR refactors the AXI module constructors in `test/tb_axi_dw_pkg.sv` by removing redundant `begin...end` blocks. The primary objective is to streamline the constructor definitions to account for parser errors occurring in the `sv-parser` crate used by [morty](https://github.com/pulp-platform/morty). 

- The removal addresses parsing issues related to `super.new(...)` calls, ensuring that the `sv-parser` can accurately interpret method calls without being constrained by unnecessary block delimiters.
- The `begin...end` blocks within constructors were redundant, as the constructor's logic doesn't require multiple procedural statements that necessitate such blocks.

The functional behavior and RTL characteristics of the AXI module remain **unchanged**. The constructor continues to initialize and configure module parameters as intended.
