### PR TITLE
axi_id_prepend: Fix implicit conversion linter warning

### DIFF
--- a/src/axi_id_prepend.sv
+++ b/src/axi_id_prepend.sv
@@ -84,16 +84,16 @@ module axi_id_prepend #(
       assign mst_ar_chans_o[i] = slv_ar_chans_i[i];
     end else begin : gen_prepend
       always_comb begin
-        mst_aw_chans_o[i] = slv_aw_chans_i[i];
-        mst_ar_chans_o[i] = slv_ar_chans_i[i];
+        mst_aw_chans_o[i] = mst_aw_chan_t'(slv_aw_chans_i[i]);
+        mst_ar_chans_o[i] = mst_ar_chan_t'(slv_ar_chans_i[i]);
         mst_aw_chans_o[i].id = {pre_id_i, slv_aw_chans_i[i].id[AxiIdWidthSlvPort-1:0]};
         mst_ar_chans_o[i].id = {pre_id_i, slv_ar_chans_i[i].id[AxiIdWidthSlvPort-1:0]};
       end
     end
     // The ID is in the highest bits of the struct, so an assignment from a channel with a wide ID
     // to a channel with a shorter ID correctly cuts the prepended ID.
-    assign slv_b_chans_o[i] = mst_b_chans_i[i];
-    assign slv_r_chans_o[i] = mst_r_chans_i[i];
+    assign slv_b_chans_o[i] = slv_b_chan_t'(mst_b_chans_i[i]);
+    assign slv_r_chans_o[i] = slv_r_chan_t'(mst_r_chans_i[i]);
   end
 
   // assign the handshaking's and w channel


### PR DESCRIPTION
Slang thinks the implicit conversion on assignment does not spark joy, only explicit conversion sparks joy.