### PR TITLE
APB converter fixes

### DIFF
--- a/src/axi_burst_splitter.sv
+++ b/src/axi_burst_splitter.sv
@@ -428,7 +428,7 @@ module axi_burst_splitter_ax_chan #(
               // Reduce number of bursts still to be sent by one and increment address.
               ax_d.len--;
               if (ax_d.burst == axi_pkg::BURST_INCR) begin
-                ax_d.addr = axi_pkg::aligned_addr(ax_d.addr, ax_d.size);
+                ax_d.addr = axi_pkg::aligned_addr(axi_pkg::largest_addr_t'(ax_d.addr), ax_d.size);
                 ax_d.addr += (1 << ax_d.size);
               end
             end
@@ -449,7 +449,7 @@ module axi_burst_splitter_ax_chan #(
             // Otherwise, continue with the next burst.
             ax_d.len--;
             if (ax_q.burst == axi_pkg::BURST_INCR) begin
-              ax_d.addr = axi_pkg::aligned_addr(ax_q.addr, ax_q.size);
+              ax_d.addr = axi_pkg::aligned_addr(axi_pkg::largest_addr_t'(ax_q.addr), ax_q.size);
               ax_d.addr += (1 << ax_q.size);
             end
           end

--- a/src/axi_burst_splitter.sv
+++ b/src/axi_burst_splitter.sv
@@ -428,6 +428,7 @@ module axi_burst_splitter_ax_chan #(
               // Reduce number of bursts still to be sent by one and increment address.
               ax_d.len--;
               if (ax_d.burst == axi_pkg::BURST_INCR) begin
+                ax_d.addr = axi_pkg::aligned_addr(ax_d.addr, ax_d.size);
                 ax_d.addr += (1 << ax_d.size);
               end
             end
@@ -448,6 +449,7 @@ module axi_burst_splitter_ax_chan #(
             // Otherwise, continue with the next burst.
             ax_d.len--;
             if (ax_q.burst == axi_pkg::BURST_INCR) begin
+              ax_d.addr = axi_pkg::aligned_addr(ax_q.addr, ax_q.size);
               ax_d.addr += (1 << ax_q.size);
             end
           end

--- a/src/axi_lite_to_apb.sv
+++ b/src/axi_lite_to_apb.sv
@@ -300,7 +300,9 @@ module axi_lite_to_apb #(
             // `Setup` step
             // set the request output
             apb_req_o[apb_sel_idx] = '{
-              paddr:   apb_req.addr,
+              // Align address as an unaligned APB paddr can cause unpredictable behavior (APB spec 2.1.1)
+              // AXI-lite data is always bus-aligned, even if address is not
+              paddr:   axi_pkg::aligned_addr(apb_req.addr, $clog2(DataWidth/8)),
               pprot:   apb_req.prot,
               psel:    1'b1,
               penable: 1'b0,
@@ -326,7 +328,9 @@ module axi_lite_to_apb #(
       Access: begin
         // `Access` step
         apb_req_o[apb_sel_idx] = '{
-          paddr:   apb_req.addr,
+          // Align address as an unaligned APB paddr can cause unpredictable behavior (APB spec 2.1.1)
+          // AXI-lite data is always bus-aligned, even if address is not
+          paddr:   axi_pkg::aligned_addr(apb_req.addr, $clog2(DataWidth/8)),
           pprot:   apb_req.prot,
           psel:    1'b1,
           penable: 1'b1,

--- a/src/axi_lite_to_apb.sv
+++ b/src/axi_lite_to_apb.sv
@@ -302,7 +302,7 @@ module axi_lite_to_apb #(
             apb_req_o[apb_sel_idx] = '{
               // Align address as an unaligned APB paddr can cause unpredictable behavior (APB spec 2.1.1)
               // AXI-lite data is always bus-aligned, even if address is not
-              paddr:   axi_pkg::aligned_addr(apb_req.addr, $clog2(DataWidth/8)),
+              paddr:   axi_pkg::aligned_addr(axi_pkg::largest_addr_t'(apb_req.addr), $clog2(DataWidth/8)),
               pprot:   apb_req.prot,
               psel:    1'b1,
               penable: 1'b0,
@@ -330,7 +330,7 @@ module axi_lite_to_apb #(
         apb_req_o[apb_sel_idx] = '{
           // Align address as an unaligned APB paddr can cause unpredictable behavior (APB spec 2.1.1)
           // AXI-lite data is always bus-aligned, even if address is not
-          paddr:   axi_pkg::aligned_addr(apb_req.addr, $clog2(DataWidth/8)),
+          paddr:   axi_pkg::aligned_addr(axi_pkg::largest_addr_t'(apb_req.addr), $clog2(DataWidth/8)),
           pprot:   apb_req.prot,
           psel:    1'b1,
           penable: 1'b1,

--- a/src/axi_lite_to_apb.sv
+++ b/src/axi_lite_to_apb.sv
@@ -296,7 +296,7 @@ module axi_lite_to_apb #(
         // `Idle` and `Setup` steps
         // can check here for readiness, because the response goes into spill_registers
         if (apb_req_valid && apb_wresp_ready && apb_rresp_ready) begin
-          if (apb_dec_valid) begin
+          if (apb_dec_valid && ((apb_req.write && (|apb_req.strb)) || (!apb_req.write))) begin
             // `Setup` step
             // set the request output
             apb_req_o[apb_sel_idx] = '{
@@ -314,7 +314,7 @@ module axi_lite_to_apb #(
             // decode error, generate error and do not generate APB request, pop it
             apb_req_ready = 1'b1;
             if (apb_req.write) begin
-              apb_wresp       = axi_pkg::RESP_DECERR;
+              apb_wresp       = ~(|apb_req.strb) ? axi_pkg::RESP_OKAY : axi_pkg::RESP_DECERR;
               apb_wresp_valid = 1'b1;
             end else begin
               apb_rresp.resp  = axi_pkg::RESP_DECERR;


### PR DESCRIPTION
- Drop APB write requests with '0 write strobe
- Fix burst splitter addr alignment
- Align APB addr to avoid possibly unpredictable behavior