### PR TITLE
`axi_xbar`: Remove redundant assertions

### DIFF
--- a/src/axi_xbar.sv
+++ b/src/axi_xbar.sv
@@ -154,18 +154,6 @@ import cf_math_pkg::idx_width;
     );
   end
 
-  // pragma translate_off
-  `ifndef VERILATOR
-  `ifndef XSIM
-  initial begin : check_params
-    id_slv_req_ports: assert ($bits(slv_ports_req_i[0].aw.id ) == Cfg.AxiIdWidthSlvPorts) else
-      $fatal(1, $sformatf("Slv_req and aw_chan id width not equal."));
-    id_slv_resp_ports: assert ($bits(slv_ports_resp_o[0].r.id) == Cfg.AxiIdWidthSlvPorts) else
-      $fatal(1, $sformatf("Slv_req and aw_chan id width not equal."));
-  end
-  `endif
-  `endif
-  // pragma translate_on
 endmodule
 
 `include "axi/assign.svh"


### PR DESCRIPTION
The same assertions can be found within `axi_xbar_unmuxed`:
https://github.com/pulp-platform/axi/blob/814b00076cb4439c541191f793d6630e1d219bd5/src/axi_xbar_unmuxed.sv#L256-L267
So these are redundant:
 https://github.com/pulp-platform/axi/blob/814b00076cb4439c541191f793d6630e1d219bd5/src/axi_xbar.sv#L157-L168