### PR TITLE
Bug fixing for axi_burst_unwrap module

### DIFF
--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -474,7 +474,7 @@ module axi_burst_unwrap_ax_chan #(
 
   enum logic {Idle, Busy} state_d, state_q;
   always_comb begin
-    cnt_alloc_req = 1'b0;
+    cnt_alloc_req = '0;
     ax_d          = ax_q;
     state_d       = state_q;
     ax_o          = '0;
@@ -489,8 +489,6 @@ module axi_burst_unwrap_ax_chan #(
             ax_d          = ax_i;
             ax_d.burst    = axi_pkg::BURST_INCR;
             split_len     = 8'd1;
-            // Allocate second counter only for AwChan
-            cnt_alloc_req = { AwChan, 1'b1 };
             // Try to feed first burst through.
             ax_o       = ax_d;
             // First (this) incr burst from addr to wrap boundary + container size
@@ -502,6 +500,8 @@ module axi_burst_unwrap_ax_chan #(
             if (ax_ready_i) begin
               ax_ready_o = 1'b1;
               state_d    = Busy;
+              // Allocate second counter only for AwChan
+              cnt_alloc_req = { AwChan, 1'b1 };
             end
           end else begin // No splitting required -> feed through.
             ax_o       = ax_i;

--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -468,7 +468,7 @@ module axi_burst_unwrap_ax_chan #(
   logic [AddrWidth-1:0] wrap_boundary;
 
   // The total size of this burst (beat_size * burst_length)
-  assign container_size = ax_i.len << ax_i.size;
+  assign container_size   = (ax_i.len + 1) << ax_i.size;
   // For wrapping bursts, this returns the wrap boundary (container size is power of two according to A.3.4.1)
   assign wrap_boundary = ax_i.addr & ~(AddrWidth'(container_size) - 1);
 
@@ -494,9 +494,10 @@ module axi_burst_unwrap_ax_chan #(
             // Try to feed first burst through.
             ax_o       = ax_d;
             // First (this) incr burst from addr to wrap boundary + container size
-            ax_o.len   = (wrap_boundary + container_size - ax_i.addr) >> ax_i.size;
+            ax_o.len   = ((wrap_boundary + container_size - ax_i.addr) >> ax_i.size) - 1;
             // Next incr burst from wrap boundary to addr
-            ax_d.len   = (ax_i.addr - wrap_boundary) >> ax_i.size;
+            ax_d.len   = ((ax_i.addr - wrap_boundary) >> ax_i.size) - 1;
+            ax_d.addr  = wrap_boundary;
             ax_valid_o = 1'b1;
             if (ax_ready_i) begin
               ax_ready_o = 1'b1;


### PR DESCRIPTION
1. Fix wrap len and boundary logic

This commit fixes an off‐by‐one error in the burst length calculation for wrapping bursts in the AXI interface. According to the AXI specification, the actual burst length is encoded as (AxLEN + 1). The fix adjusts the container size calculation by changing it from `ax_i.len << ax_i.size` to `(ax_i.len + 1) << ax_i.size` and modifies the computed burst lengths accordingly.

2. When an AR wrap burst comes in but master ready is low, don't increase the axi_burst_counter, or the unhandshaked AR will be dropped.