### PR TITLE
docs: clarify data-width converters' burst-type support (INCR/WRAP/FI…

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ In addition to the documents linked in the following table, we are setting up [d
 | [`axi_xp`](src/axi_xp.sv)                                   | AXI Crosspoint (XP) with homomorphous slave and master ports.                                        |                                  |
 | [`axi_zero_mem`](src/axi_zero_mem.sv)                       | AXI-attached /dev/zero. All reads will be zero, writes are absorbed.                                 |                                  |
 
+> **Burst-type support of the data-width converters (`axi_dw_converter` / `axi_dw_downsizer` / `axi_dw_upsizer`).** These modules support `INCR` bursts of any length. `WRAP` bursts are **not** supported and are answered with `SLVERR`. `FIXED` bursts are supported **only when they consist of a single beat** (`axlen == 0`); a multi-beat `FIXED` burst is answered with `SLVERR`. Note that a single-beat `FIXED` transaction that requires downsizing is re-encoded as an `INCR` burst on the master (narrow) port — this is address-equivalent for one beat, but a downstream observer will see `INCR`, not `FIXED`.
+
 ## Synthesizable Verification Modules
 
 The following modules are meant to be used for verification purposes only but are synthesizable to be used in FPGA environments.


### PR DESCRIPTION
Closes #429.

Documentation-only: adds a note to the README module table making the data-width converters' burst-type support discoverable. Today it lives only in the SystemVerilog source headers, so a user first learns of it via an unexpected `SLVERR` or by seeing `FIXED` silently become `INCR` downstream.

The note covers all three DW modules (`axi_dw_converter` / `axi_dw_downsizer` / `axi_dw_upsizer`): `INCR` any length; `WRAP` -> `SLVERR`; `FIXED` single-beat only (`axlen == 0`), multi-beat `FIXED` -> `SLVERR`; a single-beat downsized `FIXED` is re-encoded as `INCR` on the master (narrow) port (address-equivalent for one beat, but a downstream observer sees `INCR`).

No RTL touched, no functional change. Placed after the module table so it renders intact; clean `git apply` at HEAD e55ae2a.