### PR TITLE
axi_xbar_unmuxed: judge the connection relationship before routing

### DIFF
--- a/src/axi_xbar_unmuxed.sv
+++ b/src/axi_xbar_unmuxed.sv
@@ -140,7 +140,7 @@ import cf_math_pkg::idx_width;
       .dec_valid_o      ( dec_aw_valid               ),
       .dec_error_o      ( dec_aw_error               ),
       .en_default_idx_i ( en_default_mst_port_i[i]   ),
-      .default_idx_i    ( default_mst_port_i[i]      )
+      .default_idx_i    ( Connectivity[i][default_mst_port_i[i]] ? default_mst_port_i[i] : mst_port_idx_t'(Cfg.NoMstPorts) )
     );
 
     addr_decode #(
@@ -155,7 +155,7 @@ import cf_math_pkg::idx_width;
       .dec_valid_o      ( dec_ar_valid               ),
       .dec_error_o      ( dec_ar_error               ),
       .en_default_idx_i ( en_default_mst_port_i[i]   ),
-      .default_idx_i    ( default_mst_port_i[i]      )
+      .default_idx_i    ( Connectivity[i][default_mst_port_i[i]] ? default_mst_port_i[i] : mst_port_idx_t'(Cfg.NoMstPorts) )
     );
 
     assign slv_aw_select = (dec_aw_error) ?

--- a/src/axi_xbar_unmuxed.sv
+++ b/src/axi_xbar_unmuxed.sv
@@ -119,14 +119,12 @@ import cf_math_pkg::idx_width;
     logic                                 dec_ar_valid,  dec_ar_error;
 
     //if there is no connection betwen master and slave, one index for decode error will be used
-    for (genvar j = 0; j < Cfg.NoMstPorts; j++) begin : gen_addr_map
-      if (!Connectivity[i][j]) begin : fix_addr_map
-        assign addr_map[i][j].idx         = mst_port_idx_t'(Cfg.NoMstPorts);
-        assign addr_map[i][j].start_addr  = addr_map_i[j].start_addr;
-        assign addr_map[i][j].end_addr    = addr_map_i[j].end_addr;
-      end
-      else begin : keep_addr_map
-        assign addr_map[i][j] = addr_map_i[j];
+    for (genvar j = 0; j < Cfg.NoAddrRules; j++) begin : gen_addr_map
+      always_comb begin
+        addr_map[i][j] = addr_map_i[j];
+        if (!Connectivity[i][addr_map_i[j].idx]) begin
+          addr_map[i][j].idx = mst_port_idx_t'(Cfg.NoMstPorts);
+        end
       end
     end
 


### PR DESCRIPTION
For demux, we can check the connectivity before routing, this can improve transmission efficiency. The more there are such case that connectivity[i][j] == 0 between slave_port[i] and mst_port[j], the better the improvement effect will be. Because the unnecessary arbitrations have been reduced, this accelerates the correct access response. At the same time, ensure that there is a dedicated port to receive decode errors as before.