### PR TITLE
axi_to_mem: Fix strb inputs to dead_response_fifo

### DIFF
--- a/src/axi_to_detailed_mem.sv
+++ b/src/axi_to_detailed_mem.sv
@@ -908,6 +908,11 @@ module mem_stream_to_banks_detailed #(
   assign mem_req_ready = (&req_ready) & (&resp_ready) & !dead_write_fifo_full;
 
   if (HideStrb) begin : gen_dead_write_fifo
+
+    logic [NumBanks-1:0] zero_strobe_on_input;
+    for (genvar i = 0; unsigned'(i) < NumBanks; i++) begin
+      assign zero_strobe_on_input[i] = (strb_i[i*BytesPerBank+:BytesPerBank] == '0);
+    end
     fifo_v3 #(
       .FALL_THROUGH ( 1'b0     ),
       .DEPTH        ( MaxTrans+1 ),
@@ -920,8 +925,8 @@ module mem_stream_to_banks_detailed #(
       .full_o     ( dead_write_fifo_full    ),
       .empty_o    (),
       .usage_o    (),
-      .data_i     ( bank_we_o & zero_strobe ),
-      .push_i     ( mem_req_valid & mem_req_ready           ),
+      .data_i     ( we_i ? zero_strobe_on_input : '0 ),
+      .push_i     ( mem_req_valid & mem_req_ready ),
       .data_o     ( dead_response           ),
       .pop_i      ( rvalid_o & rready_i     )
     );


### PR DESCRIPTION
The inputs to the `dead_response_fifo` are incorrect; `push_i` is taken from val/rdy on the input of first fifo, `gen_reqs.i_ft_reg`, while `data_i` is taken from the output of the first fifo, `gen_reqs.i_ft_reg`. This can cause erroneous behavior on the expected responses, leading to missing B responses due to a mismatch in the expected responses and actual responses on the mem response stalling.

This PR aligns it such that all data is taken from the first fifo input.