### PR TITLE
Add `DECL` macros to be used in parameter port list

### DIFF
--- a/include/axi/typedef.svh
+++ b/include/axi/typedef.svh
@@ -14,6 +14,7 @@
 // - Thomas Benz <tbenz@iis.ee.ethz.ch>
 // - Florian Zaruba <zarubaf@iis.ee.ethz.ch>
 // - Wolfgang Roenninger <wroennin@iis.ee.ethz.ch>
+// - Riccardo Tedeschi <riccardo.tedeschi6@unibo.it>
 
 // Macros to define AXI and AXI-Lite Channel and Request/Response Structs
 
@@ -31,77 +32,91 @@
 // `AXI_TYPEDEF_R_CHAN_T(axi_r_t, axi_data_t, axi_id_t, axi_user_t)
 // `AXI_TYPEDEF_REQ_T(axi_req_t, axi_aw_t, axi_w_t, axi_ar_t)
 // `AXI_TYPEDEF_RESP_T(axi_resp_t, axi_b_t, axi_r_t)
-`define AXI_TYPEDEF_AW_CHAN_T(aw_chan_t, addr_t, id_t, user_t)  \
-  typedef struct packed {                                       \
-    id_t              id;                                       \
-    addr_t            addr;                                     \
-    axi_pkg::len_t    len;                                      \
-    axi_pkg::size_t   size;                                     \
-    axi_pkg::burst_t  burst;                                    \
-    logic             lock;                                     \
-    axi_pkg::cache_t  cache;                                    \
-    axi_pkg::prot_t   prot;                                     \
-    axi_pkg::qos_t    qos;                                      \
-    axi_pkg::region_t region;                                   \
-    axi_pkg::atop_t   atop;                                     \
-    user_t            user;                                     \
-  } aw_chan_t;
+`define AXI_DECL_AW_CHAN_T(addr_t, id_t, user_t) \
+  struct packed {                                \
+    id_t              id;                        \
+    addr_t            addr;                      \
+    axi_pkg::len_t    len;                       \
+    axi_pkg::size_t   size;                      \
+    axi_pkg::burst_t  burst;                     \
+    logic             lock;                      \
+    axi_pkg::cache_t  cache;                     \
+    axi_pkg::prot_t   prot;                      \
+    axi_pkg::qos_t    qos;                       \
+    axi_pkg::region_t region;                    \
+    axi_pkg::atop_t   atop;                      \
+    user_t            user;                      \
+  }
+`define AXI_TYPEDEF_AW_CHAN_T(aw_chan_t, addr_t, id_t, user_t) \
+  typedef `AXI_DECL_AW_CHAN_T(addr_t, id_t, user_t) aw_chan_t;
+`define AXI_DECL_W_CHAN_T(data_t, strb_t, user_t)  \
+  struct packed {                                  \
+    data_t data;                                   \
+    strb_t strb;                                   \
+    logic  last;                                   \
+    user_t user;                                   \
+  }
 `define AXI_TYPEDEF_W_CHAN_T(w_chan_t, data_t, strb_t, user_t)  \
-  typedef struct packed {                                       \
-    data_t data;                                                \
-    strb_t strb;                                                \
-    logic  last;                                                \
-    user_t user;                                                \
-  } w_chan_t;
+  typedef `AXI_DECL_W_CHAN_T(data_t, strb_t, user_t) w_chan_t;
+`define AXI_DECL_B_CHAN_T(id_t, user_t)  \
+  struct packed {                        \
+    id_t            id;                  \
+    axi_pkg::resp_t resp;                \
+    user_t          user;                \
+  }
 `define AXI_TYPEDEF_B_CHAN_T(b_chan_t, id_t, user_t)  \
-  typedef struct packed {                             \
-    id_t            id;                               \
-    axi_pkg::resp_t resp;                             \
-    user_t          user;                             \
-  } b_chan_t;
+  typedef `AXI_DECL_B_CHAN_T(id_t, user_t) b_chan_t;
+`define AXI_DECL_AR_CHAN_T(addr_t, id_t, user_t) \
+  struct packed {                                \
+    id_t              id;                        \
+    addr_t            addr;                      \
+    axi_pkg::len_t    len;                       \
+    axi_pkg::size_t   size;                      \
+    axi_pkg::burst_t  burst;                     \
+    logic             lock;                      \
+    axi_pkg::cache_t  cache;                     \
+    axi_pkg::prot_t   prot;                      \
+    axi_pkg::qos_t    qos;                       \
+    axi_pkg::region_t region;                    \
+    user_t            user;                      \
+  }
 `define AXI_TYPEDEF_AR_CHAN_T(ar_chan_t, addr_t, id_t, user_t)  \
-  typedef struct packed {                                       \
-    id_t              id;                                       \
-    addr_t            addr;                                     \
-    axi_pkg::len_t    len;                                      \
-    axi_pkg::size_t   size;                                     \
-    axi_pkg::burst_t  burst;                                    \
-    logic             lock;                                     \
-    axi_pkg::cache_t  cache;                                    \
-    axi_pkg::prot_t   prot;                                     \
-    axi_pkg::qos_t    qos;                                      \
-    axi_pkg::region_t region;                                   \
-    user_t            user;                                     \
-  } ar_chan_t;
-`define AXI_TYPEDEF_R_CHAN_T(r_chan_t, data_t, id_t, user_t)  \
-  typedef struct packed {                                     \
-    id_t            id;                                       \
-    data_t          data;                                     \
-    axi_pkg::resp_t resp;                                     \
-    logic           last;                                     \
-    user_t          user;                                     \
-  } r_chan_t;
+  typedef `AXI_DECL_AR_CHAN_T(addr_t, id_t, user_t) ar_chan_t;
+`define AXI_DECL_R_CHAN_T(data_t, id_t, user_t)  \
+  struct packed {                                \
+    id_t            id;                          \
+    data_t          data;                        \
+    axi_pkg::resp_t resp;                        \
+    logic           last;                        \
+    user_t          user;                        \
+  }
+`define AXI_TYPEDEF_R_CHAN_T(r_chan_t, data_t, id_t, user_t) \
+  typedef `AXI_DECL_R_CHAN_T(data_t, id_t, user_t) r_chan_t;
+`define AXI_DECL_REQ_T(aw_chan_t, w_chan_t, ar_chan_t)  \
+  struct packed {                                       \
+    aw_chan_t aw;                                       \
+    logic     aw_valid;                                 \
+    w_chan_t  w;                                        \
+    logic     w_valid;                                  \
+    logic     b_ready;                                  \
+    ar_chan_t ar;                                       \
+    logic     ar_valid;                                 \
+    logic     r_ready;                                  \
+  }
 `define AXI_TYPEDEF_REQ_T(req_t, aw_chan_t, w_chan_t, ar_chan_t)  \
-  typedef struct packed {                                         \
-    aw_chan_t aw;                                                 \
-    logic     aw_valid;                                           \
-    w_chan_t  w;                                                  \
-    logic     w_valid;                                            \
-    logic     b_ready;                                            \
-    ar_chan_t ar;                                                 \
-    logic     ar_valid;                                           \
-    logic     r_ready;                                            \
-  } req_t;
+  typedef `AXI_DECL_REQ_T(aw_chan_t, w_chan_t, ar_chan_t) req_t;
+`define AXI_DECL_RESP_T(b_chan_t, r_chan_t)  \
+  struct packed {                            \
+    logic     aw_ready;                      \
+    logic     ar_ready;                      \
+    logic     w_ready;                       \
+    logic     b_valid;                       \
+    b_chan_t  b;                             \
+    logic     r_valid;                       \
+    r_chan_t  r;                             \
+  }
 `define AXI_TYPEDEF_RESP_T(resp_t, b_chan_t, r_chan_t)  \
-  typedef struct packed {                               \
-    logic     aw_ready;                                 \
-    logic     ar_ready;                                 \
-    logic     w_ready;                                  \
-    logic     b_valid;                                  \
-    b_chan_t  b;                                        \
-    logic     r_valid;                                  \
-    r_chan_t  r;                                        \
-  } resp_t;
+  typedef `AXI_DECL_RESP_T(b_chan_t, r_chan_t) resp_t;
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
@@ -154,51 +169,65 @@
 // `AXI_LITE_TYPEDEF_R_CHAN_T(axi_lite_r_t, axi_lite_data_t)
 // `AXI_LITE_TYPEDEF_REQ_T(axi_lite_req_t, axi_lite_aw_t, axi_lite_w_t, axi_lite_ar_t)
 // `AXI_LITE_TYPEDEF_RESP_T(axi_lite_resp_t, axi_lite_b_t, axi_lite_r_t)
+`define AXI_LITE_DECL_AW_CHAN_T(addr_t)  \
+  struct packed {                        \
+    addr_t          addr;                \
+    axi_pkg::prot_t prot;                \
+  }
 `define AXI_LITE_TYPEDEF_AW_CHAN_T(aw_chan_lite_t, addr_t)  \
-  typedef struct packed {                                   \
-    addr_t          addr;                                   \
-    axi_pkg::prot_t prot;                                   \
-  } aw_chan_lite_t;
+  typedef `AXI_LITE_DECL_AW_CHAN_T(addr_t) aw_chan_lite_t;
+`define AXI_LITE_DECL_W_CHAN_T(data_t, strb_t)  \
+  struct packed {                               \
+    data_t   data;                              \
+    strb_t   strb;                              \
+  }
 `define AXI_LITE_TYPEDEF_W_CHAN_T(w_chan_lite_t, data_t, strb_t)  \
-  typedef struct packed {                                         \
-    data_t   data;                                                \
-    strb_t   strb;                                                \
-  } w_chan_lite_t;
+  typedef `AXI_LITE_DECL_W_CHAN_T(data_t, strb_t) w_chan_lite_t;
+`define AXI_LITE_DECL_B_CHAN_T     \
+  struct packed {                  \
+    axi_pkg::resp_t resp;          \
+  }
 `define AXI_LITE_TYPEDEF_B_CHAN_T(b_chan_lite_t)  \
-  typedef struct packed {                         \
-    axi_pkg::resp_t resp;                         \
-  } b_chan_lite_t;
+  typedef `AXI_LITE_DECL_B_CHAN_T   b_chan_lite_t;
+`define AXI_LITE_DECL_AR_CHAN_T(addr_t)  \
+  struct packed {                        \
+    addr_t          addr;                \
+    axi_pkg::prot_t prot;                \
+  }
 `define AXI_LITE_TYPEDEF_AR_CHAN_T(ar_chan_lite_t, addr_t)  \
-  typedef struct packed {                                   \
-    addr_t          addr;                                   \
-    axi_pkg::prot_t prot;                                   \
-  } ar_chan_lite_t;
+  typedef `AXI_LITE_DECL_AR_CHAN_T(addr_t) ar_chan_lite_t;
+`define AXI_LITE_DECL_R_CHAN_T(data_t)  \
+  struct packed {                       \
+    data_t          data;               \
+    axi_pkg::resp_t resp;               \
+  }
 `define AXI_LITE_TYPEDEF_R_CHAN_T(r_chan_lite_t, data_t)  \
-  typedef struct packed {                                 \
-    data_t          data;                                 \
-    axi_pkg::resp_t resp;                                 \
-  } r_chan_lite_t;
+  typedef `AXI_LITE_DECL_R_CHAN_T(data_t) r_chan_lite_t;
+`define AXI_LITE_DECL_REQ_T(aw_chan_lite_t, w_chan_lite_t, ar_chan_lite_t)  \
+  struct packed {                                                           \
+    aw_chan_lite_t aw;                                                      \
+    logic          aw_valid;                                                \
+    w_chan_lite_t  w;                                                       \
+    logic          w_valid;                                                 \
+    logic          b_ready;                                                 \
+    ar_chan_lite_t ar;                                                      \
+    logic          ar_valid;                                                \
+    logic          r_ready;                                                 \
+  }
 `define AXI_LITE_TYPEDEF_REQ_T(req_lite_t, aw_chan_lite_t, w_chan_lite_t, ar_chan_lite_t)  \
-  typedef struct packed {                                                                  \
-    aw_chan_lite_t aw;                                                                     \
-    logic          aw_valid;                                                               \
-    w_chan_lite_t  w;                                                                      \
-    logic          w_valid;                                                                \
-    logic          b_ready;                                                                \
-    ar_chan_lite_t ar;                                                                     \
-    logic          ar_valid;                                                               \
-    logic          r_ready;                                                                \
-  } req_lite_t;
+  typedef `AXI_LITE_DECL_REQ_T(aw_chan_lite_t, w_chan_lite_t, ar_chan_lite_t) req_lite_t;
+`define AXI_LITE_DECL_RESP_T(b_chan_lite_t, r_chan_lite_t)  \
+  struct packed {                                           \
+    logic          aw_ready;                                \
+    logic          w_ready;                                 \
+    b_chan_lite_t  b;                                       \
+    logic          b_valid;                                 \
+    logic          ar_ready;                                \
+    r_chan_lite_t  r;                                       \
+    logic          r_valid;                                 \
+  }
 `define AXI_LITE_TYPEDEF_RESP_T(resp_lite_t, b_chan_lite_t, r_chan_lite_t)  \
-  typedef struct packed {                                                   \
-    logic          aw_ready;                                                \
-    logic          w_ready;                                                 \
-    b_chan_lite_t  b;                                                       \
-    logic          b_valid;                                                 \
-    logic          ar_ready;                                                \
-    r_chan_lite_t  r;                                                       \
-    logic          r_valid;                                                 \
-  } resp_lite_t;
+  typedef `AXI_LITE_DECL_RESP_T(b_chan_lite_t, r_chan_lite_t) resp_lite_t;
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
@@ -240,6 +269,5 @@
 `define AXI_LITE_TYPEDEF_ALL(__name, __addr_t, __data_t, __strb_t)                                \
   `AXI_LITE_TYPEDEF_ALL_CT(__name, __name``_req_t, __name``_resp_t, __addr_t, __data_t, __strb_t)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-
 
 `endif


### PR DESCRIPTION
We can split the `TYPDEF` macro into `TYPEDEF` (backward compatible to define a new type) and `DECL` (to be used for `type` parameters), as done [here](https://github.com/openhwgroup/cv-hpdcache/blob/master/rtl/include/hpdcache_typedef.svh). These macros are particularly useful e.g. for synthesis wrappers or for sane type parameters defaults.