### PR TITLE
src: axi_fifo_delay_dyn: Fix incorrect power-of-two check for `Depth` parameter

### DIFF
--- a/src/axi_fifo_delay_dyn.sv
+++ b/src/axi_fifo_delay_dyn.sv
@@ -283,7 +283,7 @@ module stream_fifo_delay_dyn #(
   `endif
   `endif
 
-  if (Depth & (Depth - 1) == 0)
+  if ((Depth & (Depth - 1)) != 0)
     $fatal(1, "Depth must be a power of two");
 
   localparam int unsigned BookeepingBits = $clog2(Depth) + 1;

--- a/src/axi_fifo_delay_dyn.sv
+++ b/src/axi_fifo_delay_dyn.sv
@@ -283,7 +283,7 @@ module stream_fifo_delay_dyn #(
   `endif
   `endif
 
-  if ((Depth & (Depth - 1)) != 0)
+  if (Depth == 0 || (Depth & (Depth - 1)) != 0)
     $fatal(1, "Depth must be a power of two");
 
   localparam int unsigned BookeepingBits = $clog2(Depth) + 1;


### PR DESCRIPTION
The `axi_fifo_delay_dyn` module's parameter constraint checker incorrectly identified valid `Depth` values as not being a power of two.

This commit corrects the logic to accurately verify that the `Depth` parameter is a power of two.