### PR TITLE
Only invalidate WRAP bursts if they are unmodifiable

### DIFF
--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -103,7 +103,6 @@ module axi_burst_unwrap #(
     // The AXI Spec (A3.4.1) only allows splitting non-modifiable transactions ..
     // ... but this module only splits WRAP bursts, so ignore all others
     if (!axi_pkg::modifiable(cache) && (burst == axi_pkg::BURST_WRAP)) begin
-      // .. if they are INCR bursts and longer than 16 beats.
       return 1'b0;
     end
     // All other transactions are supported.


### PR DESCRIPTION
This PR changes the `axi_burst_unwrap` module to only return a slave error if a WRAP burst transaction is marked unmodifiable; before, all unmodifiable transactions returned a slave error, even the ones that the module would not have modified.