### PR TITLE
feat(bus): integrate AXI-to-APB bridge and fix WRAP burst handling

### DIFF
--- a/src/axi_burst_splitter_gran.sv
+++ b/src/axi_burst_splitter_gran.sv
@@ -105,8 +105,8 @@ module axi_burst_splitter_gran #(
   function bit txn_supported(axi_pkg::atop_t atop, axi_pkg::burst_t burst, axi_pkg::cache_t cache,
       axi_pkg::len_t len, axi_pkg::len_t len_limit);
 
-    // if the splitter does not touch the transaction: allow it
-    if (len >= len_limit) begin
+    
+    if (len <= len_limit) begin
       return 1'b1;
 
     //

--- a/src/axi_burst_splitter_gran.sv
+++ b/src/axi_burst_splitter_gran.sv
@@ -106,6 +106,7 @@ module axi_burst_splitter_gran #(
       axi_pkg::len_t len, axi_pkg::len_t len_limit);
 
     
+    // if the splitter does not touch the transaction: allow it
     if (len <= len_limit) begin
       return 1'b1;
 


### PR DESCRIPTION
## Summary

This PR implements the AXI-to-APB bridge by connecting two existing PULP modules:

- `axi_to_axi_lite`
- `axi_lite_to_apb`

During integration testing, I found an issue in `axi_burst_splitter_gran`.

## Issue

The bridge sets `len_limit = 0` to split an AXI burst into single-beat APB transfers.

However, `txn_supported()` contained `if (len >= len_limit)`.

Because every valid AXI `len` is greater than or equal to zero, this condition always returns `1'b1`.

### Before the fix

![Before the fix](https://github.com/user-attachments/assets/8076db47-ec65-4bb7-b1e4-3bfeef6bafc5)

### After the fix

![After the fix](https://github.com/user-attachments/assets/cff56e42-1d0d-47e1-9fbe-3cc3022e8c43)

