### PR TITLE
treewide: Fix various lint issues

### DIFF
--- a/src/axi_burst_splitter_gran.sv
+++ b/src/axi_burst_splitter_gran.sv
@@ -698,7 +698,9 @@ module axi_burst_splitter_gran_counters #(
     .oup_req_i        ( cnt_req_i     ),
     .oup_data_o       ( cnt_r_idx     ),
     .oup_data_valid_o ( idq_oup_valid ),
-    .oup_gnt_o        ( idq_oup_gnt   )
+    .oup_gnt_o        ( idq_oup_gnt   ),
+    .full_o           (/* keep open */),
+    .empty_o          (/* keep open */)
   );
   assign idq_inp_req = alloc_req   & alloc_gnt;
   assign alloc_gnt   = idq_inp_gnt & |(cnt_free);

--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -616,7 +616,9 @@ module axi_burst_counters #(
     .oup_req_i        ( cnt_req_i     ),
     .oup_data_o       ( cnt_r_idx     ),
     .oup_data_valid_o ( idq_oup_valid ),
-    .oup_gnt_o        ( idq_oup_gnt   )
+    .oup_gnt_o        ( idq_oup_gnt   ),
+    .full_o           (/* keep open */),
+    .empty_o          (/* keep open */)
   );
   assign idq_inp_req = alloc_req_i & alloc_gnt_o;
   assign alloc_gnt_o = idq_inp_gnt & |(cnt_free);

--- a/src/axi_dw_downsizer.sv
+++ b/src/axi_dw_downsizer.sv
@@ -330,7 +330,9 @@ module axi_dw_downsizer #(
     .exists_mask_i   ('0              ),
     .exists_req_i    ('0              ),
     .exists_o        (/* Unused  */   ),
-    .exists_gnt_o    (/* Unused  */   )
+    .exists_gnt_o    (/* Unused  */   ),
+    .full_o          (/* Unused  */   ),
+    .empty_o         (/* Unused  */   )
   );
 
   for (genvar t = 0; unsigned'(t) < AxiMaxReads; t++) begin: gen_read_downsizer

--- a/src/axi_id_serialize.sv
+++ b/src/axi_id_serialize.sv
@@ -346,7 +346,7 @@ module axi_id_serialize #(
       else $fatal(1, "Not enought Id width on MST port to map all ID's.");
     assert(AxiSlvPortIdWidth > 32'd0)
       else $fatal(1, "Parameter AxiSlvPortIdWidth has to be larger than 0!");
-    assert(AxiMstPortIdWidth)
+    assert(AxiMstPortIdWidth > 32'd0)
       else $fatal(1, "Parameter AxiMstPortIdWidth has to be larger than 0!");
     assert(AxiMstPortIdWidth <= AxiSlvPortIdWidth)
       else $fatal(1, "Downsize implies that AxiMstPortIdWidth <= AxiSlvPortIdWidth!");

--- a/src/axi_lite_lfsr.sv
+++ b/src/axi_lite_lfsr.sv
@@ -172,6 +172,8 @@ module axi_opt_lfsr #(
 
     always_comb begin : gen_register
 
+        xnor_feedback = reg_q[XnorFeedback[MaxNumTabs-1]-1];
+
         // get the parameters
         case (Width)
             'd8     : XnorFeedback = { 'd8,    'd6,    'd5,    'd4    };
@@ -203,7 +205,6 @@ module axi_opt_lfsr #(
             reg_d[Width-1] = ser_data_i;
         // LFSR mode
         end else begin
-            xnor_feedback = reg_q[XnorFeedback[MaxNumTabs-1]-1];
             for (int unsigned t = 0; t < MaxNumTabs - 1; t++) begin : gen_feedback_path
                 xnor_feedback = xnor_feedback;
                 if (XnorFeedback[t] != 0) begin


### PR DESCRIPTION
This fixes
- an inferred latch in `axi_lite_lfsr`,
- an implicit int to bool conversion in `axi_id_serialize`,
- and missing ports of the `id_queue` module in `axi_burst_splitter_gran`, `axi_burst_unwrap`, `axi_dw_downsizer`.