### PR TITLE
fix(axi): support equal ID widths in axi_id_prepend

### DIFF
--- a/src/axi_id_prepend.sv
+++ b/src/axi_id_prepend.sv
@@ -117,7 +117,7 @@ module axi_id_prepend #(
       else $fatal(1, "Input must be at least one element wide.");
     assert(PreIdWidth == ($bits(mst_aw_chans_o[0].id) - $bits(slv_aw_chans_i[0].id)))
       else $fatal(1, "Prepend ID Width must be: $bits(mst_aw_chans_o.id)-$bits(slv_aw_chans_i.id)");
-   assert ($bits(mst_aw_chans_o[0].id) >= $bits(slv_aw_chans_i[0].id))
+    assert ($bits(mst_aw_chans_o[0].id) >= $bits(slv_aw_chans_i[0].id))
       else $fatal(1, "The master AXI port ID must not be narrower than the slave port ID.");
   end
 

--- a/src/axi_id_prepend.sv
+++ b/src/axi_id_prepend.sv
@@ -32,7 +32,8 @@ module axi_id_prepend #(
   // DEPENDENT PARAMETER DO NOT OVERWRITE!
   parameter int unsigned PreIdWidth        = AxiIdWidthMstPort - AxiIdWidthSlvPort
 ) (
-  input  logic [PreIdWidth-1:0] pre_id_i, // ID to be prepended
+  // Keep the port at least one bit wide when no ID bits need to be prepended.
+  input logic [((PreIdWidth == 0) ? 1 : PreIdWidth)-1:0] pre_id_i,
   // slave port (input), connect master modules here
   // AW channel
   input  slv_aw_chan_t [NoBus-1:0] slv_aw_chans_i,
@@ -116,8 +117,8 @@ module axi_id_prepend #(
       else $fatal(1, "Input must be at least one element wide.");
     assert(PreIdWidth == ($bits(mst_aw_chans_o[0].id) - $bits(slv_aw_chans_i[0].id)))
       else $fatal(1, "Prepend ID Width must be: $bits(mst_aw_chans_o.id)-$bits(slv_aw_chans_i.id)");
-    assert ($bits(mst_aw_chans_o[0].id) > $bits(slv_aw_chans_i[0].id))
-      else $fatal(1, "The master AXI port has to have a wider ID than the slave port.");
+   assert ($bits(mst_aw_chans_o[0].id) >= $bits(slv_aw_chans_i[0].id))
+      else $fatal(1, "The master AXI port ID must not be narrower than the slave port ID.");
   end
 
   aw_id   : assert final(

--- a/src/axi_id_prepend.sv
+++ b/src/axi_id_prepend.sv
@@ -33,7 +33,7 @@ module axi_id_prepend #(
   parameter int unsigned PreIdWidth        = AxiIdWidthMstPort - AxiIdWidthSlvPort
 ) (
   // Keep the port at least one bit wide when no ID bits need to be prepended.
-  input logic [((PreIdWidth == 0) ? 1 : PreIdWidth)-1:0] pre_id_i,
+  input  logic [((PreIdWidth == 0) ? 1 : PreIdWidth)-1:0] pre_id_i,
   // slave port (input), connect master modules here
   // AW channel
   input  slv_aw_chan_t [NoBus-1:0] slv_aw_chans_i,


### PR DESCRIPTION
## Summary

Fix `axi_id_prepend` to support the valid zero-prepend case where the slave and master AXI ID widths are equal.

## Problem

`axi_id_serialize` can instantiate `axi_id_prepend` with:

- `AxiIdWidthSlvPort = 1`
- `AxiIdWidthMstPort = 1`
- `PreIdWidth = 0`

The datapath already supports this case through `gen_no_prepend`, but:

1. `pre_id_i[PreIdWidth-1:0]` creates an invalid/underflowed array bound.
2. The assertion incorrectly requires the master ID width to be strictly greater than the slave ID width.

This causes VCS elaboration/runtime failures for the valid 1-bit to 1-bit pass-through case.

## Changes

- Keep `pre_id_i` at least one bit wide when `PreIdWidth == 0`.
- Allow the master and slave AXI ID widths to be equal.
- Update the assertion message accordingly.

## Functional impact

No functional change for the normal ID-prepend case.

- `master ID > slave ID`: ID bits are prepended as before.
- `master ID == slave ID`: existing `gen_no_prepend` pass-through path is used.
- `master ID < slave ID`: remains invalid and is rejected.

## Verification

- Verified the AXI2APB configuration uses a 6-bit upstream ID and serializes it to a single downstream ID.
- Verified the internal `axi_id_prepend` instance uses the supported 1-bit to 1-bit pass-through case.
- Confirmed the updated source has no zero-width array declaration.