### PR TITLE
changed XSIM macro in XILINX_SIMULATOR

### DIFF
--- a/src/axi_burst_splitter_gran.sv
+++ b/src/axi_burst_splitter_gran.sv
@@ -395,7 +395,7 @@ module axi_burst_splitter_gran #(
   // Assumptions and assertions
   // --------------------------------------------------
   `ifndef VERILATOR
-  `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   // pragma translate_off
   default disable iff (!rst_ni);
   // Inputs

--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -364,7 +364,7 @@ module axi_burst_unwrap #(
   // Assumptions and assertions
   // --------------------------------------------------
   `ifndef VERILATOR
-  `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   // pragma translate_off
   default disable iff (!rst_ni);
   // Inputs

--- a/src/axi_demux_id_counters.sv
+++ b/src/axi_demux_id_counters.sv
@@ -132,7 +132,7 @@ module axi_demux_id_counters #(
 
 // pragma translate_off
 `ifndef VERILATOR
-`ifndef XSIM
+`ifndef XILINX_SIMULATOR
     // Validate parameters.
     cnt_underflow: assert property(
       @(posedge clk_i) disable iff (~rst_ni) (pop_en[i] |=> !overflow)) else

--- a/src/axi_demux_simple.sv
+++ b/src/axi_demux_simple.sv
@@ -468,7 +468,7 @@ module axi_demux_simple #(
       AXI_ID_BITS:  assume (AxiIdWidth >= AxiLookBits) else
         $fatal(1, "AxiIdBits has to be equal or smaller than AxiIdWidth.");
     end
-`ifndef XSIM
+`ifndef XILINX_SIMULATOR
     default disable iff (!rst_ni);
     aw_select: assume property( @(posedge clk_i) (slv_req_i.aw_valid |->
                                                  (slv_aw_select_i < NoMstPorts))) else

--- a/src/axi_err_slv.sv
+++ b/src/axi_err_slv.sv
@@ -248,7 +248,7 @@ module axi_err_slv #(
     assert (Resp == axi_pkg::RESP_DECERR || Resp == axi_pkg::RESP_SLVERR) else
       $fatal(1, "This module may only generate RESP_DECERR or RESP_SLVERR responses!");
   end
-  `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   default disable iff (!rst_ni);
   if (!ATOPs) begin : gen_assert_atops_unsupported
     assume property( @(posedge clk_i) (slv_req_i.aw_valid |-> slv_req_i.aw.atop == '0)) else

--- a/src/axi_id_remap.sv
+++ b/src/axi_id_remap.sv
@@ -452,7 +452,7 @@ module axi_id_remap #(
     assert ($bits(mst_req_o.ar.id) == AxiMstPortIdWidth);
     assert ($bits(mst_resp_i.r.id) == AxiMstPortIdWidth);
   end
-  `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   default disable iff (!rst_ni);
   assert property (@(posedge clk_i) slv_req_i.aw_valid && slv_resp_o.aw_ready
       |-> mst_req_o.aw_valid && mst_resp_i.aw_ready);
@@ -624,7 +624,7 @@ module axi_id_remap_table #(
   // Assertions
   // pragma translate_off
   `ifndef VERILATOR
-  `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
     default disable iff (!rst_ni);
     assume property (@(posedge clk_i) push_i |->
         table_q[push_oup_id_i].cnt == '0 || table_q[push_oup_id_i].inp_id == push_inp_id_i)

--- a/src/axi_interleaved_xbar.sv
+++ b/src/axi_interleaved_xbar.sv
@@ -163,7 +163,7 @@ import cf_math_pkg::idx_width;
     // make sure that the default slave does not get changed, if there is an unserved Ax
     // pragma translate_off
     `ifndef VERILATOR
-    `ifndef XSIM
+    `ifndef XILINX_SIMULATOR
     default disable iff (~rst_ni);
     default_aw_mst_port_en: assert property(
       @(posedge clk_i) (slv_ports_req_i[i].aw_valid && !slv_ports_resp_o[i].aw_ready)
@@ -302,7 +302,7 @@ import cf_math_pkg::idx_width;
 
   // pragma translate_off
   `ifndef VERILATOR
-  `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   initial begin : check_params
     id_slv_req_ports: assert ($bits(slv_ports_req_i[0].aw.id ) == Cfg.AxiIdWidthSlvPorts) else
       $fatal(1, $sformatf("Slv_req and aw_chan id width not equal."));

--- a/src/axi_isolate.sv
+++ b/src/axi_isolate.sv
@@ -392,7 +392,7 @@ module axi_isolate_inner #(
   initial begin
     assume (NumPending > 0) else $fatal(1, "At least one pending transaction required.");
   end
-`ifndef XSIM
+`ifndef XILINX_SIMULATOR
   default disable iff (!rst_ni);
   aw_overflow: assert property (@(posedge clk_i)
       (pending_aw_q == '1) |=> (pending_aw_q != '0)) else

--- a/src/axi_lite_demux.sv
+++ b/src/axi_lite_demux.sv
@@ -442,7 +442,7 @@ module axi_lite_demux #(
 
     // pragma translate_off
     `ifndef VERILATOR
-    `ifndef XSIM
+    `ifndef XILINX_SIMULATOR
     default disable iff (!rst_ni);
     aw_select: assume property( @(posedge clk_i) (slv_req_i.aw_valid |->
                                                  (slv_aw_select_i < NoMstPorts))) else

--- a/src/axi_lite_dw_converter.sv
+++ b/src/axi_lite_dw_converter.sv
@@ -464,7 +464,7 @@ module axi_lite_dw_converter #(
     assume ($onehot(AxiSlvPortDataWidth)) else $fatal(1, "AxiSlvPortDataWidth must be power of 2");
     assume ($onehot(AxiMstPortDataWidth)) else $fatal(1, "AxiMstPortDataWidth must be power of 2");
   end
-  `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   default disable iff (~rst_ni);
   stable_aw: assert property (@(posedge clk_i)
       (mst_req_o.aw_valid && !mst_res_i.aw_ready) |=> $stable(mst_req_o.aw)) else

--- a/src/axi_lite_from_mem.sv
+++ b/src/axi_lite_from_mem.sv
@@ -235,7 +235,7 @@ module axi_lite_from_mem #(
       assert (DataWidth == $bits(axi_rsp_i.r.data)) else
           $fatal(1, "DataWidth has to match axi_rsp_i.r.data!");
     end
-  `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
     default disable iff (~rst_ni);
     assert property (@(posedge clk_i) (mem_req_i && !mem_gnt_o) |=> mem_req_i) else
         $fatal(1, "It is not allowed to deassert the request if it was not granted!");

--- a/src/axi_lite_regs.sv
+++ b/src/axi_lite_regs.sv
@@ -380,7 +380,7 @@ module axi_lite_regs #(
   // Validate parameters.
   // pragma translate_off
   `ifndef VERILATOR
-  `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
     initial begin: p_assertions
       assert (RegNumBytes > 32'd0) else
           $fatal(1, "The number of bytes must be at least 1!");

--- a/src/axi_lite_xbar.sv
+++ b/src/axi_lite_xbar.sv
@@ -114,7 +114,7 @@ module axi_lite_xbar #(
     // make sure that the default slave does not get changed, if there is an unserved Ax
     // pragma translate_off
     `ifndef VERILATOR
-    `ifndef XSIM
+    `ifndef XILINX_SIMULATOR
     default disable iff (~rst_ni);
     default_aw_mst_port_en: assert property(
       @(posedge clk_i) (slv_ports_req_i[i].aw_valid && !slv_ports_resp_o[i].aw_ready)

--- a/src/axi_serializer.sv
+++ b/src/axi_serializer.sv
@@ -197,7 +197,7 @@ module axi_serializer #(
     assert (MaxWriteTxns  >= 1)
       else $fatal(1, "Maximum number of write transactions must be >= 1!");
   end
-`ifndef XSIM
+`ifndef XILINX_SIMULATOR
   default disable iff (~rst_ni);
   aw_lost : assert property( @(posedge clk_i)
       (slv_req_i.aw_valid & slv_resp_o.aw_ready |-> mst_req_o.aw_valid & mst_resp_i.aw_ready))

--- a/src/axi_test.sv
+++ b/src/axi_test.sv
@@ -1253,7 +1253,7 @@ package axi_test;
           automatic logic [AXI_STRB_WIDTH-1:0] rand_strb, strb_mask;
           addr = axi_pkg::beat_addr(aw_beat.ax_addr, aw_beat.ax_size, aw_beat.ax_len,
                                     aw_beat.ax_burst, i);
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
           // std::randomize(w_beat) may behave differently to w_beat.randomize() wrt. limited ranges
           // Keeping alternate implementation for XSIM only
           rand_success = std::randomize(w_beat); assert (rand_success);
@@ -1416,7 +1416,7 @@ package axi_test;
         wait (ar_queue.size > 0);
         ar_beat      = ar_queue.peek();
         byte_addr    = axi_pkg::aligned_addr(ar_beat.ax_addr, axi_pkg::size_t'($clog2(DW/8)));
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
         // std::randomize(r_beat) may behave differently to r_beat.randomize() wrt. limited ranges
         // Keeping alternate implementation for XSIM only
         rand_success = std::randomize(r_beat); assert(rand_success);
@@ -1516,7 +1516,7 @@ package axi_test;
         automatic logic rand_success;
         wait (b_wait_cnt > 0 && (aw_queue.size() != 0));
         aw_beat = aw_queue.pop_front();
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
         // std::randomize(b_beat) may behave differently to b_beat.randomize() wrt. limited ranges
         // Keeping alternate implementation for XSIM only
         rand_success = std::randomize(b_beat); assert (rand_success);

--- a/src/axi_to_detailed_mem.sv
+++ b/src/axi_to_detailed_mem.sv
@@ -567,7 +567,7 @@ module axi_to_detailed_mem #(
   // Assertions
   // pragma translate_off
   `ifndef VERILATOR
-  `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   default disable iff (!rst_ni);
   assume property (@(posedge clk_i)
       axi_req_i.ar_valid && !axi_resp_o.ar_ready |=> $stable(axi_req_i.ar))

--- a/src/axi_xbar_unmuxed.sv
+++ b/src/axi_xbar_unmuxed.sv
@@ -136,7 +136,7 @@ import cf_math_pkg::idx_width;
     // make sure that the default slave does not get changed, if there is an unserved Ax
     // pragma translate_off
     `ifndef VERILATOR
-    `ifndef XSIM
+    `ifndef XILINX_SIMULATOR
     default disable iff (~rst_ni);
     default_aw_mst_port_en: assert property(
       @(posedge clk_i) (slv_ports_req_i[i].aw_valid && !slv_ports_resp_o[i].aw_ready)
@@ -255,7 +255,7 @@ import cf_math_pkg::idx_width;
 
   // pragma translate_off
   `ifndef VERILATOR
-  `ifndef XSIM
+  `ifndef XILINX_SIMULATOR
   initial begin : check_params
     id_slv_req_ports: assert ($bits(slv_ports_req_i[0].aw.id ) == Cfg.AxiIdWidthSlvPorts) else
       $fatal(1, $sformatf("Slv_req and aw_chan id width not equal."));

--- a/test/tb_axi_bus_compare.sv
+++ b/test/tb_axi_bus_compare.sv
@@ -257,7 +257,7 @@ module tb_axi_bus_compare #(
     drv.reset_master();
     wait (rst_n);
     // AW
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
     // std::randomize(aw_beat) may behave differently to aw_beat.randomize() wrt. limited ranges
     // Keeping alternate implementation for XSIM only
     rand_success = std::randomize(aw_beat); assert (rand_success);
@@ -272,7 +272,7 @@ module tb_axi_bus_compare #(
     drv.send_aw(aw_beat);
     // W beats
     for (int unsigned i = 0; i <= aw_beat.ax_len; i++) begin
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
       // std::randomize(w_beat) may behave differently to w_beat.randomize() wrt. limited ranges
       // Keeping alternate implementation for XSIM only
       rand_success = std::randomize(w_beat); assert (rand_success);

--- a/test/tb_axi_delayer.sv
+++ b/test/tb_axi_delayer.sv
@@ -83,7 +83,7 @@ module tb_axi_delayer;
     @(posedge clk);
     repeat (200) begin
         @(posedge clk);
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
         // std::randomize(ax_beat) may behave differently to ax_beat.randomize() wrt. limited ranges
         // Keeping alternate implementation for XSIM only
         rand_success = std::randomize(ax_beat); assert(rand_success);

--- a/test/tb_axi_sim_mem.sv
+++ b/test/tb_axi_sim_mem.sv
@@ -100,7 +100,7 @@ module tb_axi_sim_mem #(
     wait (rst_n);
     // AW
     forever begin
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
       // std::randomize(aw_beat) may behave differently to aw_beat.randomize() wrt. limited ranges
       // Keeping alternate implementation for XSIM only
       rand_success = std::randomize(aw_beat); assert (rand_success);
@@ -121,7 +121,7 @@ module tb_axi_sim_mem #(
     drv.send_aw(aw_beat);
     // W beats
     for (int unsigned i = 0; i <= aw_beat.ax_len; i++) begin
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
       // std::randomize(w_beat) may behave differently to w_beat.randomize() wrt. limited ranges
       // Keeping alternate implementation for XSIM only
       rand_success = std::randomize(w_beat); assert (rand_success);

--- a/test/tb_axi_slave_compare.sv
+++ b/test/tb_axi_slave_compare.sv
@@ -188,7 +188,7 @@ module tb_axi_slave_compare #(
     drv.reset_master();
     wait (rst_n);
     // AW
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
     // std::randomize(aw_beat) may behave differently to aw_beat.randomize() wrt. limited ranges
     // Keeping alternate implementation for XSIM only
     rand_success = std::randomize(aw_beat); assert (rand_success);
@@ -203,7 +203,7 @@ module tb_axi_slave_compare #(
     drv.send_aw(aw_beat);
     // W beats
     for (int unsigned i = 0; i <= aw_beat.ax_len; i++) begin
-`ifdef XSIM
+`ifdef XILINX_SIMULATOR
       // std::randomize(w_beat) may behave differently to w_beat.randomize() wrt. limited ranges
       // Keeping alternate implementation for XSIM only
       rand_success = std::randomize(w_beat); assert (rand_success);


### PR DESCRIPTION
This PR extends the following related work, replacing the `XSIM` preprocessor guard with `XILINX_SIMULATOR` across the codebase:

- [#226](https://github.com/pulp-platform/axi/issues/226#issuecomment-2952720481)
- [#232](https://github.com/pulp-platform/axi/pull/232)
- [#262](https://github.com/pulp-platform/axi/pull/262)
- [#391](https://github.com/pulp-platform/axi/pull/391)
- [#415](https://github.com/pulp-platform/axi/pull/415)
 
 The existing `` `ifdef XSIM ``/`` `ifndef XSIM `` guards rely on a macro that is **not** predefined by the Xilinx simulator. Vivado/Vitis `xsim` (`xvlog`/`xelab`) does not define `XSIM` . The macro it actually predefines for tool-specific code paths is `XILINX_SIMULATOR`. As a result the `XSIM` guards were never taken under the real xsim flow, so the intended simulator-specific workarounds were silently inactive.
 
Switching all guards to `XILINX_SIMULATOR` makes them fire as intended when compiling with Vivado/Vitis.


