### PR TITLE
use XILINX_SIMULATOR define to remove all default disable blocks

### DIFF
--- a/src/axi_burst_splitter_gran.sv
+++ b/src/axi_burst_splitter_gran.sv
@@ -396,6 +396,7 @@ module axi_burst_splitter_gran #(
   // --------------------------------------------------
   `ifndef VERILATOR
   `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   // pragma translate_off
   default disable iff (!rst_ni);
   // Inputs
@@ -412,6 +413,7 @@ module axi_burst_splitter_gran #(
   assert property (@(posedge clk_i) mst_req_o.ar_valid |-> mst_req_o.ar.len <= len_limit_i)
     else $fatal(1, "AR burst longer than a single beat emitted!");
   // pragma translate_on
+  `endif
   `endif
   `endif
 

--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -365,6 +365,7 @@ module axi_burst_unwrap #(
   // --------------------------------------------------
   `ifndef VERILATOR
   `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   // pragma translate_off
   default disable iff (!rst_ni);
   // Inputs
@@ -379,6 +380,7 @@ module axi_burst_unwrap #(
     ) else $fatal(1, "Unsupported ATOP that gives rise to a R response received,\
                       cannot respond in protocol-compliant manner!");
   // pragma translate_on
+  `endif
   `endif
   `endif
 

--- a/src/axi_demux_id_counters.sv
+++ b/src/axi_demux_id_counters.sv
@@ -133,11 +133,13 @@ module axi_demux_id_counters #(
 // pragma translate_off
 `ifndef VERILATOR
 `ifndef XSIM
+`ifndef XILINX_SIMULATOR
     // Validate parameters.
     cnt_underflow: assert property(
       @(posedge clk_i) disable iff (~rst_ni) (pop_en[i] |=> !overflow)) else
         $fatal(1, "axi_demux_id_counters > Counter: %0d underflowed.\
                    The reason is probably a faulty AXI response.", i);
+`endif
 `endif
 `endif
 // pragma translate_on

--- a/src/axi_demux_simple.sv
+++ b/src/axi_demux_simple.sv
@@ -469,6 +469,7 @@ module axi_demux_simple #(
         $fatal(1, "AxiIdBits has to be equal or smaller than AxiIdWidth.");
     end
 `ifndef XSIM
+`ifndef XILINX_SIMULATOR
     default disable iff (!rst_ni);
     aw_select: assume property( @(posedge clk_i) (slv_req_i.aw_valid |->
                                                  (slv_aw_select_i < NoMstPorts))) else
@@ -505,6 +506,7 @@ module axi_demux_simple #(
         ((w_open == '0) && (w_cnt_up ^ w_cnt_down) |-> !w_cnt_down)) else
         $fatal(1, "W counter underflowed!");
     `ASSUME(NoAtopAllowed, !AtopSupport && slv_req_i.aw_valid |-> slv_req_i.aw.atop == '0)
+`endif
 `endif
 `endif
 // pragma translate_on

--- a/src/axi_err_slv.sv
+++ b/src/axi_err_slv.sv
@@ -249,11 +249,13 @@ module axi_err_slv #(
       $fatal(1, "This module may only generate RESP_DECERR or RESP_SLVERR responses!");
   end
   `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   default disable iff (!rst_ni);
   if (!ATOPs) begin : gen_assert_atops_unsupported
     assume property( @(posedge clk_i) (slv_req_i.aw_valid |-> slv_req_i.aw.atop == '0)) else
      $fatal(1, "Got ATOP but not configured to support ATOPs!");
   end
+  `endif
   `endif
   `endif
   // pragma translate_on

--- a/src/axi_id_remap.sv
+++ b/src/axi_id_remap.sv
@@ -383,6 +383,7 @@ module axi_id_remap #(
     assert ($bits(mst_resp_i.r.id) == AxiMstPortIdWidth);
   end
   `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   default disable iff (!rst_ni);
   assert property (@(posedge clk_i) slv_req_i.aw_valid && slv_resp_o.aw_ready
       |-> mst_req_o.aw_valid && mst_resp_i.aw_ready);
@@ -398,6 +399,7 @@ module axi_id_remap #(
       |=> mst_req_o.ar_valid && $stable(mst_req_o.ar.id));
   assert property (@(posedge clk_i) mst_req_o.aw_valid && !mst_resp_i.aw_ready
       |=> mst_req_o.aw_valid && $stable(mst_req_o.aw.id));
+  `endif
   `endif
   `endif
   // pragma translate_on
@@ -555,6 +557,7 @@ module axi_id_remap_table #(
   // pragma translate_off
   `ifndef VERILATOR
   `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
     default disable iff (!rst_ni);
     assume property (@(posedge clk_i) push_i |->
         table_q[push_oup_id_i].cnt == '0 || table_q[push_oup_id_i].inp_id == push_inp_id_i)
@@ -572,6 +575,7 @@ module axi_id_remap_table #(
       assert (MaxTxnsPerId > 0);
       assert (IdxWidth >= 1);
     end
+  `endif
   `endif
   `endif
   // pragma translate_on

--- a/src/axi_interleaved_xbar.sv
+++ b/src/axi_interleaved_xbar.sv
@@ -164,6 +164,7 @@ import cf_math_pkg::idx_width;
     // pragma translate_off
     `ifndef VERILATOR
     `ifndef XSIM
+    `ifndef XILINX_SIMULATOR
     default disable iff (~rst_ni);
     default_aw_mst_port_en: assert property(
       @(posedge clk_i) (slv_ports_req_i[i].aw_valid && !slv_ports_resp_o[i].aw_ready)
@@ -185,6 +186,7 @@ import cf_math_pkg::idx_width;
           |=> $stable(default_mst_port_i[i]))
         else $fatal (1, $sformatf({"It is not allowed to change the default mst port",
                                    "when there is an unserved Ar beat. Slave Port: %0d"}, i));
+    `endif
     `endif
     `endif
     // pragma translate_on
@@ -303,12 +305,14 @@ import cf_math_pkg::idx_width;
   // pragma translate_off
   `ifndef VERILATOR
   `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   initial begin : check_params
     id_slv_req_ports: assert ($bits(slv_ports_req_i[0].aw.id ) == Cfg.AxiIdWidthSlvPorts) else
       $fatal(1, $sformatf("Slv_req and aw_chan id width not equal."));
     id_slv_resp_ports: assert ($bits(slv_ports_resp_o[0].r.id) == Cfg.AxiIdWidthSlvPorts) else
       $fatal(1, $sformatf("Slv_req and aw_chan id width not equal."));
   end
+  `endif
   `endif
   `endif
   // pragma translate_on

--- a/src/axi_isolate.sv
+++ b/src/axi_isolate.sv
@@ -393,6 +393,7 @@ module axi_isolate_inner #(
     assume (NumPending > 0) else $fatal(1, "At least one pending transaction required.");
   end
 `ifndef XSIM
+`ifndef XILINX_SIMULATOR
   default disable iff (!rst_ni);
   aw_overflow: assert property (@(posedge clk_i)
       (pending_aw_q == '1) |=> (pending_aw_q != '0)) else
@@ -406,6 +407,7 @@ module axi_isolate_inner #(
   ar_underflow: assert property (@(posedge clk_i)
       (pending_ar_q == '0) |=> (pending_ar_q != '1)) else
       $fatal(1, "pending_ar_q underflowed");
+`endif
 `endif
 `endif
 // pragma translate_on

--- a/src/axi_lite_demux.sv
+++ b/src/axi_lite_demux.sv
@@ -443,6 +443,7 @@ module axi_lite_demux #(
     // pragma translate_off
     `ifndef VERILATOR
     `ifndef XSIM
+    `ifndef XILINX_SIMULATOR
     default disable iff (!rst_ni);
     aw_select: assume property( @(posedge clk_i) (slv_req_i.aw_valid |->
                                                  (slv_aw_select_i < NoMstPorts))) else
@@ -464,6 +465,7 @@ module axi_lite_demux #(
     ar_stable: assert property( @(posedge clk_i) (slv_ar_valid && !slv_ar_ready)
                                |=> $stable(slv_ar_chan)) else
       $fatal(1, "slv_aw_chan_select unstable with valid set.");
+    `endif
     `endif
     `endif
     // pragma translate_on

--- a/src/axi_lite_dw_converter.sv
+++ b/src/axi_lite_dw_converter.sv
@@ -465,6 +465,7 @@ module axi_lite_dw_converter #(
     assume ($onehot(AxiMstPortDataWidth)) else $fatal(1, "AxiMstPortDataWidth must be power of 2");
   end
   `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   default disable iff (~rst_ni);
   stable_aw: assert property (@(posedge clk_i)
       (mst_req_o.aw_valid && !mst_res_i.aw_ready) |=> $stable(mst_req_o.aw)) else
@@ -481,6 +482,7 @@ module axi_lite_dw_converter #(
   stable_r:  assert property (@(posedge clk_i)
       (slv_res_o.r_valid  && !slv_req_i.r_ready)  |=> $stable(slv_res_o.r)) else
       $fatal(1, "R must remain stable until handshake happened.");
+  `endif
   `endif
   `endif
   // pragma translate_on

--- a/src/axi_lite_from_mem.sv
+++ b/src/axi_lite_from_mem.sv
@@ -236,6 +236,7 @@ module axi_lite_from_mem #(
           $fatal(1, "DataWidth has to match axi_rsp_i.r.data!");
     end
   `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
     default disable iff (~rst_ni);
     assert property (@(posedge clk_i) (mem_req_i && !mem_gnt_o) |=> mem_req_i) else
         $fatal(1, "It is not allowed to deassert the request if it was not granted!");
@@ -247,6 +248,7 @@ module axi_lite_from_mem #(
         $fatal(1, "mem_wdata_i has to be stable if request is not granted!");
     assert property (@(posedge clk_i) (mem_req_i && !mem_gnt_o) |=> $stable(mem_be_i)) else
         $fatal(1, "mem_be_i has to be stable if request is not granted!");
+  `endif
   `endif
   `endif
   `endif

--- a/src/axi_lite_regs.sv
+++ b/src/axi_lite_regs.sv
@@ -381,6 +381,7 @@ module axi_lite_regs #(
   // pragma translate_off
   `ifndef VERILATOR
   `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
     initial begin: p_assertions
       assert (RegNumBytes > 32'd0) else
           $fatal(1, "The number of bytes must be at least 1!");
@@ -402,6 +403,7 @@ module axi_lite_regs #(
       assert property (@(posedge clk_i) (!reg_load_i[i] && AxiReadOnly[i] |=> $stable(reg_q_o[i])))
           else $fatal(1, "Read-only register at `byte_index: %0d` was changed by AXI!", i);
     end
+  `endif
   `endif
   `endif
   // pragma translate_on

--- a/src/axi_lite_xbar.sv
+++ b/src/axi_lite_xbar.sv
@@ -115,6 +115,7 @@ module axi_lite_xbar #(
     // pragma translate_off
     `ifndef VERILATOR
     `ifndef XSIM
+    `ifndef XILINX_SIMULATOR
     default disable iff (~rst_ni);
     default_aw_mst_port_en: assert property(
       @(posedge clk_i) (slv_ports_req_i[i].aw_valid && !slv_ports_resp_o[i].aw_ready)
@@ -136,6 +137,7 @@ module axi_lite_xbar #(
           |=> $stable(default_mst_port_i[i]))
         else $fatal (1, $sformatf("It is not allowed to change the default mst port\
                                    when there is an unserved Ar beat. Slave Port: %0d", i));
+    `endif
     `endif
     `endif
     // pragma translate_on

--- a/src/axi_serializer.sv
+++ b/src/axi_serializer.sv
@@ -198,6 +198,7 @@ module axi_serializer #(
       else $fatal(1, "Maximum number of write transactions must be >= 1!");
   end
 `ifndef XSIM
+`ifndef XILINX_SIMULATOR
   default disable iff (~rst_ni);
   aw_lost : assert property( @(posedge clk_i)
       (slv_req_i.aw_valid & slv_resp_o.aw_ready |-> mst_req_o.aw_valid & mst_resp_i.aw_ready))
@@ -214,6 +215,7 @@ module axi_serializer #(
   r_lost :  assert property( @(posedge clk_i)
       (mst_resp_i.r_valid & mst_req_o.r_ready |-> slv_resp_o.r_valid & slv_req_i.r_ready))
     else $error("R beat lost.");
+`endif
 `endif
 `endif
 // pragma translate_on

--- a/src/axi_to_detailed_mem.sv
+++ b/src/axi_to_detailed_mem.sv
@@ -568,6 +568,7 @@ module axi_to_detailed_mem #(
   // pragma translate_off
   `ifndef VERILATOR
   `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   default disable iff (!rst_ni);
   assume property (@(posedge clk_i)
       axi_req_i.ar_valid && !axi_resp_o.ar_ready |=> $stable(axi_req_i.ar))
@@ -592,6 +593,7 @@ module axi_to_detailed_mem #(
     else $error("Non-incrementing bursts are not supported!");
   assert property (@(posedge clk_i) meta_valid && meta.atop != '0 |-> meta.write)
     else $warning("Unexpected atomic operation on read.");
+  `endif
   `endif
   `endif
   // pragma translate_on

--- a/src/axi_xbar_unmuxed.sv
+++ b/src/axi_xbar_unmuxed.sv
@@ -137,6 +137,7 @@ import cf_math_pkg::idx_width;
     // pragma translate_off
     `ifndef VERILATOR
     `ifndef XSIM
+    `ifndef XILINX_SIMULATOR
     default disable iff (~rst_ni);
     default_aw_mst_port_en: assert property(
       @(posedge clk_i) (slv_ports_req_i[i].aw_valid && !slv_ports_resp_o[i].aw_ready)
@@ -158,6 +159,7 @@ import cf_math_pkg::idx_width;
           |=> $stable(default_mst_port_i[i]))
         else $fatal (1, $sformatf("It is not allowed to change the default mst port\
                                    when there is an unserved Ar beat. Slave Port: %0d", i));
+    `endif
     `endif
     `endif
     // pragma translate_on
@@ -256,12 +258,14 @@ import cf_math_pkg::idx_width;
   // pragma translate_off
   `ifndef VERILATOR
   `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   initial begin : check_params
     id_slv_req_ports: assert ($bits(slv_ports_req_i[0].aw.id ) == Cfg.AxiIdWidthSlvPorts) else
       $fatal(1, $sformatf("Slv_req and aw_chan id width not equal."));
     id_slv_resp_ports: assert ($bits(slv_ports_resp_o[0].r.id) == Cfg.AxiIdWidthSlvPorts) else
       $fatal(1, $sformatf("Slv_req and aw_chan id width not equal."));
   end
+  `endif
   `endif
   `endif
   // pragma translate_on


### PR DESCRIPTION
newer versions of Vivado (2024.2 in my case) use the `XILINX_SIMULATOR` define instead of `XSIM`

this extends #391.