### PR TITLE
tb_axi_xbar: Fix queue format specifier

### DIFF
--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -2142,7 +2142,7 @@ package axi_test;
                   $warning("Unexpected RData ID: %0h \n \
                             Addr:     %h \n \
                             Byte Idx: %h \n \
-                            Exp Data: %h \n \
+                            Exp Data: %p \n \
                             Act Data: %h \n \
                             BeatData: %h",
                   r_beat.r_id, beat_address+j, idx_data, exp_data, act_data, r_beat.r_data);


### PR DESCRIPTION
`exp_data` is a queue. To print its contents, the `%p` format specifier for unpacked aggregate types needs to be used instead of `%h`. Fixes a slang compilation error.