### PR TITLE
Axi_burst_splitter: single beat ATOP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- Add optional single beat atop support to `axi_burst_splitter`.
+
 ### Added
 - Add `axi_burst_unwrap`. #326
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-### Changed
-- Add optional single beat atop support to `axi_burst_splitter`.
-
 ### Added
 - Add `axi_burst_unwrap`. #326
 
@@ -19,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Add random user signal generation for llc-partition test. #315
 - Update `common_verification` from `v0.2.4` to `v0.2.5`.
+- Add optional single beat atop support to `axi_burst_splitter`.
 
 ## 0.39.6 - 2024-12-04
 ### Added

--- a/src/axi_burst_splitter.sv
+++ b/src/axi_burst_splitter.sv
@@ -436,9 +436,9 @@ module axi_burst_splitter_ax_chan #(
             ax_valid_o = 1'b1;
             if (ax_ready_i) begin
               // Reduce number of bursts still to be sent by one and increment address.
-              ax_d.len--;
-              if (ax_d.burst == axi_pkg::BURST_INCR) begin
-                ax_d.addr += (1 << ax_d.size);
+              ax_d.len = ax_i.len - 1;
+              if (ax_i.burst == axi_pkg::BURST_INCR) begin
+                ax_d.addr = ax_i.addr + (1 << ax_i.size);
               end
             end
             state_d = Busy;
@@ -456,9 +456,9 @@ module axi_burst_splitter_ax_chan #(
             state_d = Idle;
           end else begin
             // Otherwise, continue with the next burst.
-            ax_d.len--;
+            ax_d.len = ax_q.len - 1;
             if (ax_q.burst == axi_pkg::BURST_INCR) begin
-              ax_d.addr += (1 << ax_q.size);
+              ax_d.addr = ax_q.addr + (1 << ax_q.size);
             end
           end
         end

--- a/src/axi_burst_splitter.sv
+++ b/src/axi_burst_splitter.sv
@@ -418,7 +418,7 @@ module axi_burst_splitter_ax_chan #(
             ax_valid_o = 1'b1;
             // As soon as downstream is ready, allocate a counter and acknowledge upstream.
             if (ax_ready_i) begin
-              cnt_alloc_req = SingleBeatAtopSupport ? ax_is_atop_i : 1'b1;
+              cnt_alloc_req = SingleBeatAtopSupport ? ~ax_is_atop_i : 1'b1;
               ax_ready_o    = 1'b1;
             end
           end else begin // Splitting required.


### PR DESCRIPTION
Add support to single beat ATOPs to the axi_burst_splitter.
This is achieved by not allocating a counter for these transactions, and allowing unmatched responses to be passed upstream without trying to deallocate a counter. ATOPs have unique ids, so no other counter will ever exist for the id used by the ATOPs.