### PR TITLE
axi_burst_unwrap: Remove overly pessimistic assertion

### DIFF
--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -176,6 +176,7 @@ module axi_burst_unwrap #(
     unique case (w_state_q)
       WReady: begin
         if (act_req.w_valid) begin
+          w_cnt_req = 1'b1;
           if (w_cnt_gnt) begin
             w_last_d = act_req.w.last | (w_cnt_len == 8'd0);
             mst_req_o.w.last  = w_last_d;
@@ -183,7 +184,6 @@ module axi_burst_unwrap #(
             // Try to forward the beat downstream.
             mst_req_o.w_valid = 1'b1;
             if (mst_resp_i.w_ready) begin
-              w_cnt_req = 1'b1;
               act_resp.w_ready = 1'b1;
               if (w_last_d && !act_req.w.last) begin
                 w_state_d = WFeedthrough;

--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -647,11 +647,4 @@ module axi_burst_counters #(
   // registers
   `FFARN(err_q, err_d, '0, clk_i, rst_ni)
 
-  `ifndef VERILATOR
-  // pragma translate_off
-  assume property (@(posedge clk_i) idq_oup_gnt |-> idq_oup_valid)
-    else $warning("Invalid output at ID queue, read not granted!");
-  // pragma translate_on
-  `endif
-
 endmodule

--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -176,14 +176,14 @@ module axi_burst_unwrap #(
     unique case (w_state_q)
       WReady: begin
         if (act_req.w_valid) begin
+          w_cnt_req = 1'b1;
           if (w_cnt_gnt) begin
             w_last_d = act_req.w.last | (w_cnt_len == 8'd0);
             mst_req_o.w.last  = w_last_d;
-            w_cnt_dec         = 1'b1;
             // Try to forward the beat downstream.
             mst_req_o.w_valid = 1'b1;
             if (mst_resp_i.w_ready) begin
-              w_cnt_req = 1'b1;
+              w_cnt_dec        = 1'b1;
               act_resp.w_ready = 1'b1;
               if (w_last_d && !act_req.w.last) begin
                 w_state_d = WFeedthrough;

--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -176,14 +176,14 @@ module axi_burst_unwrap #(
     unique case (w_state_q)
       WReady: begin
         if (act_req.w_valid) begin
-          w_cnt_req = 1'b1;
           if (w_cnt_gnt) begin
             w_last_d = act_req.w.last | (w_cnt_len == 8'd0);
             mst_req_o.w.last  = w_last_d;
+            w_cnt_dec         = 1'b1;
             // Try to forward the beat downstream.
             mst_req_o.w_valid = 1'b1;
             if (mst_resp_i.w_ready) begin
-              w_cnt_dec        = 1'b1;
+              w_cnt_req = 1'b1;
               act_resp.w_ready = 1'b1;
               if (w_last_d && !act_req.w.last) begin
                 w_state_d = WFeedthrough;

--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -131,9 +131,9 @@ module axi_burst_unwrap #(
   // --------------------------------------------------
   // AW Channel
   // --------------------------------------------------
-  logic           b_cnt_dec, b_cnt_req, b_cnt_gnt, b_cnt_err;
-  logic           w_cnt_dec, w_cnt_req, w_cnt_gnt;
-  axi_pkg::len_t  b_cnt_len, w_cnt_len;
+  logic b_cnt_dec, b_cnt_req, b_cnt_gnt, b_cnt_err, b_cnt_empty;
+  logic w_cnt_dec, w_cnt_req, w_cnt_gnt, w_cnt_empty;
+  axi_pkg::len_t b_cnt_len, w_cnt_len;
   axi_burst_unwrap_ax_chan #(
     .AwChan   ( 1'b1         ),
     .chan_t   ( aw_chan_t    ),
@@ -151,6 +151,7 @@ module axi_burst_unwrap #(
     .ax_ready_i     ( mst_resp_i.aw_ready                ),
     .cnt_id_i       ( mst_resp_i.b.id                    ),
     .cnt_len_o      ({ w_cnt_len      , b_cnt_len       }),
+    .cnt_empty_o    ({ w_cnt_empty    , b_cnt_empty     }),
     .cnt_set_err_i  ( mst_resp_i.b.resp[1]               ),
     .cnt_err_o      ( b_cnt_err                          ),
     .cnt_dec_i      ({ w_cnt_dec      , b_cnt_dec       }),
@@ -175,15 +176,16 @@ module axi_burst_unwrap #(
 
     unique case (w_state_q)
       WReady: begin
-        if (act_req.w_valid) begin
+        // Moritz: Additionally verify that we are expecting a W beat.
+        if (act_req.w_valid & ~w_cnt_empty) begin
           w_cnt_req = 1'b1;
           if (w_cnt_gnt) begin
             w_last_d = act_req.w.last | (w_cnt_len == 8'd0);
             mst_req_o.w.last  = w_last_d;
             // Try to forward the beat downstream.
             mst_req_o.w_valid = 1'b1;
+            w_cnt_dec        = 1'b1;
             if (mst_resp_i.w_ready) begin
-              w_cnt_dec        = 1'b1;
               act_resp.w_ready = 1'b1;
               if (w_last_d && !act_req.w.last) begin
                 w_state_d = WFeedthrough;
@@ -231,7 +233,8 @@ module axi_burst_unwrap #(
 
     unique case (b_state_q)
       BReady: begin
-        if (mst_resp_i.b_valid) begin
+        // Moritz: Additionally verify that we are expecting a B channel response.
+        if (mst_resp_i.b_valid & ~b_cnt_empty) begin
           b_cnt_req = 1'b1;
           if (b_cnt_gnt) begin
             if (b_cnt_len == 8'd0) begin
@@ -292,6 +295,7 @@ module axi_burst_unwrap #(
     .ax_ready_i     ( mst_resp_i.ar_ready      ),
     .cnt_id_i       ( mst_resp_i.r.id          ),
     .cnt_len_o      ({ unc1 , r_cnt_len       }),
+    .cnt_empty_o    (                          ),
     .cnt_set_err_i  ( 1'b0                     ),
     .cnt_err_o      (                          ),
     .cnt_dec_i      ({ 1'b0 , r_cnt_dec       }),
@@ -406,6 +410,7 @@ module axi_burst_unwrap_ax_chan #(
 
   input  id_t                 cnt_id_i,
   output axi_pkg::len_t [1:0] cnt_len_o,
+  output logic          [1:0] cnt_empty_o,
   input  logic                cnt_set_err_i,
   output logic                cnt_err_o,
   input  logic          [1:0] cnt_dec_i,
@@ -430,6 +435,7 @@ module axi_burst_unwrap_ax_chan #(
     .alloc_gnt_o   ( cnt_alloc_gnt[0] ),
     .cnt_id_i      ( cnt_id_i         ),
     .cnt_len_o     ( cnt_len_o[0]     ),
+    .cnt_empty_o   ( cnt_empty_o[0]   ),
     .cnt_set_err_i ( cnt_set_err_i    ),
     .cnt_err_o     ( cnt_err_o        ),
     .cnt_dec_i     ( cnt_dec_i[0]     ),
@@ -455,6 +461,7 @@ module axi_burst_unwrap_ax_chan #(
     .alloc_gnt_o   ( cnt_alloc_gnt[1] ),
     .cnt_id_i      ( 1'b0             ),
     .cnt_len_o     ( cnt_len_o[1]     ),
+    .cnt_empty_o   ( cnt_empty_o[1]   ),
     .cnt_set_err_i ( 1'b0             ),
     .cnt_err_o     (                  ),
     .cnt_dec_i     ( cnt_dec_i[1]     ),
@@ -551,6 +558,7 @@ module axi_burst_counters #(
 
   input  id_t           cnt_id_i,
   output axi_pkg::len_t cnt_len_o,
+  logic                 cnt_empty_o,
   input  logic          cnt_set_err_i,
   output logic          cnt_err_o,
   input  logic          cnt_dec_i,
@@ -622,6 +630,7 @@ module axi_burst_counters #(
   logic [8:0] read_len;
   assign read_len    = cnt_oup[cnt_r_idx] - 1;
   assign cnt_len_o   = read_len[7:0];
+  assign cnt_empty_o = (&cnt_free);
 
   assign idq_oup_pop = cnt_req_i & cnt_gnt_o & cnt_dec_i & (cnt_len_o == 8'd0);
   always_comb begin

--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -176,7 +176,6 @@ module axi_burst_unwrap #(
     unique case (w_state_q)
       WReady: begin
         if (act_req.w_valid) begin
-          w_cnt_req = 1'b1;
           if (w_cnt_gnt) begin
             w_last_d = act_req.w.last | (w_cnt_len == 8'd0);
             mst_req_o.w.last  = w_last_d;
@@ -184,6 +183,7 @@ module axi_burst_unwrap #(
             // Try to forward the beat downstream.
             mst_req_o.w_valid = 1'b1;
             if (mst_resp_i.w_ready) begin
+              w_cnt_req = 1'b1;
               act_resp.w_ready = 1'b1;
               if (w_last_d && !act_req.w.last) begin
                 w_state_d = WFeedthrough;


### PR DESCRIPTION
This PR fixes a bug in the `axi_burst_unwrap` module, where the `id_queue` managing a write burst's outstanding W beats receives decrement requests even if the W channel transfer was not handshaked. 