### PR TITLE
axi_isolate: fix deadlock during drain

### DIFF
--- a/src/axi_isolate.sv
+++ b/src/axi_isolate.sv
@@ -178,7 +178,7 @@ module axi_isolate #(
       .slv_req_i  ( demux_req[1] ),
       .slv_resp_o ( demux_rsp[1] )
     );
-  end else begin : g_passthrough
+  end else begin
     assign demux_req[0] = slv_req_i;
     assign slv_resp_o = demux_rsp[0];
     // In pass-through, silence the second demux port as it is not used
@@ -528,3 +528,4 @@ module axi_isolate_intf #(
   `endif
   // pragma translate_on
 endmodule
+

--- a/src/axi_isolate.sv
+++ b/src/axi_isolate.sv
@@ -89,10 +89,7 @@ module axi_isolate #(
   `AXI_TYPEDEF_R_CHAN_T(r_chan_t, data_t, id_t, user_t)
 
   // Capacity of `axi_isolate_inner`, derived from the maximum number of transactions the demux
-  // admits (`2**AxiLookBits` ID buckets, each counting up to `2**IdCounterWidth - 1`).  The
-  // inner's counters can then never saturate, so the inner never stalls a request the demux
-  // has already committed to a master port; surplus requests instead stall at the demux's
-  // slave port, before they are committed.
+  // admits (`2**AxiLookBits` ID buckets, each counting up to `2**IdCounterWidth - 1`).
   localparam int unsigned DemuxLookBits   = 32'd1;
   localparam int unsigned DemuxCntWidth   = cf_math_pkg::idx_width(NumPending);
   localparam int unsigned DemuxMaxPending =
@@ -104,10 +101,6 @@ module axi_isolate #(
   axi_resp_t [1:0]  demux_rsp;
 
   if (TerminateTransaction) begin
-    // Registered demux select, one per channel: 0 routes to `axi_isolate_inner`, 1 to the
-    // error slave.  It follows `isolate_i`, but holds while the demux has a request presented
-    // at a master port that is not yet accepted, as the demux commits the W routing on first
-    // presentation and requires a stable select until the handshake completes.
     logic sel_aw_q, sel_ar_q;
     // A request is presented at a demux master port and not yet accepted.  Requests stalled by
     // the demux itself are not committed to a port and do not hold the select.
@@ -118,9 +111,6 @@ module axi_isolate #(
     assign demux_ar_unaccepted = (demux_req[0].ar_valid | demux_req[1].ar_valid)
                                  & ~slv_resp_o.ar_ready;
 
-    // Reset to the error slave, as `axi_isolate_inner` resets to `Isolate`.  The hold must act
-    // on the register load; masking the select output combinationally would form a loop
-    // through `slv_resp_o.*_ready`.
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
         sel_aw_q <= 1'b1;

--- a/src/axi_isolate.sv
+++ b/src/axi_isolate.sv
@@ -88,10 +88,49 @@ module axi_isolate #(
   `AXI_TYPEDEF_AR_CHAN_T(ar_chan_t, addr_t, id_t, user_t)
   `AXI_TYPEDEF_R_CHAN_T(r_chan_t, data_t, id_t, user_t)
 
+  // Capacity of `axi_isolate_inner`, derived from the maximum number of transactions the demux
+  // admits (`2**AxiLookBits` ID buckets, each counting up to `2**IdCounterWidth - 1`).  The
+  // inner's counters can then never saturate, so the inner never stalls a request the demux
+  // has already committed to a master port; surplus requests instead stall at the demux's
+  // slave port, before they are committed.
+  localparam int unsigned DemuxLookBits   = 32'd1;
+  localparam int unsigned DemuxCntWidth   = cf_math_pkg::idx_width(NumPending);
+  localparam int unsigned DemuxMaxPending =
+      (32'd1 << DemuxLookBits) * ((32'd1 << DemuxCntWidth) - 32'd1);
+  localparam int unsigned InnerPending    =
+      TerminateTransaction ? DemuxMaxPending + 32'd1 : NumPending;
+
   axi_req_t [1:0]   demux_req;
   axi_resp_t [1:0]  demux_rsp;
 
   if (TerminateTransaction) begin
+    // Registered demux select, one per channel: 0 routes to `axi_isolate_inner`, 1 to the
+    // error slave.  It follows `isolate_i`, but holds while the demux has a request presented
+    // at a master port that is not yet accepted, as the demux commits the W routing on first
+    // presentation and requires a stable select until the handshake completes.
+    logic sel_aw_q, sel_ar_q;
+    // A request is presented at a demux master port and not yet accepted.  Requests stalled by
+    // the demux itself are not committed to a port and do not hold the select.
+    logic demux_aw_unaccepted, demux_ar_unaccepted;
+
+    assign demux_aw_unaccepted = (demux_req[0].aw_valid | demux_req[1].aw_valid)
+                                 & ~slv_resp_o.aw_ready;
+    assign demux_ar_unaccepted = (demux_req[0].ar_valid | demux_req[1].ar_valid)
+                                 & ~slv_resp_o.ar_ready;
+
+    // Reset to the error slave, as `axi_isolate_inner` resets to `Isolate`.  The hold must act
+    // on the register load; masking the select output combinationally would form a loop
+    // through `slv_resp_o.*_ready`.
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        sel_aw_q <= 1'b1;
+        sel_ar_q <= 1'b1;
+      end else begin
+        if (!demux_aw_unaccepted) sel_aw_q <= isolate_i;
+        if (!demux_ar_unaccepted) sel_ar_q <= isolate_i;
+      end
+    end
+
     axi_demux #(
       .AxiIdWidth     ( AxiIdWidth  ),
       .AtopSupport    ( AtopSupport ),
@@ -105,20 +144,20 @@ module axi_isolate #(
       .NoMstPorts     ( 2           ),
       .MaxTrans       ( NumPending  ),
       // We don't need many bits here as the common case will be to go for the pass-through.
-      .AxiLookBits    ( 1           ),
-      .UniqueIds      ( 1'b0        ),
-      .SpillAw        ( 1'b0        ),
-      .SpillW         ( 1'b0        ),
-      .SpillB         ( 1'b0        ),
-      .SpillAr        ( 1'b0        ),
-      .SpillR         ( 1'b0        )
+      .AxiLookBits    ( DemuxLookBits ),
+      .UniqueIds      ( 1'b0          ),
+      .SpillAw        ( 1'b0          ),
+      .SpillW         ( 1'b0          ),
+      .SpillB         ( 1'b0          ),
+      .SpillAr        ( 1'b0          ),
+      .SpillR         ( 1'b0          )
     ) i_axi_demux (
       .clk_i,
       .rst_ni,
-      .test_i          ( 1'b0       ),
+      .test_i          ( 1'b0      ),
       .slv_req_i,
-      .slv_aw_select_i ( isolated_o ),
-      .slv_ar_select_i ( isolated_o ),
+      .slv_aw_select_i ( sel_aw_q  ),
+      .slv_ar_select_i ( sel_ar_q  ),
       .slv_resp_o,
       .mst_reqs_o      ( demux_req ),
       .mst_resps_i     ( demux_rsp )
@@ -139,7 +178,7 @@ module axi_isolate #(
       .slv_req_i  ( demux_req[1] ),
       .slv_resp_o ( demux_rsp[1] )
     );
-  end else begin
+  end else begin : g_passthrough
     assign demux_req[0] = slv_req_i;
     assign slv_resp_o = demux_rsp[0];
     // In pass-through, silence the second demux port as it is not used
@@ -148,9 +187,9 @@ module axi_isolate #(
   end
 
   axi_isolate_inner #(
-    .NumPending ( NumPending  ),
-    .axi_req_t  ( axi_req_t   ),
-    .axi_resp_t ( axi_resp_t  )
+    .NumPending ( InnerPending ),
+    .axi_req_t  ( axi_req_t    ),
+    .axi_resp_t ( axi_resp_t   )
   ) i_axi_isolate (
     .clk_i,
     .rst_ni,
@@ -489,4 +528,3 @@ module axi_isolate_intf #(
   `endif
   // pragma translate_on
 endmodule
-


### PR DESCRIPTION
## Fix
Follow up to #441: Two changes, both under `TerminateTransaction = 1'b1`, `axi_isolate_inner` is unchanged.
### Registered selects
The demux selects are driven by a registered `isolate_i` instead of `isolated_o`. The register only updates on cycles where the channel has no request presented-and-unaccepted at a demux master port: once a request is presented, `w_select_q` is latched, so the select has to hold until the handshake completes. The same gate covers de-isolation: if `isolate_i` falls while a request sits unaccepted at the error slave, the select stays 1 until it is accepted; otherwise the AW would move to port 0 (inner module) while its W beats are already routed to the error slave.

### Inner sizing
The inner now gets a larger `NumPending` than the demux:
```
localparam int unsigned DemuxCntWidth   = cf_math_pkg::idx_width(NumPending);
localparam int unsigned DemuxMaxPending = (32'd1 << DemuxLookBits) * ((32'd1 << DemuxCntWidth) - 32'd1);
localparam int unsigned InnerPending    = TerminateTransaction ? DemuxMaxPending + 32'd1 : NumPending;
```
`DemuxMaxPending` is the most transactions the demux's ID counters can have outstanding at once. With one more than that, the inner can never saturate and refuse a request the demux has already routed to port 0, so backpressure always happens at the demux's slave port, before `w_select_q` is latched.

## Question: is the shared NumPending intentional?
The demux and inner module use `NumPending` differently: the demux only sizes its ID counters with it, so it admits up to `2 * (2**idx_width(NumPending) - 1)` transactions (possible 5 for `NumPending = 4`), while the inner treats it as an exact limit and cuts the AW channel at `pending_aw_q >= NumPending` while staying in `Normal`, so the demux can route one more request to the inner than it will accept. If `isolate_i` is asserted in that state, the FSM enters `Drain` directly (`Hold` is skipped, since the parked request was never forwarded downstream) and the drain runs with a request already committed at port 0 and unaccepted. Was the demux admitting more than the inner's limit intentional, and is deriving the inner's capacity from the demux ceiling the right fix, or would you rather bound the demux to exactly `NumPending`?

## Verification
Ran a cocotb bench covering the scenario from #441, terminations during a loaded drain (W and ID-hash interlocks, W-before-AW ordering), select-hold windows on both channels in both isolate_i directions, saturation at the demux counter ceiling, ATOP AR-credit draining, and seeded random traffic. The demux's `slv_aw_select_stable` / `slv_ar_select_stable` assertions were enabled in all runs, with no violations. Happy to contribute this bench if it's useful
