### PR TITLE
Expose AxiLookBits in axi_burst_splitter to avoid logic explosion

### DIFF
--- a/src/axi_burst_splitter.sv
+++ b/src/axi_burst_splitter.sv
@@ -35,6 +35,8 @@ module axi_burst_splitter #(
   parameter int unsigned AddrWidth    = 32'd0,
   parameter int unsigned DataWidth    = 32'd0,
   parameter int unsigned IdWidth      = 32'd0,
+  // Number of least-significant ID bits used by the internal demux to track in-flight
+  // transactions (0 < AxiLookBits <= IdWidth), see doc/axi_demux.md for the trade-off.
   parameter int unsigned AxiLookBits  = IdWidth,
   parameter int unsigned UserWidth    = 32'd0,
   parameter type         axi_req_t    = logic,

--- a/src/axi_burst_splitter.sv
+++ b/src/axi_burst_splitter.sv
@@ -35,6 +35,7 @@ module axi_burst_splitter #(
   parameter int unsigned AddrWidth    = 32'd0,
   parameter int unsigned DataWidth    = 32'd0,
   parameter int unsigned IdWidth      = 32'd0,
+  parameter int unsigned AxiLookBits  = IdWidth,
   parameter int unsigned UserWidth    = 32'd0,
   parameter type         axi_req_t    = logic,
   parameter type         axi_resp_t   = logic
@@ -72,6 +73,7 @@ module axi_burst_splitter #(
     .AddrWidth     ( AddrWidth     ),
     .DataWidth     ( DataWidth     ),
     .IdWidth       ( IdWidth       ),
+    .AxiLookBits   ( AxiLookBits   ),
     .UserWidth     ( UserWidth     ),
     .axi_req_t     ( axi_req_t     ),
     .axi_resp_t    ( axi_resp_t    ),

--- a/src/axi_burst_splitter_gran.sv
+++ b/src/axi_burst_splitter_gran.sv
@@ -34,6 +34,8 @@ module axi_burst_splitter_gran #(
   parameter int unsigned AddrWidth     = 32'd0,
   parameter int unsigned DataWidth     = 32'd0,
   parameter int unsigned IdWidth       = 32'd0,
+  /// Number of least-significant ID bits used by the internal demux to track in-flight
+  /// transactions (0 < AxiLookBits <= IdWidth), see doc/axi_demux.md for the trade-off.
   parameter int unsigned AxiLookBits   = IdWidth,
   parameter int unsigned UserWidth     = 32'd0,
   parameter type         axi_req_t     = logic,
@@ -410,6 +412,10 @@ module axi_burst_splitter_gran #(
     else $fatal(1, "AW burst longer than a single beat emitted!");
   assert property (@(posedge clk_i) mst_req_o.ar_valid |-> mst_req_o.ar.len <= len_limit_i)
     else $fatal(1, "AR burst longer than a single beat emitted!");
+  initial begin
+    assume (AxiLookBits > 0 && AxiLookBits <= IdWidth) else
+      $fatal(1, "AxiLookBits (%0d) must be in ]0, IdWidth (%0d)]!", AxiLookBits, IdWidth);
+  end
   // pragma translate_on
   `endif
   `endif
@@ -738,10 +744,6 @@ module axi_burst_splitter_gran_counters #(
   // pragma translate_off
   assume property (@(posedge clk_i) idq_oup_gnt |-> idq_oup_valid)
     else $warning("Invalid output at ID queue, read not granted!");
-  initial begin
-    assume (AxiLookBits > 0 && AxiLookBits <= IdWidth) else
-      $fatal(1, "AxiLookBits (%0d) must be in ]0, IdWidth (%0d)]!", AxiLookBits, IdWidth);
-  end
   // pragma translate_on
   `endif
 

--- a/src/axi_burst_splitter_gran.sv
+++ b/src/axi_burst_splitter_gran.sv
@@ -34,6 +34,7 @@ module axi_burst_splitter_gran #(
   parameter int unsigned AddrWidth     = 32'd0,
   parameter int unsigned DataWidth     = 32'd0,
   parameter int unsigned IdWidth       = 32'd0,
+  parameter int unsigned AxiLookBits   = IdWidth,
   parameter int unsigned UserWidth     = 32'd0,
   parameter type         axi_req_t     = logic,
   parameter type         axi_resp_t    = logic,
@@ -88,7 +89,7 @@ module axi_burst_splitter_gran #(
     .axi_resp_t   ( axi_resp_t  ),
     .NoMstPorts   ( 2           ),
     .MaxTrans     ( MaxTxns     ),
-    .AxiLookBits  ( IdWidth     )
+    .AxiLookBits  ( AxiLookBits )
   ) i_demux_supported_vs_unsupported (
     .clk_i,
     .rst_ni,

--- a/src/axi_burst_splitter_gran.sv
+++ b/src/axi_burst_splitter_gran.sv
@@ -738,6 +738,10 @@ module axi_burst_splitter_gran_counters #(
   // pragma translate_off
   assume property (@(posedge clk_i) idq_oup_gnt |-> idq_oup_valid)
     else $warning("Invalid output at ID queue, read not granted!");
+  initial begin
+    assume (AxiLookBits > 0 && AxiLookBits <= IdWidth) else
+      $fatal(1, "AxiLookBits (%0d) must be in ]0, IdWidth (%0d)]!", AxiLookBits, IdWidth);
+  end
   // pragma translate_on
   `endif
 

--- a/src/axi_burst_splitter_gran.sv
+++ b/src/axi_burst_splitter_gran.sv
@@ -34,6 +34,8 @@ module axi_burst_splitter_gran #(
   parameter int unsigned AddrWidth     = 32'd0,
   parameter int unsigned DataWidth     = 32'd0,
   parameter int unsigned IdWidth       = 32'd0,
+  /// Number of least-significant ID bits used by the internal demux to track in-flight
+  /// transactions (0 < AxiLookBits <= IdWidth), see doc/axi_demux.md for the trade-off.
   parameter int unsigned AxiLookBits   = IdWidth,
   parameter int unsigned UserWidth     = 32'd0,
   parameter type         axi_req_t     = logic,
@@ -411,6 +413,10 @@ module axi_burst_splitter_gran #(
     else $fatal(1, "AW burst longer than a single beat emitted!");
   assert property (@(posedge clk_i) mst_req_o.ar_valid |-> mst_req_o.ar.len <= len_limit_i)
     else $fatal(1, "AR burst longer than a single beat emitted!");
+  initial begin
+    assume (AxiLookBits > 0 && AxiLookBits <= IdWidth) else
+      $fatal(1, "AxiLookBits (%0d) must be in ]0, IdWidth (%0d)]!", AxiLookBits, IdWidth);
+  end
   // pragma translate_on
   `endif
   `endif
@@ -739,10 +745,6 @@ module axi_burst_splitter_gran_counters #(
   // pragma translate_off
   assume property (@(posedge clk_i) idq_oup_gnt |-> idq_oup_valid)
     else $warning("Invalid output at ID queue, read not granted!");
-  initial begin
-    assume (AxiLookBits > 0 && AxiLookBits <= IdWidth) else
-      $fatal(1, "AxiLookBits (%0d) must be in ]0, IdWidth (%0d)]!", AxiLookBits, IdWidth);
-  end
   // pragma translate_on
   `endif
 

--- a/src/axi_burst_splitter_gran.sv
+++ b/src/axi_burst_splitter_gran.sv
@@ -739,6 +739,10 @@ module axi_burst_splitter_gran_counters #(
   // pragma translate_off
   assume property (@(posedge clk_i) idq_oup_gnt |-> idq_oup_valid)
     else $warning("Invalid output at ID queue, read not granted!");
+  initial begin
+    assume (AxiLookBits > 0 && AxiLookBits <= IdWidth) else
+      $fatal(1, "AxiLookBits (%0d) must be in ]0, IdWidth (%0d)]!", AxiLookBits, IdWidth);
+  end
   // pragma translate_on
   `endif
 

--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -33,6 +33,7 @@ module axi_burst_unwrap #(
   parameter int unsigned AddrWidth    = 32'd0,
   parameter int unsigned DataWidth    = 32'd0,
   parameter int unsigned IdWidth      = 32'd0,
+  parameter int unsigned AxiLookBits  = IdWidth, // Number of ID bits to use for internal demux (AxiLookBits <= IdWidth)
   parameter int unsigned UserWidth    = 32'd0,
   parameter type         axi_req_t    = logic,
   parameter type         axi_resp_t   = logic
@@ -76,7 +77,7 @@ module axi_burst_unwrap #(
     .axi_resp_t   ( axi_resp_t  ),
     .NoMstPorts   ( 2           ),
     .MaxTrans     ( MaxTxns     ),
-    .AxiLookBits  ( IdWidth     ),
+    .AxiLookBits  ( AxiLookBits ),
     .SpillAw      ( 1'b0        ),
     .SpillW       ( 1'b0        ),
     .SpillB       ( 1'b0        ),

--- a/src/axi_burst_unwrap.sv
+++ b/src/axi_burst_unwrap.sv
@@ -33,7 +33,9 @@ module axi_burst_unwrap #(
   parameter int unsigned AddrWidth    = 32'd0,
   parameter int unsigned DataWidth    = 32'd0,
   parameter int unsigned IdWidth      = 32'd0,
-  parameter int unsigned AxiLookBits  = IdWidth, // Number of ID bits to use for internal demux (AxiLookBits <= IdWidth)
+  // Number of least-significant ID bits used by the internal demux to track in-flight
+  // transactions (0 < AxiLookBits <= IdWidth), see doc/axi_demux.md for the trade-off.
+  parameter int unsigned AxiLookBits  = IdWidth,
   parameter int unsigned UserWidth    = 32'd0,
   parameter type         axi_req_t    = logic,
   parameter type         axi_resp_t   = logic

--- a/src/axi_to_axi_lite.sv
+++ b/src/axi_to_axi_lite.sv
@@ -105,6 +105,8 @@ module axi_to_axi_lite #(
     assume (AxiIdWidth   > 0) else $fatal(1, "AXI ID width has to be > 0");
     assume (AxiAddrWidth > 0) else $fatal(1, "AXI address width has to be > 0");
     assume (AxiDataWidth > 0) else $fatal(1, "AXI data width has to be > 0");
+    assume (AxiLookBits > 0 && AxiLookBits <= AxiIdWidth) else
+      $fatal(1, "AxiLookBits (%0d) must be in ]0, AxiIdWidth (%0d)]!", AxiLookBits, AxiIdWidth);
   end
   `endif
   // pragma translate_on

--- a/src/axi_to_axi_lite.sv
+++ b/src/axi_to_axi_lite.sv
@@ -19,6 +19,8 @@ module axi_to_axi_lite #(
   parameter int unsigned AxiAddrWidth    = 32'd0,
   parameter int unsigned AxiDataWidth    = 32'd0,
   parameter int unsigned AxiIdWidth      = 32'd0,
+  // Number of least-significant ID bits used by the internal demux to track in-flight
+  // transactions (0 < AxiLookBits <= IdWidth), see doc/axi_demux.md for the trade-off.
   parameter int unsigned AxiLookBits     = AxiIdWidth,
   parameter int unsigned AxiUserWidth    = 32'd0,
   parameter int unsigned AxiMaxWriteTxns = 32'd0,
@@ -253,6 +255,8 @@ module axi_to_axi_lite_intf #(
   parameter int unsigned AXI_ADDR_WIDTH     = 32'd0,
   parameter int unsigned AXI_DATA_WIDTH     = 32'd0,
   parameter int unsigned AXI_ID_WIDTH       = 32'd0,
+  /// Number of least-significant ID bits used to track in-flight transactions
+  /// (0 < AXI_LOOK_BITS <= AXI_ID_WIDTH), see doc/axi_demux.md for the trade-off.
   parameter int unsigned AXI_LOOK_BITS      = AXI_ID_WIDTH,
   parameter int unsigned AXI_USER_WIDTH     = 32'd0,
   /// Maximum number of outstanding writes.

--- a/src/axi_to_axi_lite.sv
+++ b/src/axi_to_axi_lite.sv
@@ -19,6 +19,7 @@ module axi_to_axi_lite #(
   parameter int unsigned AxiAddrWidth    = 32'd0,
   parameter int unsigned AxiDataWidth    = 32'd0,
   parameter int unsigned AxiIdWidth      = 32'd0,
+  parameter int unsigned AxiLookBits     = AxiIdWidth,
   parameter int unsigned AxiUserWidth    = 32'd0,
   parameter int unsigned AxiMaxWriteTxns = 32'd0,
   parameter int unsigned AxiMaxReadTxns  = 32'd0,
@@ -65,6 +66,7 @@ module axi_to_axi_lite #(
     .AddrWidth    ( AxiAddrWidth    ),
     .DataWidth    ( AxiDataWidth    ),
     .IdWidth      ( AxiIdWidth      ),
+    .AxiLookBits  ( AxiLookBits     ),
     .UserWidth    ( AxiUserWidth    ),
     .axi_req_t    ( full_req_t      ),
     .axi_resp_t   ( full_resp_t     )
@@ -249,6 +251,7 @@ module axi_to_axi_lite_intf #(
   parameter int unsigned AXI_ADDR_WIDTH     = 32'd0,
   parameter int unsigned AXI_DATA_WIDTH     = 32'd0,
   parameter int unsigned AXI_ID_WIDTH       = 32'd0,
+  parameter int unsigned AXI_LOOK_BITS      = AXI_ID_WIDTH,
   parameter int unsigned AXI_USER_WIDTH     = 32'd0,
   /// Maximum number of outstanding writes.
   parameter int unsigned AXI_MAX_WRITE_TXNS = 32'd1,
@@ -299,6 +302,7 @@ module axi_to_axi_lite_intf #(
     .AxiAddrWidth    ( AXI_ADDR_WIDTH     ),
     .AxiDataWidth    ( AXI_DATA_WIDTH     ),
     .AxiIdWidth      ( AXI_ID_WIDTH       ),
+    .AxiLookBits     ( AXI_LOOK_BITS      ),
     .AxiUserWidth    ( AXI_USER_WIDTH     ),
     .AxiMaxWriteTxns ( AXI_MAX_WRITE_TXNS ),
     .AxiMaxReadTxns  ( AXI_MAX_READ_TXNS  ),


### PR DESCRIPTION
Fixes #341.

This PR exposes the `AxiLookBits` parameter in `axi_burst_splitter` (and cascades it through to `axi_burst_splitter_gran` and `axi_to_axi_lite`). 

Previously, the internal demux always instantiated with `AxiLookBits` hardcoded to the full `IdWidth`, which caused a massive logic explosion (counter array size of `2**IdWidth`) when dealing with large AXI IDs. By exposing this parameter (defaulting to `IdWidth` for backwards compatibility), users can now override it appropriately.