### PR TITLE
axi_demux_simple: expose B and R arbiters indexes

### DIFF
--- a/src/axi_burst_splitter_gran.sv
+++ b/src/axi_burst_splitter_gran.sv
@@ -98,7 +98,9 @@ module axi_burst_splitter_gran #(
     .slv_ar_select_i  ( sel_ar_unsupported            ),
     .slv_resp_o       ( slv_resp ),
     .mst_reqs_o       ( {unsupported_req,  act_req}   ),
-    .mst_resps_i      ( {unsupported_resp, act_resp}  )
+    .mst_resps_i      ( {unsupported_resp, act_resp}  ),
+    .mst_b_idx_o      (                               ),
+    .mst_r_idx_o      (                               )
   );
 
   // Define supported transactions.

--- a/src/axi_demux.sv
+++ b/src/axi_demux.sv
@@ -205,7 +205,9 @@ module axi_demux #(
     .slv_ar_select_i ( slv_ar_select ),
     .slv_resp_o      ( slv_resp_cut  ),
     .mst_reqs_o      ( mst_reqs_o    ),
-    .mst_resps_i     ( mst_resps_i   )
+    .mst_resps_i     ( mst_resps_i   ),
+    .mst_b_idx_o     (               ),
+    .mst_r_idx_o     (               )
   );
 
 endmodule

--- a/src/axi_demux_simple.sv
+++ b/src/axi_demux_simple.sv
@@ -63,7 +63,9 @@ module axi_demux_simple #(
   output axi_resp_t                     slv_resp_o,
   // Master Ports
   output axi_req_t    [NoMstPorts-1:0]  mst_reqs_o,
-  input  axi_resp_t   [NoMstPorts-1:0]  mst_resps_i
+  input  axi_resp_t   [NoMstPorts-1:0]  mst_resps_i,
+  output select_t                       mst_b_idx_o,
+  output select_t                       mst_r_idx_o
 );
 
   localparam int unsigned IdCounterWidth = cf_math_pkg::idx_width(MaxTrans);
@@ -373,6 +375,8 @@ module axi_demux_simple #(
       );
     end
 
+    assign mst_b_idx_o = b_idx;
+
     //--------------------------------------
     //  R Channel
     //--------------------------------------
@@ -456,6 +460,8 @@ module axi_demux_simple #(
       // assign mst_r_chans[i]        = mst_resps_i[i].r;
       assign mst_r_valids[i]       = mst_resps_i[i].r_valid;
     end
+
+    assign mst_r_idx_o = r_idx;
 
 // Validate parameters.
 // pragma translate_off

--- a/src/axi_to_mem_interleaved.sv
+++ b/src/axi_to_mem_interleaved.sv
@@ -119,7 +119,9 @@ module axi_to_mem_interleaved #(
     .slv_aw_select_i ( 1'b1                     ),
     .slv_resp_o      ( axi_resp_o               ),
     .mst_reqs_o      ( {w_axi_req,  r_axi_req}  ),
-    .mst_resps_i     ( {w_axi_resp, r_axi_resp} )
+    .mst_resps_i     ( {w_axi_resp, r_axi_resp} ),
+    .mst_b_idx_o     (                          ),
+    .mst_r_idx_o     (                          )
   );
 
   axi_to_mem #(

--- a/src/axi_to_mem_split.sv
+++ b/src/axi_to_mem_split.sv
@@ -103,7 +103,9 @@ module axi_to_mem_split #(
     .slv_aw_select_i ( 1'b1                            ),
     .slv_resp_o      ( axi_resp_o                      ),
     .mst_reqs_o      ( {axi_write_req,  axi_read_req}  ),
-    .mst_resps_i     ( {axi_write_resp, axi_read_resp} )
+    .mst_resps_i     ( {axi_write_resp, axi_read_resp} ),
+    .mst_b_idx_o     (                                 ),
+    .mst_r_idx_o     (                                 )
   );
 
   assign busy_o = read_busy || write_busy;


### PR DESCRIPTION
For ACE related modifications to propagate WACK/RACK signals, it is useful to know which R or B beat has won the internal arbitration. I would propose to make the indexes externally visible. While the change is minimal, it has the drawback to change the interface of this module. What do you think?