### PR TITLE
axi_to_detailed_mem: Parenthesize read active-bank mask

### DIFF
--- a/src/axi_to_detailed_mem.sv
+++ b/src/axi_to_detailed_mem.sv
@@ -505,8 +505,8 @@ module axi_to_detailed_mem #(
     // Set active write banks based on strobe
     assign meta_buf_bank_strb[i] = |meta_buf.strb[i*NumBytesPerBank +: NumBytesPerBank];
     // Set active read banks based on size and address offset: (bank.end > addr) && (bank.start < addr+size)
-    assign meta_buf_size_enable[i] = ((i*NumBytesPerBank + NumBytesPerBank) > (meta_buf.addr % DataWidth/8)) &&
-                                     ((i*NumBytesPerBank) < ((meta_buf.addr % DataWidth/8) + 1<<meta_buf.size));
+    assign meta_buf_size_enable[i] = ((i*NumBytesPerBank + NumBytesPerBank) > (meta_buf.addr % (DataWidth/8))) &&
+                                     ((i*NumBytesPerBank) < ((meta_buf.addr % (DataWidth/8)) + (1<<meta_buf.size)));
   end
   assign resp_b_err    = |(m2s_resp.err    &  meta_buf_bank_strb);   // Ensure only active banks are used (strobe)
   assign resp_b_exokay = &(m2s_resp.exokay | ~meta_buf_bank_strb) & meta_buf.lock;   // Ensure only active banks are used (strobe)


### PR DESCRIPTION
Claudio and I stumbled across the following:

### Problem

`meta_buf_size_enable` restricts the per-bank read-error reduction (`resp_r_err = |(m2s_resp.err & meta_buf_size_enable)`) to the banks actually covered by the access. Operator precedence broke its computation:

    meta_buf.addr % DataWidth/8   parses as  (meta_buf.addr % DataWidth) / 8
    ... + 1<<meta_buf.size        parses as  (... + 1) << meta_buf.size

instead of the intended `meta_buf.addr % (DataWidth/8)` and `... + (1<<meta_buf.size)`.

### Impact

The mask happens to be correct for beat-aligned reads but is wrong for sub-beat address offsets. Example: a 4-byte read of the last 32-bit register of a small register block over a 64-bit bus wrongly marks the upper bank as active. An over-read of the adjacent unmapped word (as emitted under devmode error reporting) then poisons the whole beat's `r.resp` with SLVERR.

### Fix

Parenthesize both sub-expressions: `% (DataWidth/8)` and `(1<<size)`.