### PR TITLE
Use XSIM define to remove all default disable blocks under src directory

### DIFF
--- a/src/axi_burst_splitter_gran.sv
+++ b/src/axi_burst_splitter_gran.sv
@@ -397,6 +397,7 @@ module axi_burst_splitter_gran #(
   // Assumptions and assertions
   // --------------------------------------------------
   `ifndef VERILATOR
+  `ifndef XSIM
   // pragma translate_off
   default disable iff (!rst_ni);
   // Inputs
@@ -413,6 +414,7 @@ module axi_burst_splitter_gran #(
   assert property (@(posedge clk_i) mst_req_o.ar_valid |-> mst_req_o.ar.len <= len_limit_i)
     else $fatal(1, "AR burst longer than a single beat emitted!");
   // pragma translate_on
+  `endif
   `endif
 
 endmodule

--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -364,6 +364,7 @@ module axi_burst_unwrap #(
   // Assumptions and assertions
   // --------------------------------------------------
   `ifndef VERILATOR
+  `ifndef XSIM
   // pragma translate_off
   default disable iff (!rst_ni);
   // Inputs
@@ -378,6 +379,7 @@ module axi_burst_unwrap #(
     ) else $fatal(1, "Unsupported ATOP that gives rise to a R response received,\
                       cannot respond in protocol-compliant manner!");
   // pragma translate_on
+  `endif
   `endif
 
 endmodule

--- a/src/axi_demux_simple.sv
+++ b/src/axi_demux_simple.sv
@@ -460,13 +460,13 @@ module axi_demux_simple #(
 // Validate parameters.
 // pragma translate_off
 `ifndef VERILATOR
-`ifndef XSIM
     initial begin: validate_params
       no_mst_ports: assume (NoMstPorts > 0) else
         $fatal(1, "The Number of slaves (NoMstPorts) has to be at least 1");
       AXI_ID_BITS:  assume (AxiIdWidth >= AxiLookBits) else
         $fatal(1, "AxiIdBits has to be equal or smaller than AxiIdWidth.");
     end
+`ifndef XSIM
     default disable iff (!rst_ni);
     aw_select: assume property( @(posedge clk_i) (slv_req_i.aw_valid |->
                                                  (slv_aw_select_i < NoMstPorts))) else

--- a/src/axi_err_slv.sv
+++ b/src/axi_err_slv.sv
@@ -244,11 +244,11 @@ module axi_err_slv #(
 
   // pragma translate_off
   `ifndef VERILATOR
-  `ifndef XSIM
   initial begin
     assert (Resp == axi_pkg::RESP_DECERR || Resp == axi_pkg::RESP_SLVERR) else
       $fatal(1, "This module may only generate RESP_DECERR or RESP_SLVERR responses!");
   end
+  `ifndef XSIM
   default disable iff (!rst_ni);
   if (!ATOPs) begin : gen_assert_atops_unsupported
     assume property( @(posedge clk_i) (slv_req_i.aw_valid |-> slv_req_i.aw.atop == '0)) else

--- a/src/axi_id_remap.sv
+++ b/src/axi_id_remap.sv
@@ -382,6 +382,7 @@ module axi_id_remap #(
     assert ($bits(mst_req_o.ar.id) == AxiMstPortIdWidth);
     assert ($bits(mst_resp_i.r.id) == AxiMstPortIdWidth);
   end
+  `ifndef XSIM
   default disable iff (!rst_ni);
   assert property (@(posedge clk_i) slv_req_i.aw_valid && slv_resp_o.aw_ready
       |-> mst_req_o.aw_valid && mst_resp_i.aw_ready);
@@ -397,6 +398,7 @@ module axi_id_remap #(
       |=> mst_req_o.ar_valid && $stable(mst_req_o.ar.id));
   assert property (@(posedge clk_i) mst_req_o.aw_valid && !mst_resp_i.aw_ready
       |=> mst_req_o.aw_valid && $stable(mst_req_o.aw.id));
+  `endif
   `endif
   // pragma translate_on
 endmodule
@@ -552,6 +554,7 @@ module axi_id_remap_table #(
   // Assertions
   // pragma translate_off
   `ifndef VERILATOR
+  `ifndef XSIM
     default disable iff (!rst_ni);
     assume property (@(posedge clk_i) push_i |->
         table_q[push_oup_id_i].cnt == '0 || table_q[push_oup_id_i].inp_id == push_inp_id_i)
@@ -569,6 +572,7 @@ module axi_id_remap_table #(
       assert (MaxTxnsPerId > 0);
       assert (IdxWidth >= 1);
     end
+  `endif
   `endif
   // pragma translate_on
 

--- a/src/axi_isolate.sv
+++ b/src/axi_isolate.sv
@@ -392,6 +392,7 @@ module axi_isolate_inner #(
   initial begin
     assume (NumPending > 0) else $fatal(1, "At least one pending transaction required.");
   end
+`ifndef XSIM
   default disable iff (!rst_ni);
   aw_overflow: assert property (@(posedge clk_i)
       (pending_aw_q == '1) |=> (pending_aw_q != '0)) else
@@ -405,6 +406,7 @@ module axi_isolate_inner #(
   ar_underflow: assert property (@(posedge clk_i)
       (pending_ar_q == '0) |=> (pending_ar_q != '1)) else
       $fatal(1, "pending_ar_q underflowed");
+`endif
 `endif
 // pragma translate_on
 endmodule

--- a/src/axi_lite_demux.sv
+++ b/src/axi_lite_demux.sv
@@ -442,6 +442,7 @@ module axi_lite_demux #(
 
     // pragma translate_off
     `ifndef VERILATOR
+    `ifndef XSIM
     default disable iff (!rst_ni);
     aw_select: assume property( @(posedge clk_i) (slv_req_i.aw_valid |->
                                                  (slv_aw_select_i < NoMstPorts))) else
@@ -463,6 +464,7 @@ module axi_lite_demux #(
     ar_stable: assert property( @(posedge clk_i) (slv_ar_valid && !slv_ar_ready)
                                |=> $stable(slv_ar_chan)) else
       $fatal(1, "slv_aw_chan_select unstable with valid set.");
+    `endif
     `endif
     // pragma translate_on
   end

--- a/src/axi_lite_dw_converter.sv
+++ b/src/axi_lite_dw_converter.sv
@@ -464,6 +464,7 @@ module axi_lite_dw_converter #(
     assume ($onehot(AxiSlvPortDataWidth)) else $fatal(1, "AxiSlvPortDataWidth must be power of 2");
     assume ($onehot(AxiMstPortDataWidth)) else $fatal(1, "AxiMstPortDataWidth must be power of 2");
   end
+  `ifndef XSIM
   default disable iff (~rst_ni);
   stable_aw: assert property (@(posedge clk_i)
       (mst_req_o.aw_valid && !mst_res_i.aw_ready) |=> $stable(mst_req_o.aw)) else
@@ -480,6 +481,7 @@ module axi_lite_dw_converter #(
   stable_r:  assert property (@(posedge clk_i)
       (slv_res_o.r_valid  && !slv_req_i.r_ready)  |=> $stable(slv_res_o.r)) else
       $fatal(1, "R must remain stable until handshake happened.");
+  `endif
   `endif
   // pragma translate_on
 endmodule

--- a/src/axi_lite_from_mem.sv
+++ b/src/axi_lite_from_mem.sv
@@ -235,6 +235,7 @@ module axi_lite_from_mem #(
       assert (DataWidth == $bits(axi_rsp_i.r.data)) else
           $fatal(1, "DataWidth has to match axi_rsp_i.r.data!");
     end
+  `ifndef XSIM
     default disable iff (~rst_ni);
     assert property (@(posedge clk_i) (mem_req_i && !mem_gnt_o) |=> mem_req_i) else
         $fatal(1, "It is not allowed to deassert the request if it was not granted!");
@@ -246,6 +247,7 @@ module axi_lite_from_mem #(
         $fatal(1, "mem_wdata_i has to be stable if request is not granted!");
     assert property (@(posedge clk_i) (mem_req_i && !mem_gnt_o) |=> $stable(mem_be_i)) else
         $fatal(1, "mem_be_i has to be stable if request is not granted!");
+  `endif
   `endif
   `endif
   // pragma translate_on

--- a/src/axi_lite_regs.sv
+++ b/src/axi_lite_regs.sv
@@ -380,6 +380,7 @@ module axi_lite_regs #(
   // Validate parameters.
   // pragma translate_off
   `ifndef VERILATOR
+  `ifndef XSIM
     initial begin: p_assertions
       assert (RegNumBytes > 32'd0) else
           $fatal(1, "The number of bytes must be at least 1!");
@@ -401,6 +402,7 @@ module axi_lite_regs #(
       assert property (@(posedge clk_i) (!reg_load_i[i] && AxiReadOnly[i] |=> $stable(reg_q_o[i])))
           else $fatal(1, "Read-only register at `byte_index: %0d` was changed by AXI!", i);
     end
+  `endif
   `endif
   // pragma translate_on
 endmodule

--- a/src/axi_lite_xbar.sv
+++ b/src/axi_lite_xbar.sv
@@ -114,6 +114,7 @@ module axi_lite_xbar #(
     // make sure that the default slave does not get changed, if there is an unserved Ax
     // pragma translate_off
     `ifndef VERILATOR
+    `ifndef XSIM
     default disable iff (~rst_ni);
     default_aw_mst_port_en: assert property(
       @(posedge clk_i) (slv_ports_req_i[i].aw_valid && !slv_ports_resp_o[i].aw_ready)
@@ -135,6 +136,7 @@ module axi_lite_xbar #(
           |=> $stable(default_mst_port_i[i]))
         else $fatal (1, $sformatf("It is not allowed to change the default mst port\
                                    when there is an unserved Ar beat. Slave Port: %0d", i));
+    `endif
     `endif
     // pragma translate_on
     axi_lite_demux #(

--- a/src/axi_serializer.sv
+++ b/src/axi_serializer.sv
@@ -197,6 +197,7 @@ module axi_serializer #(
     assert (MaxWriteTxns  >= 1)
       else $fatal(1, "Maximum number of write transactions must be >= 1!");
   end
+`ifndef XSIM
   default disable iff (~rst_ni);
   aw_lost : assert property( @(posedge clk_i)
       (slv_req_i.aw_valid & slv_resp_o.aw_ready |-> mst_req_o.aw_valid & mst_resp_i.aw_ready))
@@ -213,6 +214,7 @@ module axi_serializer #(
   r_lost :  assert property( @(posedge clk_i)
       (mst_resp_i.r_valid & mst_req_o.r_ready |-> slv_resp_o.r_valid & slv_req_i.r_ready))
     else $error("R beat lost.");
+`endif
 `endif
 // pragma translate_on
 endmodule

--- a/src/axi_to_detailed_mem.sv
+++ b/src/axi_to_detailed_mem.sv
@@ -567,6 +567,7 @@ module axi_to_detailed_mem #(
   // Assertions
   // pragma translate_off
   `ifndef VERILATOR
+  `ifndef XSIM
   default disable iff (!rst_ni);
   assume property (@(posedge clk_i)
       axi_req_i.ar_valid && !axi_resp_o.ar_ready |=> $stable(axi_req_i.ar))
@@ -591,6 +592,7 @@ module axi_to_detailed_mem #(
     else $error("Non-incrementing bursts are not supported!");
   assert property (@(posedge clk_i) meta_valid && meta.atop != '0 |-> meta.write)
     else $warning("Unexpected atomic operation on read.");
+  `endif
   `endif
   // pragma translate_on
 endmodule


### PR DESCRIPTION
Some files already have the XSIM ifndef to remove the `default disable` blocks (https://github.com/pulp-platform/axi/blob/master/src/axi_xbar_unmuxed.sv), which are not supported by XSIM. This MR completes this task to make all files consistent, and ensuring they can be simulated with Vivado. 