### PR TITLE
`axi_mux`: Remove dependency of ready on valid

### DIFF
--- a/src/axi_mux.sv
+++ b/src/axi_mux.sv
@@ -296,17 +296,23 @@ module axi_mux #(
           aw_ready        = 1'b1;
           lock_aw_valid_d = 1'b0;
           load_aw_lock    = 1'b1;
+          w_fifo_push     = 1'b1;
         end
       end else begin
-        if (!w_fifo_full && aw_valid) begin
-          mst_aw_valid = 1'b1;
-          w_fifo_push = 1'b1;
+        if (!w_fifo_full) begin
           if (mst_aw_ready) begin
             aw_ready = 1'b1;
-          end else begin
-            // go to lock if transaction not in this cycle
-            lock_aw_valid_d = 1'b1;
-            load_aw_lock    = 1'b1;
+          end
+          if (aw_valid) begin
+            mst_aw_valid = 1'b1;
+            if (!mst_aw_ready) begin
+              // go to lock if transaction not in this cycle
+              lock_aw_valid_d = 1'b1;
+              load_aw_lock    = 1'b1;
+              // remember if it was a unicast transaction
+            end else begin
+              w_fifo_push = 1'b1;
+            end
           end
         end
       end


### PR DESCRIPTION
This change was originally introduced in https://github.com/pulp-platform/axi/pull/398, though it may no longer be strictly required.

However, when this is possible, it is in general good to remove dependencies of `aw_ready` on `aw_valid`, as the dependency creates paths that are double in length, for de-asserting valid (from subordinate->manager to manager->subordinate->manager).

This PR further changes the condition which determines when the AW channel (or the arbitration outcome carried within it) is pushed into the W FIFO.
Instead of pushing it as soon as there is a valid AW, it only pushes when the AW is handshaked.
I don't know if there was a specific reason for this to be implemented as it was, but from what I understand this change shouldn't have any relevant performance implications, and is in my opinion safer.

Probably we could also decouple ready and valid, while reverting the `w_fifo_push` change, if needed. But, it would remain to be tested whether this would work with multicast.